### PR TITLE
refactor: move random number generator into collisions

### DIFF
--- a/libs/superdrops/condensation.hpp
+++ b/libs/superdrops/condensation.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors: Shin-ichiro Shima (SiS)
  * -----
- * Last Modified: Wednesday 17th April 2024
+ * Last Modified: Wednesday 8th May 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -165,12 +165,11 @@ struct DoCondensation {
    * @param subt The microphysics time step.
    * @param supers The view of super-droplets.
    * @param state The State.
-   * @param genpool The Kokkos thread-safe random number generator pool.
    * @return The updated view super-droplets.
    */
   KOKKOS_INLINE_FUNCTION subviewd_supers operator()(const TeamMember &team_member,
                                                     const unsigned int subt, subviewd_supers supers,
-                                                    State &state, GenRandomPool genpool) const {
+                                                    State &state) const {
     do_condensation(team_member, supers, state);
     return supers;
   }

--- a/libs/superdrops/urbg.hpp
+++ b/libs/superdrops/urbg.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Tuesday 9th April 2024
+ * Last Modified: Wednesday 8th May 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -132,7 +132,7 @@ KOKKOS_INLINE_FUNCTION viewd_supers shuffle_supers(const viewd_supers supers,
  */
 KOKKOS_INLINE_FUNCTION viewd_supers one_shuffle_supers(const TeamMember& team_member,
                                                        const viewd_supers supers,
-                                                       GenRandomPool genpool) {
+                                                       const GenRandomPool genpool) {
   Kokkos::single(Kokkos::PerTeam(team_member), [&]() {
     URBG<ExecSpace> urbg{genpool.get_state()};
     shuffle_supers(supers, urbg);


### PR DESCRIPTION
GenRandomPool is only need by DoCollisions micrcophysics, so store in that struct instead of creating it in RunCLEO.