### PR TITLE
seperate input scripts from running and plotting some examples

### DIFF
--- a/examples/adiabaticparcel/cuspbifurc.py
+++ b/examples/adiabaticparcel/cuspbifurc.py
@@ -6,7 +6,7 @@ Created Date: Friday 17th November 2023
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Thursday 18th April 2024
+Last Modified: Friday 3rd May 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -153,7 +153,7 @@ zprof = displacement(time, config["W_avg"], config["TAU_half"])
 
 ### plot results
 # sample drops to plot from whole range of SD ids
-sample = [0, int(config["totnsupers"])]
+sample = [0, int(config["maxnsupers"])]
 radii = sdtracing.attribute_for_superdroplets_sample(sddata, "radius",
                                                      minid=sample[0],
                                                      maxid=sample[1])

--- a/examples/boxmodelcollisions/shima2009.py
+++ b/examples/boxmodelcollisions/shima2009.py
@@ -6,7 +6,7 @@ Created Date: Friday 17th November 2023
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Monday 15th April 2024
+Last Modified: Friday 3rd May 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -161,7 +161,7 @@ if "golovin" in kernels:
     # 4. plot results
     tplt = [0, 1200, 2400, 3600]
     # 0.2 factor for guassian smoothing
-    smoothsig = 0.62*(config["totnsupers"]**(-1/5))
+    smoothsig = 0.62*(config["maxnsupers"]**(-1/5))
     plotwitherr = True
 
     savename = savefigpath + "golovin_validation.png"
@@ -195,7 +195,7 @@ if "long" in kernels:
     # 4. plot results
     tplt = [0, 600, 1200, 1800]
     # 0.2 factor for guassian smoothing
-    smoothsig = 0.62*(config["totnsupers"]**(-1/5))
+    smoothsig = 0.62*(config["maxnsupers"]**(-1/5))
     plotwitherr = False
 
     savename = savefigpath + "long_validation.png"
@@ -229,7 +229,7 @@ if "lowlist" in kernels:
     # 4. plot results
     tplt = [0, 600, 1200, 1800, 2400, 3600]
     # 0.2 factor for guassian smoothing
-    smoothsig = 0.62*(config["totnsupers"]**(-1/5))
+    smoothsig = 0.62*(config["maxnsupers"]**(-1/5))
     plotwitherr = False
 
     savename = savefigpath + "lowlist_validation.png"

--- a/examples/constthermo2d/constthermo2d.py
+++ b/examples/constthermo2d/constthermo2d.py
@@ -6,7 +6,7 @@ Created Date: Friday 17th November 2023
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Friday 12th April 2024
+Last Modified: Friday 3rd May 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -196,13 +196,13 @@ pltmoms.plot_domainmassmoments(time, massmoms, savename=savename)
 nsample = 500
 savename = savefigpath + "const2d_randomsample.png"
 pltsds.plot_randomsample_superdrops(time, sddata,
-                                        config["totnsupers"],
+                                        config["maxnsupers"],
                                         nsample,
                                         savename=savename)
 
 savename = savefigpath + "const2d_motion2d.png"
 pltsds.plot_randomsample_superdrops_2dmotion(sddata,
-                                                 config["totnsupers"],
+                                                 config["maxnsupers"],
                                                  nsample,
                                                  savename=savename,
                                                  arrows=False)

--- a/examples/divfreemotion/divfree2d.py
+++ b/examples/divfreemotion/divfree2d.py
@@ -6,7 +6,7 @@ Created Date: Friday 17th November 2023
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Friday 12th April 2024
+Last Modified: Friday 3rd May 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -182,16 +182,16 @@ gbxs = pygbxsdat.get_gridboxes(gridfile, consts["COORD0"], isprint=True)
 
 time = pyzarr.get_time(dataset)
 sddata = pyzarr.get_supers(dataset, consts)
-totnsupers =pyzarr.get_totnsupers(dataset)
+maxnsupers =pyzarr.get_maxnsupers(dataset)
 
 # 4. plot results
-savename = savefigpath + "df2d_totnsupers_validation.png"
-pltmoms.plot_totnsupers(time, totnsupers, savename=savename)
+savename = savefigpath + "df2d_maxnsupers_validation.png"
+pltmoms.plot_maxnsupers(time, maxnsupers, savename=savename)
 
 nsample = 500
 savename = savefigpath + "df2d_motion2d_validation.png"
 pltsds.plot_randomsample_superdrops_2dmotion(sddata,
-                                                 config["totnsupers"],
+                                                 config["maxnsupers"],
                                                  nsample,
                                                  savename=savename,
                                                  arrows=False)

--- a/examples/divfreemotion/divfree2d.py
+++ b/examples/divfreemotion/divfree2d.py
@@ -25,6 +25,7 @@ import sys
 import numpy as np
 import matplotlib.pyplot as plt
 from pathlib import Path
+import divfree2d_inputfiles
 
 path2CLEO = sys.argv[1]
 path2build = sys.argv[2]
@@ -35,69 +36,22 @@ sys.path.append(path2CLEO+"/examples/exampleplotting/") # for imports from examp
 
 from plotssrc import pltsds, pltmoms
 from pySD.sdmout_src import *
-from pySD.gbxboundariesbinary_src import read_gbxboundaries as rgrid
-from pySD.gbxboundariesbinary_src import create_gbxboundaries as cgrid
-from pySD.initsuperdropsbinary_src import *
-from pySD.initsuperdropsbinary_src import create_initsuperdrops as csupers
-from pySD.initsuperdropsbinary_src import read_initsuperdrops as rsupers
-from pySD.thermobinary_src import thermogen
-from pySD.thermobinary_src import create_thermodynamics as cthermo
-from pySD.thermobinary_src import read_thermodynamics as rthermo
 
 ### ---------------------------------------------------------------- ###
 ### ----------------------- INPUT PARAMETERS ----------------------- ###
 ### ---------------------------------------------------------------- ###
 ### --- essential paths and filenames --- ###
 # path and filenames for creating initial SD conditions
-constsfile = path2CLEO+"/libs/cleoconstants.hpp"
 binpath = path2build+"/bin/"
 sharepath = path2build+"/share/"
 gridfile = sharepath+"df2d_dimlessGBxboundaries.dat"
 initSDsfile = sharepath+"df2d_dimlessSDsinit.dat"
 thermofile =  sharepath+"/df2d_dimlessthermo.dat"
+savefigpath = path2build+"/bin/" # directory for saving figures
 
 # path and file names for plotting results
 setupfile = binpath+"df2d_setup.txt"
 dataset = binpath+"df2d_sol.zarr"
