### PR TITLE
Default values and only folder names in scripts

### DIFF
--- a/scripts/bash/build_cleo_cuda_openmp.sh
+++ b/scripts/bash/build_cleo_cuda_openmp.sh
@@ -84,6 +84,6 @@ cmake -DCMAKE_CXX_COMPILER=${CXX} \
     ${kokkosflags} ${kokkosdevice} ${kokkoshost}
 
 # ensure these directories exist (it's a good idea for later use)
-mkdir -p ${path2build}bin
-mkdir -p ${path2build}share
+mkdir -p ${path2build}/bin
+mkdir -p ${path2build}/share
 ### ---------------------------------------------------- ###

--- a/scripts/bash/build_cleo_openmp.sh
+++ b/scripts/bash/build_cleo_openmp.sh
@@ -66,6 +66,6 @@ cmake -DCMAKE_CXX_COMPILER=${CXX} \
     ${kokkosflags} ${kokkosdevice} ${kokkoshost}
 
 # ensure these directories exist (it's a good idea for later use)
-mkdir -p ${path2build}bin
-mkdir -p ${path2build}share
+mkdir -p ${path2build}/bin
+mkdir -p ${path2build}/share
 ### ---------------------------------------------------- ###

--- a/scripts/bash/build_cleo_serial.sh
+++ b/scripts/bash/build_cleo_serial.sh
@@ -66,6 +66,6 @@ cmake -DCMAKE_CXX_COMPILER=${CXX} \
     ${kokkosflags} ${kokkosdevice} ${kokkoshost}
 
 # ensure these directories exist (it's a good idea for later use)
-mkdir -p ${path2build}bin
-mkdir -p ${path2build}share
+mkdir -p ${path2build}/bin
+mkdir -p ${path2build}/share
 ### ---------------------------------------------------- ###

--- a/scripts/build_compile_cleocoupledsdm.sh
+++ b/scripts/build_compile_cleocoupledsdm.sh
@@ -20,14 +20,10 @@ spack load cmake@3.23.1%gcc
 cleoenv=/work/mh1126/m300950/cleoenv
 
 buildtype=$1
-path2CLEO=${HOME}/CLEO
-path2build=$2 # get from command line argument
+path2CLEO=${2:-${HOME}/CLEO}
+path2build=${3:-${path2CLEO}/build} # get from command line argument
 executables="cleocoupledsdm"
 
