### PR TITLE
Yac updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
         -DCMAKE_CXX_COMPILER=g++ \
         -DKokkos_ARCH_NATIVE=ON \
         -DKokkos_ENABLE_SERIAL=ON \
+        -DENABLE_YAC_COUPLING=ON \
         -DYAXT_ROOT=${HOME}/yaxt \
         -DYAC_ROOT=${HOME}/yac \
         -DCMAKE_MODULE_PATH=${PWD}/../libs/coupldyn_yac/cmake ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
 
     - name: Build YAC
       run: |
-        curl -s -L https://gitlab.dkrz.de/dkrz-sw/yac/-/archive/release-3.0.3_p2/yac-release-3.0.3_p2.tar.gz | tar xvz
-        cd yac-release-3.0.3_p2
+        curl -s -L https://gitlab.dkrz.de/dkrz-sw/yac/-/archive/v3.2.0_a_p2/yac-v3.2.0_a_p2.tar.gz | tar xvz
+        cd yac-v3.2.0_a_p2
         ./configure CFLAGS="-fPIC" CC=mpicc FC=mpif90 --disable-mpi-checks --with-yaxt-root=${HOME}/yaxt \
         --prefix=$HOME/yac
         make -j 4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,9 @@ jobs:
     - name: Build example spdtest
       run: cd build && make spdtest
 
+    - name: Build example divfree2D_yac
+      run: cd build && make divfree2D_yac
+
     - name: Build example yac1
       run: cd build && make yac1
 

--- a/examples/yac/divfreemotion/src/CMakeLists.txt
+++ b/examples/yac/divfreemotion/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(divfree2D_yac EXCLUDE_FROM_ALL "main_divfree2D.cpp")
 # Add directories and link libraries to target
 target_link_libraries(divfree2D_yac PRIVATE coupldyn_yac cartesiandomain "${CLEOLIBS}")
 target_link_libraries(divfree2D_yac PUBLIC Kokkos::kokkos)
-target_include_directories(divfree2D_yac PRIVATE "${CMAKE_SOURCE_DIR}/libs" ${YAC_C_INCLUDE_DIR})
+target_include_directories(divfree2D_yac PRIVATE "${CMAKE_SOURCE_DIR}/libs")
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(divfree2D PRIVATE)

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -14,5 +14,8 @@ add_subdirectory(observers)
 # libraries particular to certain CLEO configurations #
 add_subdirectory(coupldyn_cvode EXCLUDE_FROM_ALL)
 add_subdirectory(coupldyn_fromfile EXCLUDE_FROM_ALL)
-add_subdirectory(coupldyn_yac EXCLUDE_FROM_ALL)
 add_subdirectory(cartesiandomain EXCLUDE_FROM_ALL)
+
+if(ENABLE_YAC_COUPLING)
+    add_subdirectory(coupldyn_yac EXCLUDE_FROM_ALL)
+endif()

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
@@ -27,7 +27,7 @@
 
 #include <mpi.h>
 extern "C" {
-#include "yac_interface.h"
+#include "yac.h"
 }
 
 /* return (k,i,j) indicies from idx for a flattened 3D array


### PR DESCRIPTION
This PR introduces the following changes:
- Added the divfree2D_yac example as a CI build step
- Updated the YAC version for correct build flags and to make the python interface available for future execution tests
- Added a flag to guard the build of coupldyn_yac when YAC coupling is not wanted