-
-### --- plotting initialisation figures --- ###
-isfigures = [True, True] # booleans for [making, saving] initialisation figures
-savefigpath = path2build+"/bin/" # directory for saving figures
-SDgbxs2plt = [0] # gbxindex of SDs to plot (nb. "all" can be very slow)
-
-### --- settings for 2-D gridbox boundaries --- ###
-zgrid = [0, 1500, 50]     # evenly spaced zhalf coords [zmin, zmax, zdelta] [m]
-xgrid = [0, 1500, 50]     # evenly spaced xhalf coords [m]
-ygrid = np.array([0, 20])  # array of yhalf coords [m]
-
-### --- settings for initial superdroplets --- ###
-# settings for initial superdroplet coordinates
-zlim = 750        # max z coord of superdroplets
-npergbx = 8       # number of superdroplets per gridbox
-
-# [min, max] range of initial superdroplet radii (and implicitly solute masses)
-rspan                = [3e-9, 3e-6] # [m]
-
-# settings for initial superdroplet multiplicies
-# (from bimodal Lognormal distribution)
-geomeans             = [0.02e-6, 0.15e-6]
-geosigs              = [1.4, 1.6]
-scalefacs            = [6e6, 4e6]
-numconc = np.sum(scalefacs)
-
-### --- settings for 2D Thermodynamics --- ###
-PRESS0 = 100000 # [Pa]
-THETA = 298.15  # [K]
-qcond = 0.0     # [Kg/Kg]
-WMAX = 0.6      # [m/s]
-VVEL = None     # [m/s]
-Zlength = 1500  # [m]
-Xlength = 1500  # [m]
-qvapmethod = "sratio"
-Zbase = 750     # [m]
-sratios = [1.0, 1.0] # s_ratio [below, above] Zbase
-### ---------------------------------------------------------------- ###
-### ---------------------------------------------------------------- ###
 
 ### ---------------------------------------------------------------- ###
 ### ------------------- BINARY FILES GENERATION--------------------- ###
@@ -109,52 +63,14 @@ else:
   Path(path2build).mkdir(exist_ok=True)
   Path(sharepath).mkdir(exist_ok=True)
   Path(binpath).mkdir(exist_ok=True)
-  if isfigures[1]:
-    Path(savefigpath).mkdir(exist_ok=True)
+  Path(savefigpath).mkdir(exist_ok=True)
 
 ### --- delete any existing initial conditions --- ###
 os.system("rm "+gridfile)
 os.system("rm "+initSDsfile)
 os.system("rm "+thermofile[:-4]+"*")
 
-### ----- write gridbox boundaries binary ----- ###
-cgrid.write_gridboxboundaries_binary(gridfile, zgrid, xgrid, ygrid, constsfile)
-rgrid.print_domain_info(constsfile, gridfile)
-
-### ----- write thermodynamics binaries ----- ###
-thermodyngen = thermogen.SimpleThermo2DFlowField(configfile, constsfile, PRESS0,
-                                                THETA, qvapmethod, sratios, Zbase,
-                                                qcond, WMAX, Zlength, Xlength,
-                                                VVEL)
-cthermo.write_thermodynamics_binary(thermofile, thermodyngen, configfile,
-                                    constsfile, gridfile)
-
-
-### ----- write initial superdroplets binary ----- ###
-nsupers = crdgens.nsupers_at_domain_base(gridfile, constsfile, npergbx, zlim)
-coord3gen = crdgens.SampleCoordGen(True) # sample coord3 randomly
-coord1gen = crdgens.SampleCoordGen(True) # sample coord1 randomly
-coord2gen = None                        # do not generate superdroplet coord2s
-xiprobdist = probdists.LnNormal(geomeans, geosigs, scalefacs)
-radiigen = rgens.SampleLog10RadiiGen(rspan) # randomly sample radii from rspan [m]
-dryradiigen = dryrgens.ScaledRadiiGen(1.0)
-
-initattrsgen = attrsgen.AttrsGenerator(radiigen, dryradiigen, xiprobdist,
-                                        coord3gen, coord1gen, coord2gen)
-csupers.write_initsuperdrops_binary(initSDsfile, initattrsgen,
-                                      configfile, constsfile,
-                                      gridfile, nsupers, numconc)
-
-### ----- show (and save) plots of binary file data ----- ###
-if isfigures[0]:
-  rgrid.plot_gridboxboundaries(constsfile, gridfile,
-                               savefigpath, isfigures[1])
-  rthermo.plot_thermodynamics(constsfile, configfile, gridfile,
-                              thermofile, savefigpath, isfigures[1])
-  rsupers.plot_initGBxs_distribs(configfile, constsfile, initSDsfile,
-                              gridfile, savefigpath, isfigures[1],
-                              SDgbxs2plt)
-  plt.close()
+divfree2d_inputfiles.main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile)
 ### ---------------------------------------------------------------- ###
 ### ---------------------------------------------------------------- ###
 
@@ -170,7 +86,6 @@ print('Config file: '+configfile)
 os.system(executable + ' ' + configfile)
 ### ---------------------------------------------------------------- ###
 ### ---------------------------------------------------------------- ###
-
 
 ### ---------------------------------------------------------------- ###
 ### ------------------------- PLOT RESULTS ------------------------- ###

--- a/examples/divfreemotion/divfree2d.py
+++ b/examples/divfreemotion/divfree2d.py
@@ -182,7 +182,7 @@ gbxs = pygbxsdat.get_gridboxes(gridfile, consts["COORD0"], isprint=True)
 
 time = pyzarr.get_time(dataset)
 sddata = pyzarr.get_supers(dataset, consts)
-maxnsupers =pyzarr.get_maxnsupers(dataset)
+maxnsupers =pyzarr.get_totnsupers(dataset)
 
 # 4. plot results
 savename = savefigpath + "df2d_maxnsupers_validation.png"

