### PR TITLE
install yac and yaxt and compile with YAC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
 
     - name: Build YAC
       run: |
-        curl -s -L https://gitlab.dkrz.de/dkrz-sw/yac/-/archive/v3.2.0_a_p2/yac-v3.2.0_a_p2.tar.gz | tar xvz
-        cd yac-v3.2.0_a_p2
+        curl -s -L https://gitlab.dkrz.de/dkrz-sw/yac/-/archive/v3.2.0_b_p1/yac-v3.2.0_b_p1.tar.gz | tar xvz
+        cd yac-v3.2.0_b_p1
         ./configure CFLAGS="-fPIC" CC=mpicc FC=mpif90 --disable-mpi-checks --with-yaxt-root=${HOME}/yaxt \
         --prefix=$HOME/yac
         make -j 4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ jobs:
 
     - name: Build YAXT
       run: |
-        curl -s -L https://swprojects.dkrz.de/redmine/attachments/download/529/yaxt-0.10.0.tar.gz | tar xvz
-        cd yaxt-0.10.0
+        curl -s -L https://swprojects.dkrz.de/redmine/attachments/download/534/yaxt-0.11.1.tar.gz | tar xvz
+        cd yaxt-0.11.1
         ./configure --without-regard-for-quality --without-example-programs --without-perf-programs --with-pic \
         --prefix=$HOME/yaxt
         make -j 4

--- a/scripts/bash/install_yac.sh
+++ b/scripts/bash/install_yac.sh
@@ -21,8 +21,8 @@ root4YAC=$1 # absolute path for YAC and YAXT installations
 yaxt_source=https://swprojects.dkrz.de/redmine/attachments/download/534/yaxt-0.11.1.tar.gz
 yaxt_version=yaxt-0.11.1 # must match yaxt_source
 
-yac_source=https://gitlab.dkrz.de/dkrz-sw/yac/-/archive/v3.2.0_a_p2/yac-v3.2.0_a_p2.tar.gz
-yac_version=yac-v3.2.0_a_p2 # must match yac_source
+yac_source=https://gitlab.dkrz.de/dkrz-sw/yac/-/archive/v3.2.0_b_p1/yac-v3.2.0_b_p1.tar.gz
+yac_version=yac-v3.2.0_b_p1 # must match yac_source
 
 gcc=gcc/11.2.0-gcc-11.2.0
 openmpi=openmpi/4.1.2-gcc-11.2.0
@@ -33,8 +33,8 @@ netcdf_root=/sw/spack-levante/netcdf-c-4.8.1-6qheqr # must match with `module sh
 fyaml=libfyaml
 fyaml_root=/sw/spack-levante/libfyaml-0.7.12-fvbhgo # must match with `spack location -i libfyaml``
 
-CC=mpicc
-FC=mpifort
+CC=/sw/spack-levante/openmpi-4.1.2-mnmady/bin/mpicc # must match gcc
+FC=/sw/spack-levante/openmpi-4.1.2-mnmady/bin/mpif90 # must match gcc
 
 if [ "${root4YAC}" == "" ]
 then
@@ -49,17 +49,19 @@ else
   cd ${yaxt_version}
   ./configure \
     CC=${CC} FC=${FC} \
+    CFLAGS="-O0 -g -Wall -fPIC" \
+    FCFLAGS="-O0 -g -Wall -cpp -fimplicit-none" \
     --without-regard-for-quality \
     --without-example-programs \
     --without-perf-programs \
     --with-pic \
     --prefix=${root4YAC}/yaxt
-  make -j 4
+  make -j 8
   make install
   cd ${root4YAC} && rm -rf ${yaxt_version}
   ### ------------------------------------------------------ ###
 
-  ### --------------------- install YAC -------------------- ###
+  ## --------------------- install YAC -------------------- ###
   cd ${root4YAC} && pwd
   curl -s -L ${yac_source} | tar xvz
   cd ${yac_version}
@@ -67,16 +69,16 @@ else
     CC=${CC} FC=${FC} \
     CFLAGS="-O0 -g -Wall -fPIC" \
     FCFLAGS="-O0 -g -Wall -cpp -fimplicit-none" \
-    LDFLAGS=-lm \
+    MKL_CLIBS="`pkg-config --libs mkl-static-lp64-seq`" \
+    MKL_CFLAGS="`pkg-config --cflags mkl-static-lp64-seq`" \
+    LDFLAGS="-lm" \
     --disable-mpi-checks \
     --with-yaxt-root=${root4YAC}/yaxt \
     --with-netcdf-root=${netcdf_root} \
     --with-fyaml-root=${fyaml_root} \
     --enable-rpaths \
-    MKL_CLIBS="`pkg-config --libs mkl-static-lp64-seq`" \
-    MKL_CFLAGS="`pkg-config --cflags mkl-static-lp64-seq`" \
     --prefix=${root4YAC}/yac
-  make -j 4
+  make -j 8
   make install
   cd ${root4YAC} && rm -rf ${yac_version}
 ### ------------------------------------------------------ ###

--- a/scripts/bash/install_yac.sh
+++ b/scripts/bash/install_yac.sh
@@ -18,8 +18,8 @@
 
 root4YAC=$1 # absolute path for YAC and YAXT installations
 
-yaxt_source=https://swprojects.dkrz.de/redmine/attachments/download/529/yaxt-0.10.0.tar.gz
-yaxt_version=yaxt-0.10.0 # must match yaxt_source
+yaxt_source=https://swprojects.dkrz.de/redmine/attachments/download/534/yaxt-0.11.1.tar.gz
+yaxt_version=yaxt-0.11.1 # must match yaxt_source
 
 yac_source=https://gitlab.dkrz.de/dkrz-sw/yac/-/archive/v3.2.0_a_p2/yac-v3.2.0_a_p2.tar.gz
 yac_version=yac-v3.2.0_a_p2 # must match yac_source


### PR DESCRIPTION
- update yac and yaxt versions in CI
- update yac and yaxt versions installed by helper installation bash script
- fix to use correct mpicc and mpif90 compilers when building and compiling yac and yaxt in helper installation bash script
- added compiler flags to yaxt installation in helper installation bash script