### PR TITLE
hotfix: added missing variable name to create_motion

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -175,7 +175,7 @@ create_motion(const unsigned int motionstep)
   // const auto terminalv = NullTerminalVelocity{};
   // const auto terminalv = RogersYauTerminalVelocity{};
   // const auto terminalv = SimmelTerminalVelocity{};
-  const auto RogersGKTerminalVelocity{};
+  const auto terminalv = RogersGKTerminalVelocity{};
 
   // const auto ngbxs = (unsigned int)15; // total number of gbxs
   // const auto ngbxs4reset = (unsigned int)5; // number of gbxs to randomly select in reset


### PR DESCRIPTION
Fix for the direct main build