--- a/examples/divfreemotion/divfree2d_inputfiles.py
+++ b/examples/divfreemotion/divfree2d_inputfiles.py
@@ -1,0 +1,133 @@
+'''
+----- CLEO -----
+File: divfree2d_inputfiles.py
+Project: divfreemotion
+Created Date: Friday 17th November 2023
+Author: Clara Bayley (CB)
+Additional Contributors:
+-----
+Last Modified: Friday 3rd May 2024
+Modified By: CB
+-----
+License: BSD 3-Clause "New" or "Revised" License
+https://opensource.org/licenses/BSD-3-Clause
+-----
+Copyright (c) 2023 MPI-M, Clara Bayley
+-----
+File Description:
+Script generates input files for divergence free motion of superdroplets in
+a 2-D divergence free wind field.
+'''
+
+import sys
+
+def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    sys.path.append(path2CLEO)  # for imports from pySD package
+
+    from pySD.gbxboundariesbinary_src import read_gbxboundaries as rgrid
+    from pySD.gbxboundariesbinary_src import create_gbxboundaries as cgrid
+    from pySD.initsuperdropsbinary_src import crdgens, rgens, dryrgens, probdists, attrsgen
+    from pySD.initsuperdropsbinary_src import create_initsuperdrops as csupers
+    from pySD.initsuperdropsbinary_src import read_initsuperdrops as rsupers
+    from pySD.thermobinary_src import thermogen
+    from pySD.thermobinary_src import create_thermodynamics as cthermo
+    from pySD.thermobinary_src import read_thermodynamics as rthermo
+
+    ### ---------------------------------------------------------------- ###
+    ### ----------------------- INPUT PARAMETERS ----------------------- ###
+    ### ---------------------------------------------------------------- ###
+    ### --- essential paths and filenames --- ###
+    # path and filenames for creating initial SD conditions
+    constsfile = path2CLEO+"/libs/cleoconstants.hpp"
+
+    ### --- plotting initialisation figures --- ###
+    isfigures = [True, True] # booleans for [making, saving] initialisation figures
+    savefigpath = path2build+"/bin/" # directory for saving figures
+    SDgbxs2plt = [0] # gbxindex of SDs to plot (nb. "all" can be very slow)
+
+    ### --- settings for 2-D gridbox boundaries --- ###
+    zgrid = [0, 1500, 50]     # evenly spaced zhalf coords [zmin, zmax, zdelta] [m]
+    xgrid = [0, 1500, 50]     # evenly spaced xhalf coords [m]
+    ygrid = np.array([0, 20])  # array of yhalf coords [m]
+
+    ### --- settings for initial superdroplets --- ###
+    # settings for initial superdroplet coordinates
+    zlim = 750        # max z coord of superdroplets
+    npergbx = 8       # number of superdroplets per gridbox
+
+    # [min, max] range of initial superdroplet radii (and implicitly solute masses)
+    rspan                = [3e-9, 3e-6] # [m]
+
+    # settings for initial superdroplet multiplicies
+    # (from bimodal Lognormal distribution)
+    geomeans             = [0.02e-6, 0.15e-6]
+    geosigs              = [1.4, 1.6]
+    scalefacs            = [6e6, 4e6]
+    numconc = np.sum(scalefacs)
+
+    ### --- settings for 2D Thermodynamics --- ###
+    PRESS0 = 100000 # [Pa]
+    THETA = 298.15  # [K]
+    qcond = 0.0     # [Kg/Kg]
+    WMAX = 0.6      # [m/s]
+    VVEL = None     # [m/s]
+    Zlength = 1500  # [m]
+    Xlength = 1500  # [m]
+    qvapmethod = "sratio"
+    Zbase = 750     # [m]
+    sratios = [1.0, 1.0] # s_ratio [below, above] Zbase
+    ### ---------------------------------------------------------------- ###
+    ### ---------------------------------------------------------------- ###
+
+    if path2CLEO == path2build:
+        raise ValueError("build directory cannot be CLEO")
+
+    ### ---------------------------------------------------------------- ###
+    ### ------------------- BINARY FILES GENERATION--------------------- ###
+    ### ---------------------------------------------------------------- ###
+    ### ----- write gridbox boundaries binary ----- ###
+    cgrid.write_gridboxboundaries_binary(gridfile, zgrid, xgrid, ygrid, constsfile)
+    rgrid.print_domain_info(constsfile, gridfile)
+
+    ### ----- write thermodynamics binaries ----- ###
+    thermodyngen = thermogen.SimpleThermo2DFlowField(configfile, constsfile, PRESS0,
+                                                    THETA, qvapmethod, sratios, Zbase,
+                                                    qcond, WMAX, Zlength, Xlength,
+                                                    VVEL)
+    cthermo.write_thermodynamics_binary(thermofile, thermodyngen, configfile,
+                                      constsfile, gridfile)
+
+    ### ----- write initial superdroplets binary ----- ###
+    nsupers = crdgens.nsupers_at_domain_base(gridfile, constsfile, npergbx, zlim)
+    coord3gen = crdgens.SampleCoordGen(True) # sample coord3 randomly
+    coord1gen = crdgens.SampleCoordGen(True) # sample coord1 randomly
+    coord2gen = None                        # do not generate superdroplet coord2s
+    xiprobdist = probdists.LnNormal(geomeans, geosigs, scalefacs)
+    radiigen = rgens.SampleLog10RadiiGen(rspan) # randomly sample radii from rspan [m]
+    dryradiigen = dryrgens.ScaledRadiiGen(1.0)
+
+    initattrsgen = attrsgen.AttrsGenerator(radiigen, dryradiigen, xiprobdist,
+                                            coord3gen, coord1gen, coord2gen)
+    csupers.write_initsuperdrops_binary(initSDsfile, initattrsgen,
+                                          configfile, constsfile,
+                                          gridfile, nsupers, numconc)
+
+    ### ----- show (and save) plots of binary file data ----- ###
+    if isfigures[0]:
+      rgrid.plot_gridboxboundaries(constsfile, gridfile,
+                                  savefigpath, isfigures[1])
+      rthermo.plot_thermodynamics(constsfile, configfile, gridfile,
+                                  thermofile, savefigpath, isfigures[1])
+      rsupers.plot_initGBxs_distribs(configfile, constsfile, initSDsfile,
+                                  gridfile, savefigpath, isfigures[1],
+                                  SDgbxs2plt)
+      plt.close()
+    ### ---------------------------------------------------------------- ###
+    ### ---------------------------------------------------------------- ###
+
+if __name__ == "__main__":
+    ### args = path2CLEO, path2build, configfile, binpath, gridfile, initSDsfile, thermofile
+    main(*sys.argv[1:])

--- a/examples/exampleplotting/exampleplotting.py
+++ b/examples/exampleplotting/exampleplotting.py
@@ -6,7 +6,7 @@ Created Date: Sunday 26th November 2023
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Monday 15th April 2024
+Last Modified: Friday 3rd May 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -73,11 +73,11 @@ sddata = pyzarr.get_supers(ds, consts)
 savename = ""
 if savefig:
   savename = savefigpath+"/randomsample_attrs.png"
