### PR TITLE
Bugfix and Asserts in Collisions

### DIFF
--- a/libs/superdrops/breakup.hpp
+++ b/libs/superdrops/breakup.hpp
@@ -1,4 +1,5 @@
-/* Copyright (c) 2023 MPI-M, Clara Bayley
+/*
+ * Copyright (c) 2024 MPI-M, Clara Bayley
  *
  * ----- CLEO -----
  * File: breakup.hpp
@@ -7,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Thursday 14th December 2023
+ * Last Modified: Tuesday 23rd January 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -25,6 +26,7 @@
 
 #include <functional>
 #include <concepts>
+#include <cassert>
 
 #include <Kokkos_Core.hpp>
 
@@ -175,7 +177,10 @@ Note: implicit casting of xi from unsigned long long to double. */
 {
   const auto old_xi = drop2.get_xi(); // = drop1.xi
   const auto totnfrags = double{nfrags(drop1, drop2) * old_xi};
-  const auto new_xi = (unsigned long long)Kokkos::round(totnfrags) / 2;
+  const auto new_xi = (unsigned long long)Kokkos::round(totnfrags);
+
+  assert((new_xi > old_xi) &&
+         "nfrags must increase multiplicity during breakup");
 
   const auto sum_rcubed = double{drop1.rcubed() + drop2.rcubed()};
   const auto new_rcubed = double{sum_rcubed * old_xi / new_xi};
@@ -184,8 +189,11 @@ Note: implicit casting of xi from unsigned long long to double. */
   const auto sum_msol = double{drop1.get_msol() + drop2.get_msol()};
   const auto new_msol = double{sum_msol * old_xi / new_xi};
 
-  drop1.set_xi(new_xi);
-  drop2.set_xi(old_xi - new_xi);
+  const auto new_xi_1 = new_xi / 2; // same as floor() for positive ints
+  const auto new_xi_2 = new_xi - new_xi_1;
+
+  drop1.set_xi(new_xi_1);
+  drop2.set_xi(new_xi_2);
 
   drop1.set_radius(new_r);
   drop2.set_radius(new_r);
@@ -209,6 +217,9 @@ Note: implicit casting of xi from unsigned long long to double. */
   const auto old_xi = drop2.get_xi();
   const auto totnfrags = double{nfrags(drop1, drop2) * old_xi};
   const auto new_xi = (unsigned long long)Kokkos::round(totnfrags);
+
+  assert((new_xi > old_xi) &&
+         "nfrags must increase multiplicity during breakup");
 
   const auto sum_rcubed = double{drop1.rcubed() + drop2.rcubed()};
   const auto new_rcubed = double{sum_rcubed * old_xi / new_xi};

--- a/libs/superdrops/coalescence.hpp
+++ b/libs/superdrops/coalescence.hpp
@@ -1,4 +1,5 @@
-/* Copyright (c) 2023 MPI-M, Clara Bayley
+/*
+ * Copyright (c) 2024 MPI-M, Clara Bayley
  *
  * ----- CLEO -----
  * File: coalescence.hpp
@@ -7,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 22nd December 2023
+ * Last Modified: Tuesday 23rd January 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -17,7 +18,8 @@
  * class and function to enact collision-coalescence events
  * in superdroplet model according to Shima et al. 2009.
  * Coalescence struct satisfies PairEnactX concept
- * used in Collisions struct */
+ * used in Collisions struct
+ */
 
 #ifndef COALESCENCE_HPP
 #define COALESCENCE_HPP
@@ -174,12 +176,17 @@ DoCoalescence::twin_superdroplet_coalescence(const unsigned long long gamma,
                                              Superdrop &drop2) const
 /* if xi1 = gamma*xi2 coalescence makes twin SDs
 with same xi, r and solute mass. According to Shima et al. 2009
-Section 5.1.3. part (5) option (b).
+Section 5.1.3. part (5) option (b). In rare case where
+xi1 = xi2 = gamma = 1, new_xi of drop1 = 0 and drop1 should be removed
+from domain.
 Note: implicit casting of gamma (i.e. therefore droplets'
 xi values) from unsigned long long to double. */
 {
   const auto old_xi = drop2.get_xi(); // = drop1.xi
   const auto new_xi = old_xi / 2; // same as floor() for positive ints
+
+  assert((new_xi < old_xi) &&
+         "coalescence must decrease multiplicity");
 
   const auto new_rcubed = double{drop2.rcubed() +
                                  gamma * drop1.rcubed()};
@@ -208,7 +215,12 @@ Shima et al. 2009 Section 5.1.3. part (5) option (a)
 Note: implicit casting of gamma (i.e. therefore droplets'
 xi values) from unsigned long long to double. */
 {
-  drop1.set_xi(drop1.get_xi() - gamma * drop2.get_xi());
+  const auto new_xi =  drop1.get_xi() - gamma * drop2.get_xi();
+
+  assert((new_xi < drop1.get_xi()) &&
+         "coalescence must decrease multiplicity");
+
+  drop1.set_xi(new_xi);
 
   const auto new_rcubed = double{drop2.rcubed() +
                                  gamma * drop1.rcubed()};


### PR DESCRIPTION
* Corrected algorithm in twin breakup to update mass and radius correctly
* Added asserts in breakup to check multiplicity, xi, decreases
* Added asserts in coalescence to check multiplicity, xi, increases