### PR TITLE
cocogitto in GitHub CI

### DIFF
--- a/.github/workflows/cocogitto.yml
+++ b/.github/workflows/cocogitto.yml
@@ -1,0 +1,19 @@
+name: cocogitto
+
+on: [push]
+
+jobs:
+  cog_check_job:
+    runs-on: ubuntu-latest
+    name: check commits with cocogitto
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Conventional commits compliance
+        uses: oknozor/cocogitto-action@v3
+        with:
+          check-latest-tag-only: true
+          git-user: 'yoctoyotta1024'
+          git-user-email: 'yoctoyotta1024@yahoo.com'

--- a/.github/workflows/cocogitto.yml
+++ b/.github/workflows/cocogitto.yml
@@ -11,9 +11,44 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Conventional commits compliance
+      - name: Conventional commits compliance check
         uses: oknozor/cocogitto-action@v3
         with:
           check-latest-tag-only: true
           git-user: 'yoctoyotta1024'
           git-user-email: 'yoctoyotta1024@yahoo.com'
+
+  release:
+    needs: cog_check_job
+    # Only release new version when merging into `origin/main`.`
+    if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'yoctoyotta1024'"
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    name: Perform semantic versioning release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: semver release with cocogitto
+        uses: oknozor/cocogitto-action@v3
+        id: release
+        with:
+          release: true
+          check-latest-tag-only: true
+          git-user: 'yoctoyotta1024'
+          git-user-email: 'yoctoyotta1024@yahoo.com'
+
+      # The version number is accessible as a github action output
+      - name: Print version
+        run: "echo '${{ steps.release.outputs.version }}'"
+
+      - name: Generate Changelog
+        run: cog changelog --at ${{ steps.release.outputs.version }} -t full_hash > GITHUB_CHANGELOG.md
+
+      - name: Upload github release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: GITHUB_CHANGELOG.md
+          tag_name: ${{ steps.release.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
+- - -

--- a/cog.toml
+++ b/cog.toml
@@ -7,10 +7,14 @@ branch_whitelist = []
 skip_ci = "[skip ci]"
 skip_untracked = false
 tag_prefix = "v"
-pre_bump_hooks = []
-post_bump_hooks = []
 pre_package_bump_hooks = []
 post_package_bump_hooks = []
+
+pre_bump_hooks = [
+    "echo {{version}}",
+]
+
+post_bump_hooks = []
 
 [git_hooks]
 
@@ -18,7 +22,11 @@ post_package_bump_hooks = []
 
 [changelog]
 path = "CHANGELOG.md"
-authors = []
+template = "remote"
+remote = "github.com"
+repository = "CLEO"
+owner = "yoctoyotta1024"
+authors = [{ username = "yoctoyotta1024", signature = "Clara Bayley" }]
 
 [bump_profiles]
 

--- a/cog.toml
+++ b/cog.toml
@@ -1,0 +1,25 @@
+from_latest_tag = false
+ignore_merge_commits = true
+disable_changelog = false
+disable_bump_commit = false
+generate_mono_repository_global_tag = true
+branch_whitelist = []
+skip_ci = "[skip ci]"
+skip_untracked = false
+tag_prefix = "v"
+pre_bump_hooks = []
+post_bump_hooks = []
+pre_package_bump_hooks = []
+post_package_bump_hooks = []
+
+[git_hooks]
+
+[commit_types]
+
+[changelog]
+path = "CHANGELOG.md"
+authors = []
+
+[bump_profiles]
+
+[packages]


### PR DESCRIPTION
add cocogitto to CI in order to:
- check commits conform to conventional commit upon git pushes
- update changelog and make tag for version control upon pushes to main branch