-pltsds.plot_randomsample_superdrops(time, sddata, config["totnsupers"],
+pltsds.plot_randomsample_superdrops(time, sddata, config["maxnsupers"],
                                     nsample, savename=savename)
 if savefig:
   savename = savefigpath+"/randomsample_2dmotion.png"
-pltsds.plot_randomsample_superdrops_2dmotion(sddata, config["totnsupers"],
+pltsds.plot_randomsample_superdrops_2dmotion(sddata, config["maxnsupers"],
                                              nsample, arrows=False)
 ### ---------------------------------------------------------------- ###
 
@@ -87,7 +87,7 @@ if rspan == ["min", "max"]:
   rspan = [ak.min(non_nanradius), ak.max(non_nanradius)]
 
 if smoothsig_mass:
-  smoothsig_mass = smoothsig_mass*(config["totnsupers"]**(-1/5))
+  smoothsig_mass = smoothsig_mass*(config["maxnsupers"]**(-1/5))
 if savefig:
   savename = savefigpath+"/domain_mass_distrib.png"
 fig, ax = pltdist.plot_domainmass_distribs(time.secs, sddata, t2plts,
@@ -98,7 +98,7 @@ fig, ax = pltdist.plot_domainmass_distribs(time.secs, sddata, t2plts,
                                      savename=savename)
 
 if smoothsig_num:
-  smoothsig_num = smoothsig_num*(config["totnsupers"]**(-1/5))
+  smoothsig_num = smoothsig_num*(config["maxnsupers"]**(-1/5))
 if savefig:
   savename = savefigpath+"/domain_numconc_distrib.png"
 fig, ax = pltdist.plot_domainnumconc_distribs(time.secs, sddata, t2plts,

--- a/examples/exampleplotting/plotssrc/pltmoms.py
+++ b/examples/exampleplotting/plotssrc/pltmoms.py
@@ -6,7 +6,7 @@ Created Date: Tuesday 21st November 2023
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Wednesday 22nd November 2023
+Last Modified: Friday 3rd May 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License

--- a/examples/exampleplotting/plotssrc/pltsds.py
+++ b/examples/exampleplotting/plotssrc/pltsds.py
@@ -6,7 +6,7 @@ Created Date: Friday 17th November 2023
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Monday 25th March 2024
+Last Modified: Friday 3rd May 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License

--- a/examples/rainshaft1d/rainshaft1d.py
+++ b/examples/rainshaft1d/rainshaft1d.py
@@ -196,7 +196,7 @@ pltmoms.plot_domainmassmoments(time, massmoms, savename=savename)
 nsample = 500
 savename = savefigpath + "rain1d_randomsample.png"
 pltsds.plot_randomsample_superdrops(time, sddata,
-                                        config["totnsupers"],
+                                        config["maxnsupers"],
                                         nsample,
                                         savename=savename)
 

--- a/examples/yac/fromfile/yac1_fromfile.py
+++ b/examples/yac/fromfile/yac1_fromfile.py
@@ -102,7 +102,7 @@ gbxs = pygbxsdat.get_gridboxes(gridfile, consts["COORD0"], isprint=True)
 
 time = pyzarr.get_time(dataset)
 sddata = pyzarr.get_supers(dataset, consts)
-maxnsupers = pyzarr.get_maxnsupers(dataset)
+maxnsupers = pyzarr.get_totnsupers(dataset)
 thermo, winds = pyzarr.get_thermodata(dataset, config["ntime"], gbxs["ndims"],
                                       consts, getwinds=True)
 

--- a/examples/yac/fromfile/yac1_fromfile.py
+++ b/examples/yac/fromfile/yac1_fromfile.py
@@ -102,18 +102,18 @@ gbxs = pygbxsdat.get_gridboxes(gridfile, consts["COORD0"], isprint=True)
 
 time = pyzarr.get_time(dataset)
 sddata = pyzarr.get_supers(dataset, consts)
-totnsupers = pyzarr.get_totnsupers(dataset)
+maxnsupers = pyzarr.get_maxnsupers(dataset)
 thermo, winds = pyzarr.get_thermodata(dataset, config["ntime"], gbxs["ndims"],
                                       consts, getwinds=True)
 
 # plot super-droplet results
-savename = savefigpath + "yac1_totnsupers_validation.png"
-pltmoms.plot_totnsupers(time, totnsupers, savename=savename)
+savename = savefigpath + "yac1_maxnsupers_validation.png"
+pltmoms.plot_maxnsupers(time, maxnsupers, savename=savename)
 
 nsample = 1000
 savename = savefigpath + "yac1_motion2d_validation.png"
 pltsds.plot_randomsample_superdrops_2dmotion(sddata,
-                                             config["totnsupers"],
+                                             config["maxnsupers"],
                                              nsample,
                                              savename=savename,
                                              arrows=False,

--- a/examples/yac/fromfile/yac1_fromfile.py
+++ b/examples/yac/fromfile/yac1_fromfile.py
@@ -6,7 +6,7 @@ Created Date: Friday 17th November 2023
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Friday 12th April 2024
+Last Modified: Friday 3rd May 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -22,9 +22,10 @@ Plots output data as .png files for visual checks.
 
 import os
 import sys
+from pathlib import Path
 import numpy as np
 import matplotlib.pyplot as plt
-from pathlib import Path
+import yac1_fromfile_inputfiles
 
 path2CLEO = sys.argv[1]
 path2build = sys.argv[2]
@@ -34,62 +35,25 @@ sys.path.append(path2CLEO)  # for imports from pySD package
 # for imports from example plotting package
 sys.path.append(path2CLEO+"/examples/exampleplotting/")
 
-from src import gen_input_thermo, plot_output_thermo
+from src import plot_output_thermo
 from plotssrc import pltsds, pltmoms
 from pySD.sdmout_src import *
-from pySD.gbxboundariesbinary_src import read_gbxboundaries as rgrid
-from pySD.gbxboundariesbinary_src import create_gbxboundaries as cgrid
-from pySD.initsuperdropsbinary_src import *
-from pySD.initsuperdropsbinary_src import create_initsuperdrops as csupers
-from pySD.thermobinary_src import create_thermodynamics as cthermo
-from pySD.thermobinary_src import read_thermodynamics as rthermo
 
 ### ---------------------------------------------------------------- ###
 ### ----------------------- INPUT PARAMETERS ----------------------- ###
 ### ---------------------------------------------------------------- ###
 ### --- essential paths and filenames --- ###
 # path and filenames for creating initial SD conditions
-constsfile = path2CLEO+"/libs/cleoconstants.hpp"
 binpath = path2build+"/bin/"
 sharepath = path2build+"/share/"
 gridfile = sharepath+"yac1_dimlessGBxboundaries.dat"
 initSDsfile = sharepath+"yac1_dimlessSDsinit.dat"
 thermofile = sharepath+"/yac1_dimlessthermo.dat"
+savefigpath = path2build+"/bin/"  # directory for saving figures
 
 # path and file names for plotting results
 setupfile = binpath+"yac1_setup.txt"
 dataset = binpath+"yac1_sol.zarr"
-
-### --- plotting initialisation figures --- ###
-# booleans for [making, saving] initialisation figures
-isfigures = [True, True]
-savefigpath = path2build+"/bin/"  # directory for saving figures
-
-### --- settings for 2-D gridbox boundaries --- ###
-zgrid = [0, 1500, 60]           # evenly spaced zhalf coords [zmin, zmax, zdelta] [m]
-xgrid = [0, 1500, 50]           # evenly spaced xhalf coords [m]
-ygrid = np.array([0, 100, 200, 300])   # array of yhalf coords [m]
-
-### --- settings for initial superdroplets --- ###
-# settings for initial superdroplet coordinates
-zlim = 1000             # max z coord of superdroplets
-npergbx = 2             # number of superdroplets per gridbox
-
-monor = 1e-6            # all SDs have this same radius [m]
-dryr_sf = 1.0           # scale factor for dry radii [m]
-numconc = 5e8           # total no. conc of real droplets [m^-3]
-randcoord = False       # sample SD spatial coordinates randomly or not
-
-### --- settings for 2D Thermodynamics --- ###
-PRESSz0 = 101500 # [Pa]
-TEMPz0 = 300     # [K]
-qvapz0 = 0.05    # [Kg/Kg]
-qcondz0 = 0.001  # [Kg/Kg]
-WMAX = 1.5       # [m/s]
-Zlength = 1500   # [m]
-Xlength = 1500   # [m]
-VMAX = 1.0       # [m/s]
-Ylength = 300    # [m]
 ### ---------------------------------------------------------------- ###
 ### ---------------------------------------------------------------- ###
 
@@ -103,46 +67,14 @@ else:
     Path(path2build).mkdir(exist_ok=True)
     Path(sharepath).mkdir(exist_ok=True)
     Path(binpath).mkdir(exist_ok=True)
-    if isfigures[1]:
-        Path(savefigpath).mkdir(exist_ok=True)
+    Path(savefigpath).mkdir(exist_ok=True)
 
 ### --- delete any existing initial conditions --- ###
 os.system("rm "+gridfile)
 os.system("rm "+initSDsfile)
 os.system("rm "+thermofile[:-4]+"*")
 
-### ----- write gridbox boundaries binary ----- ###
-cgrid.write_gridboxboundaries_binary(gridfile, zgrid, xgrid, ygrid, constsfile)
-rgrid.print_domain_info(constsfile, gridfile)
-
-### ----- write thermodynamics binaries ----- ###
-thermodyngen = gen_input_thermo.TimeVarying3DThermo(PRESSz0, TEMPz0, qvapz0, qcondz0,
-                                                    WMAX, Zlength, Xlength, VMAX, Ylength)
-cthermo.write_thermodynamics_binary(thermofile, thermodyngen, configfile,
-                                    constsfile, gridfile)
-
-### ----- write initial superdroplets binary ----- ###
-nsupers = crdgens.nsupers_at_domain_base(gridfile, constsfile, npergbx, zlim)
-radiigen  =  rgens.MonoAttrGen(monor)                 # all SDs have the same radius [m]
-dryradiigen =  dryrgens.ScaledRadiiGen(dryr_sf)       # dryradii are 1/sf of radii [m]
-coord3gen =  crdgens.SampleCoordGen(randcoord)        # (not) random coord3 of SDs
-coord1gen =  crdgens.SampleCoordGen(randcoord)        # (not) random coord1 of SDs
-coord2gen =  crdgens.SampleCoordGen(randcoord)        # (not) random coord2 of SDs
-xiprobdist = probdists.DiracDelta(monor)              # monodisperse droplet probability distrib
-
-initattrsgen = attrsgen.AttrsGenerator(radiigen, dryradiigen, xiprobdist,
-                                       coord3gen, coord1gen, coord2gen)
-csupers.write_initsuperdrops_binary(initSDsfile, initattrsgen,
-                                    configfile, constsfile,
-                                    gridfile, nsupers, numconc)
-
-### ----- show (and save) plots of binary file data ----- ###
-if isfigures[0]:
-    rgrid.plot_gridboxboundaries(constsfile, gridfile,
-                                 savefigpath, isfigures[1])
-    rthermo.plot_thermodynamics(constsfile, configfile, gridfile,
-                                thermofile, savefigpath, isfigures[1])
-    plt.close()
+yac1_fromfile_inputfiles.main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile)
 ### ---------------------------------------------------------------- ###
 ### ---------------------------------------------------------------- ###
 

--- a/examples/yac/fromfile/yac1_fromfile_inputfiles.py
+++ b/examples/yac/fromfile/yac1_fromfile_inputfiles.py
@@ -1,0 +1,139 @@
+'''
+----- CLEO -----
+File: yac1_fromfile_inputfiles.py
+Project: fromfile
+Created Date: Friday 17th November 2023
+Author: Clara Bayley (CB)
+Additional Contributors:
+-----
+Last Modified: Friday 3rd May 2024
+Modified By: CB
+-----
+License: BSD 3-Clause "New" or "Revised" License
+https://opensource.org/licenses/BSD-3-Clause
+-----
+Copyright (c) 2023 MPI-M, Clara Bayley
+-----
+File Description:
+Script generates input files for 3D example with time varying
+thermodynamics read from binary files to test that YAC can send
+the data to CLEO correctly.
+'''
+
+import os
+import sys
+import numpy as np
+import matplotlib.pyplot as plt
+from pathlib import Path
+
+path2CLEO = sys.argv[1]
+path2build = sys.argv[2]
+configfile = sys.argv[3]
+
+sys.path.append(path2CLEO)  # for imports from pySD package
+
+from src import gen_input_thermo
+from pySD.gbxboundariesbinary_src import read_gbxboundaries as rgrid
+from pySD.gbxboundariesbinary_src import create_gbxboundaries as cgrid
+from pySD.initsuperdropsbinary_src import *
+from pySD.initsuperdropsbinary_src import create_initsuperdrops as csupers
+from pySD.thermobinary_src import create_thermodynamics as cthermo
+from pySD.thermobinary_src import read_thermodynamics as rthermo
+
+### ---------------------------------------------------------------- ###
+### ----------------------- INPUT PARAMETERS ----------------------- ###
+### ---------------------------------------------------------------- ###
+### --- essential paths and filenames --- ###
+# path and filenames for creating initial SD conditions
+constsfile = path2CLEO+"/libs/cleoconstants.hpp"
+binpath = path2build+"/bin/"
+sharepath = path2build+"/share/"
+gridfile = sharepath+"yac1_dimlessGBxboundaries.dat"
+initSDsfile = sharepath+"yac1_dimlessSDsinit.dat"
+thermofile = sharepath+"/yac1_dimlessthermo.dat"
+
+### --- plotting initialisation figures --- ###
+# booleans for [making, saving] initialisation figures
+isfigures = [True, True]
+savefigpath = path2build+"/bin/"  # directory for saving figures
+
+### --- settings for 2-D gridbox boundaries --- ###
+zgrid = [0, 1500, 60]           # evenly spaced zhalf coords [zmin, zmax, zdelta] [m]
+xgrid = [0, 1500, 50]           # evenly spaced xhalf coords [m]
+ygrid = np.array([0, 100, 200, 300])   # array of yhalf coords [m]
+
+### --- settings for initial superdroplets --- ###
+# settings for initial superdroplet coordinates
+zlim = 1000             # max z coord of superdroplets
+npergbx = 2             # number of superdroplets per gridbox
+
+monor = 1e-6            # all SDs have this same radius [m]
+dryr_sf = 1.0           # scale factor for dry radii [m]
+numconc = 5e8           # total no. conc of real droplets [m^-3]
+randcoord = False       # sample SD spatial coordinates randomly or not
+
+### --- settings for 2D Thermodynamics --- ###
+PRESSz0 = 101500 # [Pa]
+TEMPz0 = 300     # [K]
+qvapz0 = 0.05    # [Kg/Kg]
+qcondz0 = 0.001  # [Kg/Kg]
+WMAX = 1.5       # [m/s]
+Zlength = 1500   # [m]
+Xlength = 1500   # [m]
+VMAX = 1.0       # [m/s]
+Ylength = 300    # [m]
+### ---------------------------------------------------------------- ###
+### ---------------------------------------------------------------- ###
+
+### ---------------------------------------------------------------- ###
+### ------------------- BINARY FILES GENERATION--------------------- ###
+### ---------------------------------------------------------------- ###
+### --- ensure build, share and bin directories exist --- ###
+if path2CLEO == path2build:
+    raise ValueError("build directory cannot be CLEO")
+else:
+    Path(path2build).mkdir(exist_ok=True)
+    Path(sharepath).mkdir(exist_ok=True)
+    Path(binpath).mkdir(exist_ok=True)
+    if isfigures[1]:
+        Path(savefigpath).mkdir(exist_ok=True)
+
+### --- delete any existing initial conditions --- ###
+os.system("rm "+gridfile)
+os.system("rm "+initSDsfile)
+os.system("rm "+thermofile[:-4]+"*")
+
+### ----- write gridbox boundaries binary ----- ###
+cgrid.write_gridboxboundaries_binary(gridfile, zgrid, xgrid, ygrid, constsfile)
+rgrid.print_domain_info(constsfile, gridfile)
+
+### ----- write thermodynamics binaries ----- ###
+thermodyngen = gen_input_thermo.TimeVarying3DThermo(PRESSz0, TEMPz0, qvapz0, qcondz0,
+                                                    WMAX, Zlength, Xlength, VMAX, Ylength)
+cthermo.write_thermodynamics_binary(thermofile, thermodyngen, configfile,
+                                    constsfile, gridfile)
+
+### ----- write initial superdroplets binary ----- ###
+nsupers = crdgens.nsupers_at_domain_base(gridfile, constsfile, npergbx, zlim)
+radiigen  =  rgens.MonoAttrGen(monor)                 # all SDs have the same radius [m]
+dryradiigen =  dryrgens.ScaledRadiiGen(dryr_sf)       # dryradii are 1/sf of radii [m]
+coord3gen =  crdgens.SampleCoordGen(randcoord)        # (not) random coord3 of SDs
+coord1gen =  crdgens.SampleCoordGen(randcoord)        # (not) random coord1 of SDs
+coord2gen =  crdgens.SampleCoordGen(randcoord)        # (not) random coord2 of SDs
+xiprobdist = probdists.DiracDelta(monor)              # monodisperse droplet probability distrib
+
+initattrsgen = attrsgen.AttrsGenerator(radiigen, dryradiigen, xiprobdist,
+                                       coord3gen, coord1gen, coord2gen)
+csupers.write_initsuperdrops_binary(initSDsfile, initattrsgen,
+                                    configfile, constsfile,
+                                    gridfile, nsupers, numconc)
+
+### ----- show (and save) plots of binary file data ----- ###
+if isfigures[0]:
+    rgrid.plot_gridboxboundaries(constsfile, gridfile,
+                                 savefigpath, isfigures[1])
+    rthermo.plot_thermodynamics(constsfile, configfile, gridfile,
+                                thermofile, savefigpath, isfigures[1])
+    plt.close()
+### ---------------------------------------------------------------- ###
+### ---------------------------------------------------------------- ###

--- a/examples/yac/fromfile/yac1_fromfile_inputfiles.py
+++ b/examples/yac/fromfile/yac1_fromfile_inputfiles.py
@@ -20,120 +20,122 @@ thermodynamics read from binary files to test that YAC can send
 the data to CLEO correctly.
 '''
 
-import os
 import sys
-import numpy as np
-import matplotlib.pyplot as plt
-from pathlib import Path
 
-path2CLEO = sys.argv[1]
-path2build = sys.argv[2]
-configfile = sys.argv[3]
+def main(path2CLEO, path2build, configfile):
 
-sys.path.append(path2CLEO)  # for imports from pySD package
+    import os
+    import numpy as np
+    import matplotlib.pyplot as plt
+    from pathlib import Path
 
-from src import gen_input_thermo
-from pySD.gbxboundariesbinary_src import read_gbxboundaries as rgrid
-from pySD.gbxboundariesbinary_src import create_gbxboundaries as cgrid
-from pySD.initsuperdropsbinary_src import *
-from pySD.initsuperdropsbinary_src import create_initsuperdrops as csupers
-from pySD.thermobinary_src import create_thermodynamics as cthermo
-from pySD.thermobinary_src import read_thermodynamics as rthermo
+    sys.path.append(path2CLEO)  # for imports from pySD package
 
-### ---------------------------------------------------------------- ###
-### ----------------------- INPUT PARAMETERS ----------------------- ###
-### ---------------------------------------------------------------- ###
-### --- essential paths and filenames --- ###
-# path and filenames for creating initial SD conditions
-constsfile = path2CLEO+"/libs/cleoconstants.hpp"
-binpath = path2build+"/bin/"
-sharepath = path2build+"/share/"
-gridfile = sharepath+"yac1_dimlessGBxboundaries.dat"
-initSDsfile = sharepath+"yac1_dimlessSDsinit.dat"
-thermofile = sharepath+"/yac1_dimlessthermo.dat"
+    from src import gen_input_thermo
+    from pySD.gbxboundariesbinary_src import read_gbxboundaries as rgrid
+    from pySD.gbxboundariesbinary_src import create_gbxboundaries as cgrid
+    from pySD.initsuperdropsbinary_src import *
+    from pySD.initsuperdropsbinary_src import create_initsuperdrops as csupers
+    from pySD.thermobinary_src import create_thermodynamics as cthermo
+    from pySD.thermobinary_src import read_thermodynamics as rthermo
 
-### --- plotting initialisation figures --- ###
-# booleans for [making, saving] initialisation figures
-isfigures = [True, True]
-savefigpath = path2build+"/bin/"  # directory for saving figures
+    ### ---------------------------------------------------------------- ###
+    ### ----------------------- INPUT PARAMETERS ----------------------- ###
+    ### ---------------------------------------------------------------- ###
+    ### --- essential paths and filenames --- ###
+    # path and filenames for creating initial SD conditions
+    constsfile = path2CLEO+"/libs/cleoconstants.hpp"
+    binpath = path2build+"/bin/"
+    sharepath = path2build+"/share/"
+    gridfile = sharepath+"yac1_dimlessGBxboundaries.dat"
+    initSDsfile = sharepath+"yac1_dimlessSDsinit.dat"
+    thermofile = sharepath+"/yac1_dimlessthermo.dat"
 
-### --- settings for 2-D gridbox boundaries --- ###
-zgrid = [0, 1500, 60]           # evenly spaced zhalf coords [zmin, zmax, zdelta] [m]
-xgrid = [0, 1500, 50]           # evenly spaced xhalf coords [m]
-ygrid = np.array([0, 100, 200, 300])   # array of yhalf coords [m]
+    ### --- plotting initialisation figures --- ###
+    # booleans for [making, saving] initialisation figures
+    isfigures = [True, True]
+    savefigpath = path2build+"/bin/"  # directory for saving figures
 
-### --- settings for initial superdroplets --- ###
-# settings for initial superdroplet coordinates
-zlim = 1000             # max z coord of superdroplets
-npergbx = 2             # number of superdroplets per gridbox
+    ### --- settings for 2-D gridbox boundaries --- ###
+    zgrid = [0, 1500, 60]           # evenly spaced zhalf coords [zmin, zmax, zdelta] [m]
+    xgrid = [0, 1500, 50]           # evenly spaced xhalf coords [m]
+    ygrid = np.array([0, 100, 200, 300])   # array of yhalf coords [m]
 
-monor = 1e-6            # all SDs have this same radius [m]
-dryr_sf = 1.0           # scale factor for dry radii [m]
-numconc = 5e8           # total no. conc of real droplets [m^-3]
-randcoord = False       # sample SD spatial coordinates randomly or not
+    ### --- settings for initial superdroplets --- ###
+    # settings for initial superdroplet coordinates
+    zlim = 1000             # max z coord of superdroplets
+    npergbx = 2             # number of superdroplets per gridbox
 
-### --- settings for 2D Thermodynamics --- ###
-PRESSz0 = 101500 # [Pa]
-TEMPz0 = 300     # [K]
-qvapz0 = 0.05    # [Kg/Kg]
-qcondz0 = 0.001  # [Kg/Kg]
-WMAX = 1.5       # [m/s]
-Zlength = 1500   # [m]
-Xlength = 1500   # [m]
-VMAX = 1.0       # [m/s]
-Ylength = 300    # [m]
-### ---------------------------------------------------------------- ###
-### ---------------------------------------------------------------- ###
+    monor = 1e-6            # all SDs have this same radius [m]
+    dryr_sf = 1.0           # scale factor for dry radii [m]
+    numconc = 5e8           # total no. conc of real droplets [m^-3]
+    randcoord = False       # sample SD spatial coordinates randomly or not
 
-### ---------------------------------------------------------------- ###
-### ------------------- BINARY FILES GENERATION--------------------- ###
-### ---------------------------------------------------------------- ###
-### --- ensure build, share and bin directories exist --- ###
-if path2CLEO == path2build:
-    raise ValueError("build directory cannot be CLEO")
-else:
-    Path(path2build).mkdir(exist_ok=True)
-    Path(sharepath).mkdir(exist_ok=True)
-    Path(binpath).mkdir(exist_ok=True)
-    if isfigures[1]:
-        Path(savefigpath).mkdir(exist_ok=True)
+    ### --- settings for 2D Thermodynamics --- ###
+    PRESSz0 = 101500 # [Pa]
+    TEMPz0 = 300     # [K]
+    qvapz0 = 0.05    # [Kg/Kg]
+    qcondz0 = 0.001  # [Kg/Kg]
+    WMAX = 1.5       # [m/s]
+    Zlength = 1500   # [m]
+    Xlength = 1500   # [m]
+    VMAX = 1.0       # [m/s]
+    Ylength = 300    # [m]
+    ### ---------------------------------------------------------------- ###
+    ### ---------------------------------------------------------------- ###
 
-### --- delete any existing initial conditions --- ###
-os.system("rm "+gridfile)
-os.system("rm "+initSDsfile)
-os.system("rm "+thermofile[:-4]+"*")
+    ### ---------------------------------------------------------------- ###
+    ### ------------------- BINARY FILES GENERATION--------------------- ###
+    ### ---------------------------------------------------------------- ###
+    ### --- ensure build, share and bin directories exist --- ###
+    if path2CLEO == path2build:
+        raise ValueError("build directory cannot be CLEO")
+    else:
+        Path(path2build).mkdir(exist_ok=True)
+        Path(sharepath).mkdir(exist_ok=True)
+        Path(binpath).mkdir(exist_ok=True)
+        if isfigures[1]:
+            Path(savefigpath).mkdir(exist_ok=True)
 
-### ----- write gridbox boundaries binary ----- ###
-cgrid.write_gridboxboundaries_binary(gridfile, zgrid, xgrid, ygrid, constsfile)
-rgrid.print_domain_info(constsfile, gridfile)
+    ### --- delete any existing initial conditions --- ###
+    os.system("rm "+gridfile)
+    os.system("rm "+initSDsfile)
+    os.system("rm "+thermofile[:-4]+"*")
 
-### ----- write thermodynamics binaries ----- ###
-thermodyngen = gen_input_thermo.TimeVarying3DThermo(PRESSz0, TEMPz0, qvapz0, qcondz0,
-                                                    WMAX, Zlength, Xlength, VMAX, Ylength)
-cthermo.write_thermodynamics_binary(thermofile, thermodyngen, configfile,
-                                    constsfile, gridfile)
+    ### ----- write gridbox boundaries binary ----- ###
+    cgrid.write_gridboxboundaries_binary(gridfile, zgrid, xgrid, ygrid, constsfile)
+    rgrid.print_domain_info(constsfile, gridfile)
 
-### ----- write initial superdroplets binary ----- ###
-nsupers = crdgens.nsupers_at_domain_base(gridfile, constsfile, npergbx, zlim)
-radiigen  =  rgens.MonoAttrGen(monor)                 # all SDs have the same radius [m]
-dryradiigen =  dryrgens.ScaledRadiiGen(dryr_sf)       # dryradii are 1/sf of radii [m]
-coord3gen =  crdgens.SampleCoordGen(randcoord)        # (not) random coord3 of SDs
-coord1gen =  crdgens.SampleCoordGen(randcoord)        # (not) random coord1 of SDs
-coord2gen =  crdgens.SampleCoordGen(randcoord)        # (not) random coord2 of SDs
-xiprobdist = probdists.DiracDelta(monor)              # monodisperse droplet probability distrib
+    ### ----- write thermodynamics binaries ----- ###
+    thermodyngen = gen_input_thermo.TimeVarying3DThermo(PRESSz0, TEMPz0, qvapz0, qcondz0,
+                                                        WMAX, Zlength, Xlength, VMAX, Ylength)
+    cthermo.write_thermodynamics_binary(thermofile, thermodyngen, configfile,
+                                        constsfile, gridfile)
 
-initattrsgen = attrsgen.AttrsGenerator(radiigen, dryradiigen, xiprobdist,
-                                       coord3gen, coord1gen, coord2gen)
-csupers.write_initsuperdrops_binary(initSDsfile, initattrsgen,
-                                    configfile, constsfile,
-                                    gridfile, nsupers, numconc)
+    ### ----- write initial superdroplets binary ----- ###
+    nsupers = crdgens.nsupers_at_domain_base(gridfile, constsfile, npergbx, zlim)
+    radiigen  =  rgens.MonoAttrGen(monor)                 # all SDs have the same radius [m]
+    dryradiigen =  dryrgens.ScaledRadiiGen(dryr_sf)       # dryradii are 1/sf of radii [m]
+    coord3gen =  crdgens.SampleCoordGen(randcoord)        # (not) random coord3 of SDs
+    coord1gen =  crdgens.SampleCoordGen(randcoord)        # (not) random coord1 of SDs
+    coord2gen =  crdgens.SampleCoordGen(randcoord)        # (not) random coord2 of SDs
+    xiprobdist = probdists.DiracDelta(monor)              # monodisperse droplet probability distrib
 
-### ----- show (and save) plots of binary file data ----- ###
-if isfigures[0]:
-    rgrid.plot_gridboxboundaries(constsfile, gridfile,
-                                 savefigpath, isfigures[1])
-    rthermo.plot_thermodynamics(constsfile, configfile, gridfile,
-                                thermofile, savefigpath, isfigures[1])
-    plt.close()
-### ---------------------------------------------------------------- ###
-### ---------------------------------------------------------------- ###
+    initattrsgen = attrsgen.AttrsGenerator(radiigen, dryradiigen, xiprobdist,
+                                        coord3gen, coord1gen, coord2gen)
+    csupers.write_initsuperdrops_binary(initSDsfile, initattrsgen,
+                                        configfile, constsfile,
+                                        gridfile, nsupers, numconc)
+
+    ### ----- show (and save) plots of binary file data ----- ###
+    if isfigures[0]:
+        rgrid.plot_gridboxboundaries(constsfile, gridfile,
+                                    savefigpath, isfigures[1])
+        rthermo.plot_thermodynamics(constsfile, configfile, gridfile,
+                                    thermofile, savefigpath, isfigures[1])
+        plt.close()
+    ### ---------------------------------------------------------------- ###
+    ### ---------------------------------------------------------------- ###
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/examples/yac/fromfile/yac1_fromfile_inputfiles.py
+++ b/examples/yac/fromfile/yac1_fromfile_inputfiles.py
@@ -22,19 +22,17 @@ the data to CLEO correctly.
 
 import sys
 
-def main(path2CLEO, path2build, configfile):
+def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
 
-    import os
     import numpy as np
     import matplotlib.pyplot as plt
-    from pathlib import Path
 
     sys.path.append(path2CLEO)  # for imports from pySD package
 
     from src import gen_input_thermo
     from pySD.gbxboundariesbinary_src import read_gbxboundaries as rgrid
     from pySD.gbxboundariesbinary_src import create_gbxboundaries as cgrid
-    from pySD.initsuperdropsbinary_src import *
+    from pySD.initsuperdropsbinary_src import crdgens, rgens, dryrgens, probdists, attrsgen
     from pySD.initsuperdropsbinary_src import create_initsuperdrops as csupers
     from pySD.thermobinary_src import create_thermodynamics as cthermo
     from pySD.thermobinary_src import read_thermodynamics as rthermo
@@ -45,11 +43,6 @@ def main(path2CLEO, path2build, configfile):
     ### --- essential paths and filenames --- ###
     # path and filenames for creating initial SD conditions
     constsfile = path2CLEO+"/libs/cleoconstants.hpp"
-    binpath = path2build+"/bin/"
-    sharepath = path2build+"/share/"
-    gridfile = sharepath+"yac1_dimlessGBxboundaries.dat"
-    initSDsfile = sharepath+"yac1_dimlessSDsinit.dat"
-    thermofile = sharepath+"/yac1_dimlessthermo.dat"
 
     ### --- plotting initialisation figures --- ###
     # booleans for [making, saving] initialisation figures
@@ -84,24 +77,12 @@ def main(path2CLEO, path2build, configfile):
     ### ---------------------------------------------------------------- ###
     ### ---------------------------------------------------------------- ###
 
+    if path2CLEO == path2build:
+        raise ValueError("build directory cannot be CLEO")
+
     ### ---------------------------------------------------------------- ###
     ### ------------------- BINARY FILES GENERATION--------------------- ###
     ### ---------------------------------------------------------------- ###
-    ### --- ensure build, share and bin directories exist --- ###
-    if path2CLEO == path2build:
-        raise ValueError("build directory cannot be CLEO")
-    else:
-        Path(path2build).mkdir(exist_ok=True)
-        Path(sharepath).mkdir(exist_ok=True)
-        Path(binpath).mkdir(exist_ok=True)
-        if isfigures[1]:
-            Path(savefigpath).mkdir(exist_ok=True)
-
-    ### --- delete any existing initial conditions --- ###
-    os.system("rm "+gridfile)
-    os.system("rm "+initSDsfile)
-    os.system("rm "+thermofile[:-4]+"*")
-
     ### ----- write gridbox boundaries binary ----- ###
     cgrid.write_gridboxboundaries_binary(gridfile, zgrid, xgrid, ygrid, constsfile)
     rgrid.print_domain_info(constsfile, gridfile)
@@ -138,4 +119,5 @@ def main(path2CLEO, path2build, configfile):
     ### ---------------------------------------------------------------- ###
 
 if __name__ == "__main__":
-    main(sys.argv[1], sys.argv[2], sys.argv[3])
+    ### args = path2CLEO, path2build, configfile, binpath, gridfile, initSDsfile, thermofile
+    main(*sys.argv[1:])


### PR DESCRIPTION
split generating input files in divfree2d.py and yac1_fromfile.py examples into seperate files.

Plus fix minor bug in examples caused by name change in config from 'totnsupers' -> 'maxnsupers'.