-if [ "${path2build}" == "" ]
-then
-  path2build=${HOME}/CLEO/build
-fi
 ### ---------------------------------------------------- ###
 
 if [[ "${buildtype}" != "" && "${path2CLEO}" != "" && "${path2build}" != "" &&

--- a/scripts/build_compile_cleocoupledsdm.sh
+++ b/scripts/build_compile_cleocoupledsdm.sh
@@ -20,13 +20,13 @@ spack load cmake@3.23.1%gcc
 cleoenv=/work/mh1126/m300950/cleoenv
 
 buildtype=$1
-path2CLEO=${HOME}/CLEO/
+path2CLEO=${HOME}/CLEO
 path2build=$2 # get from command line argument
 executables="cleocoupledsdm"
 
 if [ "${path2build}" == "" ]
 then
-  path2build=${HOME}/CLEO/build/
+  path2build=${HOME}/CLEO/build
 fi
 ### ---------------------------------------------------- ###
 

--- a/scripts/compile_run_cleocoupledsdm.sh
+++ b/scripts/compile_run_cleocoupledsdm.sh
@@ -22,15 +22,15 @@
 ### ------------ and executable to compile ------------- ###
 cleoenv=/work/mh1126/m300950/cleoenv
 buildtype=$1
-path2CLEO=${HOME}/CLEO/
+path2CLEO=${HOME}/CLEO
 path2build=$2 # get from command line argument
 executable="cleocoupledsdm"
-configfile=${HOME}/CLEO/src/config/config.yaml
+configfile=${path2CLEO}/src/config/config.yaml
 run_executable=${path2build}/src/${executable}
 
 if [ "${path2build}" == "" ]
 then
-  path2build=${HOME}/CLEO/build/
+  path2build=${HOME}/CLEO/build
   run_executable=${path2build}/${run_executable}
 fi
 ### ---------------------------------------------------- ###

--- a/scripts/compile_run_cleocoupledsdm.sh
+++ b/scripts/compile_run_cleocoupledsdm.sh
@@ -20,19 +20,15 @@
 ### ----- You need to edit these lines to specify ------ ###
 ### ----- (your environment and) directory paths ------- ###
 ### ------------ and executable to compile ------------- ###
+
 cleoenv=/work/mh1126/m300950/cleoenv
 buildtype=$1
-path2CLEO=${HOME}/CLEO
-path2build=$2 # get from command line argument
+path2CLEO=${2:-${HOME}/CLEO}
+path2build=${3:-${path2CLEO}/build} # get from command line argument
 executable="cleocoupledsdm"
 configfile=${path2CLEO}/src/config/config.yaml
 run_executable=${path2build}/src/${executable}
 
-if [ "${path2build}" == "" ]
-then
-  path2build=${HOME}/CLEO/build
-  run_executable=${path2build}/${run_executable}
-fi
 ### ---------------------------------------------------- ###
 
 ### ----------------- compile executable --------------- ###

--- a/scripts/create_gbxboundariesbinary_script.py
+++ b/scripts/create_gbxboundariesbinary_script.py
@@ -37,7 +37,7 @@ configfile = sys.argv[3]
 isfigures = [True, True]
 
 ### essential paths and filenames
-constsfile = path2CLEO+"libs/cleoconstants.hpp"
+constsfile = path2CLEO+"/libs/cleoconstants.hpp"
 binariespath = path2build+"/share/"
 savefigpath = path2build+"/bin/"
 

--- a/scripts/create_initsuperdropsbinary_script.py
+++ b/scripts/create_initsuperdropsbinary_script.py
@@ -41,7 +41,7 @@ isfigures = [True, True]
 gbxs2plt = "all" # indexes of GBx index of SDs to plot (nb. "all" can be very slow)
 
 ### essential paths and filenames
-constsfile = path2CLEO+"libs/cleoconstants.hpp"
+constsfile = path2CLEO+"/libs/cleoconstants.hpp"
 binariespath = path2build+"/share/"
 savefigpath = path2build+"/bin/"
 

--- a/scripts/create_thermobinaries_script.py
+++ b/scripts/create_thermobinaries_script.py
@@ -41,7 +41,7 @@ configfile = sys.argv[3]
 isfigures = [True, True]
 
 ### essential paths and filenames
-constsfile = path2CLEO+"libs/cleoconstants.hpp"
+constsfile = path2CLEO+"/libs/cleoconstants.hpp"
 binariespath = path2build+"/share/"
 savefigpath = path2build+"/bin/"
 

--- a/scripts/inputfiles.sh
+++ b/scripts/inputfiles.sh
@@ -17,8 +17,8 @@
 module load python3/2022.01-gcc-11.2.0
 source activate /work/mh1126/m300950/cleoenv
 
-path2CLEO=${HOME}/CLEO/
-path2scripts=${path2CLEO}/scripts/
+path2CLEO=${HOME}/CLEO
+path2scripts=${path2CLEO}/scripts
 python=python
 ### ---------------------------------------------------- ###
 
@@ -32,7 +32,7 @@ else
 
   if [ "${path2build}" == "" ]
   then
-    path2build=${HOME}/CLEO/build/
+    path2build=${HOME}/CLEO/build
   fi
 
   echo "config file: ${configfile}"

--- a/scripts/inputfiles.sh
+++ b/scripts/inputfiles.sh
@@ -17,23 +17,18 @@
 module load python3/2022.01-gcc-11.2.0
 source activate /work/mh1126/m300950/cleoenv
 
-path2CLEO=${HOME}/CLEO
+path2CLEO=${2:-${HOME}/CLEO}
 path2scripts=${path2CLEO}/scripts
 python=python
 ### ---------------------------------------------------- ###
 
 configfile=$1
-path2build=$2
+path2build=${3:-${path2CLEO}/build}
 
 if [ "${configfile}" == "" ]
 then
   echo "Please specify config file"
 else
-
-  if [ "${path2build}" == "" ]
-  then
-    path2build=${HOME}/CLEO/build
-  fi
 
   echo "config file: ${configfile}"
   echo "path to build directory: ${path2build}"


### PR DESCRIPTION
This PR includes minor changes to the scripts:

- All variables and parameters containing a folder name are assumed to contain only the folder name, without a forward slash. Concatenations using these variables to hold new paths should add the forward slash.
- A new option to the scripts to pass `path2CLEO` as a parameter is added. If this value is not set, the variable is defined to point to the `CLEO` folder in the user's home. A similar approach is used for the `path2build`, if it is not passed via the command line it is assumed to be `${path2CLEO}/build`.