### PR TITLE
Betterbreakup

### DIFF
--- a/libs/gridboxes/movesupersindomain.hpp
+++ b/libs/gridboxes/movesupersindomain.hpp
@@ -1,4 +1,5 @@
-/* Copyright (c) 2023 MPI-M, Clara Bayley
+/*
+ * Copyright (c) 2024 MPI-M, Clara Bayley
  *
  * ----- CLEO -----
  * File: movesupersindomain.hpp
@@ -7,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Tuesday 19th December 2023
+ * Last Modified: Wednesday 24th January 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -119,7 +120,7 @@ struct MoveSupersInDomain {
   (1b) optional detect precipitation (device)
   (2) update their sdgbxindex accordingly (device)
   (3) move superdroplets between gridboxes (host) */
-  // TODO(all) use tasking to convert all 3 team policy
+  // TODO (all) use tasking to convert all 3 team policy
   // loops in these function calls into 1 loop?
   void move_superdrops_in_domain(const unsigned int t_sdm, const GbxMaps &gbxmaps, viewd_gbx d_gbxs,
                                  const viewd_supers totsupers) const {

--- a/libs/superdrops/breakup.hpp
+++ b/libs/superdrops/breakup.hpp
@@ -148,8 +148,8 @@ KOKKOS_FUNCTION void DoBreakup<NFrags>::twin_superdroplet_breakup(Superdrop &dro
   const auto old_xi = drop2.get_xi();  // = drop1.xi
   const auto totnfrags = double{nfrags(drop1, drop2) * old_xi};
 
-  const auto new_xi1 = uint64_t{Kokkos::round(totnfrags / 2)};
-  const auto new_xi2 = uint64_t{Kokkos::round(totnfrags - new_xi1)};
+  const auto new_xi1 = (uint64_t)Kokkos::round(totnfrags / 2); // cast double to uint64_t
+  const auto new_xi2 = (uint64_t)Kokkos::round(totnfrags - new_xi1); // cast double to uint64_t
   const auto new_xitot = new_xi1 + new_xi2;
   assert((new_xi2 > old_xi) && "nfrags must increase the drop2's multiplicity during breakup");
   assert((new_xitot > (old_xi*2)) && "nfrags must increase total multiplicity during breakup");
@@ -186,7 +186,7 @@ KOKKOS_FUNCTION void DoBreakup<NFrags>::different_superdroplet_breakup(Superdrop
   drop1.set_xi(new_xi1);
 
   const auto totnfrags = double{nfrags(drop1, drop2) * old_xi2};
-  const auto new_xi2 = uint64_t{Kokkos::round(totnfrags)};
+  const auto new_xi2 = (uint64_t)Kokkos::round(totnfrags); // cast double to uint64_t
 
   assert((new_xi2 > old_xi2) && "nfrags must increase the drop2's multiplicity during breakup");
   assert(((new_xi1 + new_xi2) > (old_xi1 + old_xi2)) &&

--- a/libs/superdrops/coalescence.hpp
+++ b/libs/superdrops/coalescence.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Tuesday 23rd January 2024
+ * Last Modified: Wednesday 24th January 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -149,7 +149,7 @@ Section 5.1.3. part (5) option (b). In rare case where
 xi1 = xi2 = gamma = 1, new_xi of drop1 = 0 and drop1 should be removed
 from domain.
 Note: implicit casting of gamma (i.e. therefore droplets'
-xi values) from unsigned long long to double. */
+xi values) from uint64_t to double. */
 KOKKOS_FUNCTION void DoCoalescence::twin_superdroplet_coalescence(const uint64_t gamma,
                                                                   Superdrop &drop1,
                                                                   Superdrop &drop2) const {
@@ -177,7 +177,7 @@ KOKKOS_FUNCTION void DoCoalescence::twin_superdroplet_coalescence(const uint64_t
 via decreasing multiplicity of drop1. According to
 Shima et al. 2009 Section 5.1.3. part (5) option (a)
 Note: implicit casting of gamma (i.e. therefore droplets'
-xi values) from unsigned long long to double. */
+xi values) from uint64_t to double. */
 KOKKOS_FUNCTION void DoCoalescence::different_superdroplet_coalescence(const uint64_t gamma,
                                                                        Superdrop &drop1,
                                                                        Superdrop &drop2) const {


### PR DESCRIPTION
* ensure nfrags in collision kinetics energy parametrisation always > 2.5
* more asserts in breakup to ensure multiplicties always increase during breakup
* clearer way of rounding nfrags to calculate new xi1 and new xi2 before casting to int