### PR TITLE
Changed YAC couplings to work with the ICON bubble test data

### DIFF
--- a/examples/yac/yac_3d/yac_icon_data_reader.py
+++ b/examples/yac/yac_3d/yac_icon_data_reader.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+from yac import YAC, UnstructuredGrid, Field, Location, Calendar, TimeUnit, def_calendar
+from netCDF4 import Dataset
+import numpy as np
+
+
+def map_vertices(array):
+    vertex_dict = {}
+    vertex_mapping = 0
+    vertex_mapping_array = []
+
+    for element in array:
+        element_tuple = tuple(
+            element
+        )  # Convert the array to a tuple to make it hashable
+        if element_tuple not in vertex_dict:
+            vertex_dict[element_tuple] = vertex_mapping
+            vertex_mapping += 1
+        vertex_mapping_array.append(vertex_dict[element_tuple])
+
+    return vertex_mapping_array
+
+
+def create_yac_unstructured_grid(grid_filname):
+    # Open the NetCDF file
+    dataset = Dataset(grid_filname, "r")
+
+    # Read the variables
+    nv = dataset.dimensions["vertices"].size
+    no_cells = dataset.dimensions["ncells"].size
+
+    vertices = []
+    for cell in range(len(dataset["clon_bnds"])):
+        for vertex in range(3):
+            vertices.append(
+                [dataset["clon_bnds"][cell][vertex], dataset["clat_bnds"][cell][vertex]]
+            )
+
+    cell_vertex_indices = map_vertices(vertices)
+
+    grid_name = "bubble_grid"
+    grid = UnstructuredGrid(
+        grid_name,
+        np.ones(no_cells) * nv,
+        dataset["clon_bnds"][:, :].flatten(),
+        dataset["clat_bnds"][:, :].flatten(),
+        cell_vertex_indices,
+    )
+
+    cell_points = grid.def_points(Location.CELL, dataset["clon"][:], dataset["clat"][:])
+    grid.cell_points = cell_points
+
+    return grid
+
+
+data_filename = "aes_bubble_atm_3d_ml_20080801T000000Z.nc"
+grid_filename = "aes_bubble_atm_cgrid_ml.nc"
+
+yac = YAC()
+
+component_name = "icon_data_reader"
+component = yac.def_comp(component_name)
+
+def_calendar(Calendar.PROLEPTIC_GREGORIAN)
+grid = create_yac_unstructured_grid(grid_filename)
+
+# --- Field definitions ---
+press = Field.create(
+    "pressure", component, grid.cell_points, 1, "PT1M", TimeUnit.ISO_FORMAT
+)
+temp = Field.create(
+    "temperature", component, grid.cell_points, 1, "PT1M", TimeUnit.ISO_FORMAT
+)
+qvap = Field.create("qvap", component, grid.cell_points, 1, "PT1M", TimeUnit.ISO_FORMAT)
+qcond = Field.create(
+    "qcond", component, grid.cell_points, 1, "PT1M", TimeUnit.ISO_FORMAT
+)
+eastward_wind = Field.create(
+    "eastward_wind", component, grid.cell_points, 1, "PT1M", TimeUnit.ISO_FORMAT
+)
+northward_wind = Field.create(
+    "northward_wind", component, grid.cell_points, 1, "PT1M", TimeUnit.ISO_FORMAT
+)
+vvel = Field.create("vvel", component, grid.cell_points, 1, "PT1M", TimeUnit.ISO_FORMAT)
+
+yac.enddef()
+
+dataset = Dataset(data_filename)
+
+for step in range(5):
+    print("ICON data reader started sending step", step)
+    vvel.put(dataset["wa"][step, 0, :])
+    for height in range(3):
+        temp.put(dataset["ta"][step, height, :])
+        press.put(dataset["pfull"][step, height, :])
+        qvap.put(dataset["hus"][step, height, :])
+        qcond.put(dataset["clw"][step, height, :])
+        eastward_wind.put(dataset["ua"][step, height, :])
+        northward_wind.put(dataset["va"][step, height, :])
+        vvel.put(dataset["wa"][step, height + 1, :])
+    print("ICON data reader finished sending step", step)

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
@@ -332,29 +332,35 @@ CartesianDynamics::CartesianDynamics(const Config &config, const std::array<size
 
   // --- Field definitions ---
   int num_point_sets = 1;
-  int collection_size = 1;
+  int horizontal_fields_collection_size = ndims[2];
+  int vertical_winds_collection_size = ndims[2] + 1;
 
-  yac_cdef_field("pressure", component_id, &cell_point_id, num_point_sets, collection_size, "PT1M",
+  yac_cdef_field("pressure", component_id, &cell_point_id,
+                 num_point_sets, horizontal_fields_collection_size, "PT1M",
                  YAC_TIME_UNIT_ISO_FORMAT, &pressure_yac_id);
 
-  yac_cdef_field("temperature", component_id, &cell_point_id, num_point_sets, collection_size,
-                 "PT1M", YAC_TIME_UNIT_ISO_FORMAT, &temp_yac_id);
+  yac_cdef_field("temperature", component_id, &cell_point_id,
+                 num_point_sets, horizontal_fields_collection_size, "PT1M",
+                 YAC_TIME_UNIT_ISO_FORMAT, &temp_yac_id);
 
-  yac_cdef_field("qvap", component_id, &cell_point_id, num_point_sets, collection_size, "PT1M",
+  yac_cdef_field("qvap", component_id, &cell_point_id,
+                 num_point_sets, horizontal_fields_collection_size, "PT1M",
                  YAC_TIME_UNIT_ISO_FORMAT, &qvap_yac_id);
 
-  yac_cdef_field("qcond", component_id, &cell_point_id, num_point_sets, collection_size, "PT1M",
+  yac_cdef_field("qcond", component_id, &cell_point_id,
+                 num_point_sets, horizontal_fields_collection_size, "PT1M",
                  YAC_TIME_UNIT_ISO_FORMAT, &qcond_yac_id);
 
   yac_cdef_field("eastward_wind", component_id, &edge_point_id,
-                 num_point_sets, collection_size, "PT1M",
+                 num_point_sets, horizontal_fields_collection_size, "PT1M",
                  YAC_TIME_UNIT_ISO_FORMAT, &eastward_wind_yac_id);
 
   yac_cdef_field("northward_wind", component_id, &edge_point_id,
-                 num_point_sets, collection_size, "PT1M",
+                 num_point_sets, horizontal_fields_collection_size, "PT1M",
                  YAC_TIME_UNIT_ISO_FORMAT, &northward_wind_yac_id);
 
-  yac_cdef_field("vvel", component_id, &cell_point_id, num_point_sets, collection_size, "PT1M",
+  yac_cdef_field("vvel", component_id, &cell_point_id,
+                 num_point_sets, vertical_winds_collection_size, "PT1M",
                  YAC_TIME_UNIT_ISO_FORMAT, &vvel_yac_id);
 
   // --- Field coupling definitions ---
@@ -400,7 +406,7 @@ CartesianDynamics::CartesianDynamics(const Config &config, const std::array<size
   wvel_edge_data = std::vector<double>(horizontal_edge_number, 0);
 
   // Calls the first data retrieval from YAC to have thermodynamic data for first timestep
-  receive_fields_from_yac();
+  receive_field_collections_from_yac();
 
   std::cout << "Finished setting up YAC for receiving:\n"
                "  pressure,\n  temperature,\n"

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
@@ -76,6 +76,11 @@ struct CartesianDynamics {
   int northward_wind_yac_id;
   int vvel_yac_id;
 
+  // Containers to receive data from YAC
+  double ** yac_raw_cell_data;
+  double ** yac_raw_edge_data;
+  double ** yac_raw_vertical_wind_data;
+
   /* --- Private functions --- */
 
   /* depending on nspacedims, read in data

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
@@ -56,7 +56,8 @@ struct CartesianDynamics {
   std::vector<double> press, temp, qvap, qcond;
 
   // Container for all edge-centered data (as in data in each edge center)
-  std::vector<double> united_edge_data;
+  std::vector<double> uvel_edge_data;
+  std::vector<double> wvel_edge_data;
 
   // Target for lon and lat edge data respectively
   // (these are copied from united_edge_data after receiving from YAC)
@@ -71,7 +72,8 @@ struct CartesianDynamics {
   int temp_yac_id;
   int qvap_yac_id;
   int qcond_yac_id;
-  int hor_wind_velocities_yac_id;
+  int eastward_wind_yac_id;
+  int northward_wind_yac_id;
   int vvel_yac_id;
 
   /* --- Private functions --- */

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
@@ -123,6 +123,10 @@ struct CartesianDynamics {
   /* Public call to receive data from YAC
    * If the problem is 2D turns into a wrapper for receive_hor_slice_from_yac */
   void receive_fields_from_yac();
+  void receive_field_collections_from_yac();
+  void receive_yac_field(unsigned int field_type, unsigned int yac_field_id,
+                         double ** yac_raw_data, std::vector<double> & target_array,
+                         size_t vertical_levels);
 };
 
 /* type satisfying CoupledDyanmics solver concept

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
@@ -55,10 +55,6 @@ struct CartesianDynamics {
   // Containers for cell-centered fields
   std::vector<double> press, temp, qvap, qcond;
 
-  // Container for all edge-centered data (as in data in each edge center)
-  std::vector<double> uvel_edge_data;
-  std::vector<double> wvel_edge_data;
-
   // Target for lon and lat edge data respectively
   // (these are copied from united_edge_data after receiving from YAC)
   std::vector<double> uvel, wvel;

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
@@ -139,7 +139,9 @@ struct YacDynamics {
   std::shared_ptr<CartesianDynamics> dynvars;  // pointer to (thermo)dynamic variables
 
   /* Calls the get operations to receive data from YAC for each of the fields of interest */
-  void run_dynamics(const unsigned int t_mdl) const { dynvars->receive_fields_from_yac(); }
+  void run_dynamics(const unsigned int t_mdl) const {
+    dynvars->receive_field_collections_from_yac();
+  }
 
  public:
   YacDynamics(const Config &config, const unsigned int couplstep, const std::array<size_t, 3> ndims,


### PR DESCRIPTION
Adds support to read data from the bubble test of ICON through YAC. Now receives all vertical levels for each variable with one YAC call, using field collections.