### PR TITLE
Separate examples for Shima et al. 2009 and other collision box models

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,8 +30,8 @@ Time to get involved! Start by :doc:`installing CLEO<usage/installation>` and ex
    :caption: Contents:
 
    intro/intro
-   usage/requirements
    usage/extern
+   usage/requirements
    usage/installation
    usage/examples
    usage/quickstart

--- a/docs/source/usage/examples.rst
+++ b/docs/source/usage/examples.rst
@@ -111,13 +111,49 @@ to the third column of figure 5 from Arabas and Shima 2017 :cite:`arabasshima201
 
 Box Model Collisions
 --------------------
-These examples are for a 0-D box model with various collision-coalescence kernels.
+These examples are for a 0-D box model with various collision kernels. The setup mimics that in
+Shima et al. 2009 section 5.1.4 :cite:`shima2009`. Note that due to the randomness of the initial
+super-droplet conditions and the collision algorithm, each run of these examples will not be
+completely identical, but they should be reasonably similar, and have the same mean behaviour.
+
+The Collision Kernels
+#####################
+
+**Golovin**
+
+This example models collision-coalescence using Golovin's kernel.
+
+The plot produced, by default called ``~/CLEO/build_colls0D/bin/golovin_validation.png``, should be similar to
+Fig.2(a) of Shima et al. 2009 :cite:p:`shima2009`.
+
+**Long**
+
+This example models collision-coalescence using Long's collision efficiency as given by equation
+13 of Simmel et al. 2002 :cite:`simmel2002`.
+
+The plot produced, by default called ``~/CLEO/build_colls0D/bin/long_validation.png``, should be similar to
+Fig.2(b) of Shima et al. 2009 :cite:p:`shima2009`.
+
+**Low and List**
+
+This example models collision-coalescence using the hydrodynamic kernel with Long's collision
+efficiency as given by equation 13 of Simmel et al. 2002 :cite:`simmel2002`, and the coalescence
+efficiency from Low and List 1982(a) :cite:`lowlist1982a` (see also McFarquhar
+2004 :cite:`mcfarquhar2004`).
+
+This example produces a plot, by default called ``~/CLEO/build_colls0D/bin/lowlist_validation.png``.
+
+Running the Box Model Collisions Examples
+##########################################
 
 1. Navigate to the ``boxmodelcollisions/`` directory, e.g.
 
 .. code-block:: console
 
   $ cd ~/CLEO/examples/boxmodelcollisions/
+
+a) Shima et al. 2009
+####################
 
 2. :ref:`Configure the bash scripts<configurebash>`, ``examples/run_example.sh`` and
 ``examples/boxmodelcollisions/shima2009.sh``.
@@ -128,37 +164,40 @@ These examples are for a 0-D box model with various collision-coalescence kernel
 
   $ ./shima2009.sh
 
-By default the golovin, long, and lowlist executables will be compiled and run. You can change this
-by editing ``script_args="[...] golovin long lowlist`` in ``shima2009.sh``.
+By default the golovin exectuable and two examples using the long executable will be compiled and
+run. You can change this by editing ``script_args="[...] golovin long1 long2`` in ``shima2009.sh``.
 
-Note that due to the randomness of the initial super-droplet conditions and the
-collision-coalescence algorithm, each run of these examples will not be completely identical, but
-they should be reasonably similar, and have the same mean behaviour.
+**Golovin**
 
-a) Golovin
-##########
 This example models collision-coalescence using Golovin's kernel.
 
-The plot produced, by default called ``~/CLEO/build_shima2009/bin/golovin_validation.png``, should be similar to
-Fig.2(a) of Shima et al. 2009 :cite:p:`shima2009`.
+The plot produced, by default called ``~/CLEO/build_colls0D/bin/golovin_validation.png``, should be
+comparable to Fig.2(a) of Shima et al. 2009 :cite:p:`shima2009`.
 
-b) Long
-#######
-This example models collision-coalescence using Long's collision efficiency as given by equation
-13 of Simmel et al. 2002 :cite:`simmel2002`.
+**Long1 and Long2**
 
-The plot produced, by default called ``~/CLEO/build_shima2009/bin/long_validation.png``, should be similar to
-Fig.2(b) of Shima et al. 2009 :cite:p:`shima2009`.
+These examples model collision-coalescence using Long's collision efficiency as given by equation
+13 of Simmel et al. 2002 :cite:`simmel2002`. The two examples use different initial conditions and
+collision timesteps, as in Shima et al. 2009 :cite:p:`shima2009`.
 
-c) Low and List
-###############
-This example models collision-coalescence using the hydrodynamic kernel with Long's collision
-efficiency as given by equation 13 of Simmel et al. 2002 :cite:`simmel2002`, and the coalescence
-efficiency from Low and List 1982(a) :cite:`lowlist1982a` (see also McFarquhar
-2004 :cite:`mcfarquhar2004`).
+The plots produced, by default called ``~/CLEO/build_colls0D/bin/long_validation_1.png`` and
+``~/CLEO/build_colls0D/bin/long_validation_2.png``, should be comparable to
+Fig.2(b) and Fig.2(c) of Shima et al. 2009 :cite:p:`shima2009`.
 
-This example produces a plot, by default called ``~/CLEO/build_shima2009/bin/lowlist_validation.png``.
+b) Breakup
+##########
 
+2. :ref:`Configure the bash scripts<configurebash>`, ``examples/run_example.sh`` and
+``examples/boxmodelcollisions/breakup.sh``.
+
+3. Execute the bash script ``breakup.sh``, e.g.
+
+.. code-block:: console
+
+  $ ./breakup.sh
+
+By default kernels including collision-coalescence, breakup and rebound will be compiled and
+run. You can change this by editing ``script_args="[...] lowlist etc.`` in ``breakup.sh``.
 
 Divergence Free Motion
 ----------------------

--- a/docs/source/usage/examples.rst
+++ b/docs/source/usage/examples.rst
@@ -131,8 +131,8 @@ Fig.2(a) of Shima et al. 2009 :cite:p:`shima2009`.
 This example models collision-coalescence using Long's collision efficiency as given by equation
 13 of Simmel et al. 2002 :cite:`simmel2002`.
 
-The plot produced, by default called ``~/CLEO/build_colls0D/bin/long_validation.png``, should be similar to
-Fig.2(b) of Shima et al. 2009 :cite:p:`shima2009`.
+The plot produced, by default called ``~/CLEO/build_colls0D/bin/long_validation_[X].png``, should be
+similar to Fig.2(b) of Shima et al. 2009 :cite:p:`shima2009`.
 
 **Low and List**
 
@@ -178,7 +178,8 @@ comparable to Fig.2(a) of Shima et al. 2009 :cite:p:`shima2009`.
 
 These examples model collision-coalescence using Long's collision efficiency as given by equation
 13 of Simmel et al. 2002 :cite:`simmel2002`. The two examples use different initial conditions and
-collision timesteps, as in Shima et al. 2009 :cite:p:`shima2009`.
+collision timesteps, as in Shima et al. 2009 :cite:p:`shima2009`. However the setup of the long2
+example is not exactly that which makes Fig.2(c) in Shima et al. 2009.
 
 The plots produced, by default called ``~/CLEO/build_colls0D/bin/long_validation_1.png`` and
 ``~/CLEO/build_colls0D/bin/long_validation_2.png``, should be comparable to

--- a/docs/source/usage/extern.rst
+++ b/docs/source/usage/extern.rst
@@ -11,8 +11,6 @@ how we use Kokkos on :doc:`our page about Kokkos<../intro/kokkos>`.
 
 The Kokkos libaries for CLEO are automatically built using CMAKE and compiled if required.
 
-.. _extern_yac:
-
 YAC
 ---
 YAC is required if CLEO couples to dynamics using YAC and/or uses MPI domain decompoisiton. You can

--- a/docs/source/usage/requirements.rst
+++ b/docs/source/usage/requirements.rst
@@ -67,7 +67,8 @@ YAC is one of the :doc:`external libraries<extern>` which CLEO may require in or
 couple to dynamics and/or have MPI domain decomposition.
 
 Note that YAC (and its YAXT dependency) need to be installed manually before you can build
-CLEO with them. You can find instructions on how to do install YAC (and YAXT) :ref:`here <_extern_yac>`.
+CLEO with them. You can find instructions on how to do install YAC (and YAXT) in the
+external libraries section.
 
 YAC also requires some additional MPI, NetCDF and yaml libraries alongside the compatible gcc
 compiler which you can load on Levante via:

--- a/examples/boxmodelcollisions/attrgens_shima2009.py
+++ b/examples/boxmodelcollisions/attrgens_shima2009.py
@@ -1,0 +1,61 @@
+"""
+Copyright (c) 2024 MPI-M, Clara Bayley
+
+
+----- CLEO -----
+File: attrgens_shima2009.py
+Project: boxmodelcollisions
+Created Date: Saturday 15th June 2024
+Author: Clara Bayley (CB)
+Additional Contributors:
+-----
+Last Modified: Saturday 15th June 2024
+Modified By: CB
+-----
+License: BSD 3-Clause "New" or "Revised" License
+https://opensource.org/licenses/BSD-3-Clause
+-----
+File Description:
+Radius and xi generators as in Shima et al. 2009
+"""
+
+import numpy as np
+
+
+class SampleRadiiShima2009:
+    """method to generate superdroplet radii by sampling between rspan[0] and rspan[1]
+    with probability weighted by volume exponential probability distribution, as in
+    Shima et al. 2009"""
+
+    def __init__(self, radius0, rspan):
+        self.rspan = rspan  # [min, max] radii to sample between [m]
+        self.vol0 = (
+            4.0 / 3.0 * np.pi * radius0**3
+        )  # peak of volume exponential distribution [m^3]
+
+    def __call__(self, nsupers):
+        """Returns radii for nsupers sampled from rspan [m]"""
+
+        return self.generate_radiisample(nsupers)  # units [m]
+
+    def generate_radiisample(self, nbins):
+        """Sample from rspan[0] to rspan[1] with probability of radius[m] given by
+        exponential distirubiton in volume"""
+
+        if nbins:
+            vols = np.random.exponential(scale=self.vol0, size=nbins)  # [m^3]
+            radii = np.power(3.0 / (4.0 * np.pi) * vols, 1.0 / 3.0)
+            return radii  # [m]
+        else:
+            return np.array([])
+
+
+class SampleXiShima2009:
+    """probability of radius given by
+    Shima et al. (2009) is equal for all radii"""
+
+    def __call__(self, radii):
+        """Returns probability of each radius in radii according to uniform
+        distribution as in Shima et al. 2009"""
+
+        return np.full(radii.shape, 1 / len(radii))

--- a/examples/boxmodelcollisions/attrgens_shima2009.py
+++ b/examples/boxmodelcollisions/attrgens_shima2009.py
@@ -43,11 +43,26 @@ class SampleRadiiShima2009:
         exponential distirubiton in volume"""
 
         if nbins:
-            vols = np.random.exponential(scale=self.vol0, size=nbins)  # [m^3]
-            radii = np.power(3.0 / (4.0 * np.pi) * vols, 1.0 / 3.0)
+            radii = self.sample_truncated_volume_exponential(nbins)
+            print(len(radii))
             return radii  # [m]
         else:
             return np.array([])
+
+    def sample_truncated_volume_exponential(self, nbins):
+        """sample volume exponential rejecting samples which result
+        in radii outside rspan[0] <= r <= rspan[1] until nbins number of sample
+        radii are found"""
+        radii_sample = []
+        while len(radii_sample) < nbins:
+            n = nbins - len(radii_sample)
+            vols = np.random.exponential(self.vol0, n)  # [m^3]
+            radii = np.power(3.0 / (4.0 * np.pi) * vols, 1.0 / 3.0)
+            in_range = np.where(radii >= self.rspan[0], radii, 0)
+            in_range = np.where(radii <= self.rspan[1], in_range, 0)
+            radii_sample.extend(in_range[in_range > 0])
+
+        return np.array(radii_sample)[:nbins]
 
 
 class SampleXiShima2009:

--- a/examples/boxmodelcollisions/breakup.py
+++ b/examples/boxmodelcollisions/breakup.py
@@ -3,9 +3,9 @@ Copyright (c) 2024 MPI-M, Clara Bayley
 
 
 ----- CLEO -----
-File: shima2009.py
+File: breakup.py
 Project: boxmodelcollisions
-Created Date: Friday 17th November 2023
+Created Date: Friday 14th June 2024
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
@@ -17,8 +17,8 @@ https://opensource.org/licenses/BSD-3-Clause
 -----
 File Description:
 Script generates input files, runs CLEO 0-D box model executables for
-collisions with selected collision kernels (e.g. Golovin's or Long's) to create data.
-Then plots results comparable to Shima et al. 2009 Fig. 2
+collisions with selected collision kernels with breakup (e.g.Low and Lists's)
+to create data. Then plots results analgous to Shima et al. 2009 Fig. 2(b)
 """
 
 import os
@@ -38,7 +38,6 @@ sys.path.append(
 )  # for imports from example plotting package
 
 from plotssrc import shima2009fig
-from pySD import editconfigfile
 from pySD.sdmout_src import pyzarr, pysetuptxt, pygbxsdat
 from pySD.initsuperdropsbinary_src import rgens, probdists, attrsgen
 from pySD.initsuperdropsbinary_src import create_initsuperdrops as csupers
@@ -54,13 +53,12 @@ from pySD.gbxboundariesbinary_src import create_gbxboundaries as cgrid
 constsfile = path2CLEO + "/libs/cleoconstants.hpp"
 binpath = path2build + "/bin/"
 sharepath = path2build + "/share/"
-initSDsfile_1 = sharepath + "shima2009_dimlessSDsinit_1.dat"
-initSDsfile_2 = sharepath + "shima2009_dimlessSDsinit_2.dat"
-gridfile = sharepath + "shima2009_dimlessGBxboundaries.dat"
+initSDsfile = sharepath + "breakup_dimlessSDsinit.dat"
+gridfile = sharepath + "breakup_dimlessGBxboundaries.dat"
 
 # path and file names for plotting results
-setupfile = binpath + "shima2009_setup.txt"
-dataset = binpath + "shima2009_sol.zarr"
+setupfile = binpath + "breakup_setup.txt"
+dataset = binpath + "breakup_sol.zarr"
 
 # booleans for [making, saving] initialisation figures
 isfigures = [True, True]
@@ -83,22 +81,13 @@ coord1gen = None
 coord2gen = None
 
 # radius distirbution from exponential in droplet volume for setup 1
-rspan_1 = [1e-7, 9e-5]  # max and min range of radii to sample [m]
-volexpr0_1 = 30.531e-6  # peak of volume exponential distribution [m]
-numconc_1 = 2 ** (23)  # total no. conc of real droplets [m^-3]
-params_1 = {"COLLTSTEP": 1, "initsupers_filename": initSDsfile_1}
-
-# radius distirbution from exponential in droplet volume for setup 2
-rspan_2 = [1e-7, 2.5e-5]  # max and min range of radii to sample [m]
-volexpr0_2 = 10.117e-6  # peak of volume exponential distribution [m]
-numconc_2 = 27 * 2 ** (23)  # total no. conc of real droplets [m^-3]
-params_2 = {"COLLTSTEP": 0.1, "initsupers_filename": initSDsfile_2}
+rspan = [1e-7, 9e-5]  # max and min range of radii to sample [m]
+volexpr0 = 30.531e-6  # peak of volume exponential distribution [m]
+numconc = 2 ** (23)  # total no. conc of real droplets [m^-3]
 
 # attribute generators
-xiprobdist_1 = probdists.VolExponential(volexpr0_1, rspan_1)
-radiigen_1 = rgens.SampleLog10RadiiGen(rspan_1)  # radii are sampled from rspan [m]
-xiprobdist_2 = probdists.VolExponential(volexpr0_2, rspan_2)
-radiigen_2 = rgens.SampleLog10RadiiGen(rspan_2)  # radii are sampled from rspan [m]
+xiprobdist = probdists.VolExponential(volexpr0, rspan)
+radiigen = rgens.SampleLog10RadiiGen(rspan)  # radii are sampled from rspan [m]
 samplevol = rgrid.calc_domainvol(zgrid, xgrid, ygrid)
 dryradiigen = rgens.MonoAttrGen(dryradius)
 
@@ -120,51 +109,34 @@ else:
 
 ### --- delete any existing initial conditions --- ###
 os.system("rm " + gridfile)
-os.system("rm " + initSDsfile_1)
-os.system("rm " + initSDsfile_2)
+os.system("rm " + initSDsfile)
 
 ### ----- write gridbox boundaries binary ----- ###
 cgrid.write_gridboxboundaries_binary(gridfile, zgrid, xgrid, ygrid, constsfile)
 rgrid.print_domain_info(constsfile, gridfile)
+
+### ----- write initial superdroplets binary ----- ###
+initattrsgen = attrsgen.AttrsGenerator(
+    radiigen, dryradiigen, xiprobdist, coord3gen, coord1gen, coord2gen
+)
+csupers.write_initsuperdrops_binary(
+    initSDsfile, initattrsgen, configfile, constsfile, gridfile, nsupers, numconc
+)
+rsupers.print_initSDs_infos(initSDsfile, configfile, constsfile, gridfile)
+
 ### show (and save) plots of binary file data
 if isfigures[0]:
     rgrid.plot_gridboxboundaries(constsfile, gridfile, savefigpath, isfigures[1])
+    rsupers.plot_initGBxs_distribs(
+        configfile,
+        constsfile,
+        initSDsfile,
+        gridfile,
+        savefigpath,
+        isfigures[1],
+        "all",
+    )
     plt.close()
-
-
-### ----- write initial superdroplets binary ----- ###
-def initial_conditions_for_setup(initSDsfile, radiigen, xiprobdist, numconc, savelabel):
-    initattrsgen = attrsgen.AttrsGenerator(
-        radiigen, dryradiigen, xiprobdist, coord3gen, coord1gen, coord2gen
-    )
-    csupers.write_initsuperdrops_binary(
-        initSDsfile, initattrsgen, configfile, constsfile, gridfile, nsupers, numconc
-    )
-    rsupers.print_initSDs_infos(initSDsfile, configfile, constsfile, gridfile)
-
-    ### show (and save) plots of binary file data
-    if isfigures[0]:
-        rsupers.plot_initGBxs_distribs(
-            configfile,
-            constsfile,
-            initSDsfile,
-            gridfile,
-            savefigpath,
-            isfigures[1],
-            "all",
-            savelabel=savelabel,
-        )
-        plt.close()
-
-
-if "golovin" in kernels or "long1" in kernels:
-    initial_conditions_for_setup(
-        initSDsfile_1, radiigen_1, xiprobdist_1, numconc_1, "_1"
-    )
-if "long2" in kernels:
-    initial_conditions_for_setup(
-        initSDsfile_2, radiigen_2, xiprobdist_2, numconc_2, "_2"
-    )
 ### ---------------------------------------------------------------- ###
 ### ---------------------------------------------------------------- ###
 
@@ -223,12 +195,11 @@ def plot_results(
     )
 
 
-if "golovin" in kernels:
+if "lowlist" in kernels:
     ### ------------------------------------------------------------ ###
     ### -------------------- RUN CLEO EXECUTABLE ------------------- ###
     ### ------------------------------------------------------------ ###
-    editconfigfile.edit_config_params(configfile, params_1)
-    executable = path2build + "/examples/boxmodelcollisions/golovin/src/golcolls"
+    executable = path2build + "/examples/boxmodelcollisions/lowlist/src/lowlistcolls"
     run_exectuable(path2build, dataset, executable, configfile)
     ### ------------------------------------------------------------ ###
     ### ------------------------------------------------------------ ###
@@ -236,88 +207,18 @@ if "golovin" in kernels:
     ### ------------------------------------------------------------ ###
     ### ----------------------- PLOT RESULTS ----------------------- ###
     ### ------------------------------------------------------------ ###
-    t2plts = [0, 1200, 2400, 3600]
-    smoothsigconst = 0.62
-    xlims = [10, 5000]
-    plotwitherr = True
-    withgol = True
-    savename = "golovin_validation.png"
-    plot_results(
-        gridfile,
-        setupfile,
-        dataset,
-        numconc_1,
-        volexpr0_1,
-        t2plts,
-        smoothsigconst,
-        xlims,
-        plotwitherr,
-        withgol,
-        savename,
-    )
-    ### ------------------------------------------------------------ ###
-    ### ------------------------------------------------------------ ###
-
-if "long1" in kernels:
-    ### ------------------------------------------------------------ ###
-    ### -------------------- RUN CLEO EXECUTABLE ------------------- ###
-    ### ------------------------------------------------------------ ###
-    editconfigfile.edit_config_params(configfile, params_1)
-    executable = path2build + "/examples/boxmodelcollisions/long/src/longcolls"
-    run_exectuable(path2build, dataset, executable, configfile)
-    ### ------------------------------------------------------------ ###
-    ### ------------------------------------------------------------ ###
-
-    ### ------------------------------------------------------------ ###
-    ### ----------------------- PLOT RESULTS ----------------------- ###
-    ### ------------------------------------------------------------ ###
-    t2plts = [0, 600, 1200, 1800]
+    t2plts = [0, 600, 1200, 1800, 2400, 3600]
     smoothsigconst = 0.62
     xlims = [10, 5000]
     plotwitherr = False
     withgol = False
-    savename = "long_validation_1.png"
+    savename = "lowlist_validation.png"
     plot_results(
         gridfile,
         setupfile,
         dataset,
-        numconc_1,
-        volexpr0_1,
-        t2plts,
-        smoothsigconst,
-        xlims,
-        plotwitherr,
-        withgol,
-        savename,
-    )
-    ### ------------------------------------------------------------ ###
-    ### ------------------------------------------------------------ ###
-
-if "long2" in kernels:
-    ### ------------------------------------------------------------ ###
-    ### -------------------- RUN CLEO EXECUTABLE ------------------- ###
-    ### ------------------------------------------------------------ ###
-    editconfigfile.edit_config_params(configfile, params_2)
-    executable = path2build + "/examples/boxmodelcollisions/long/src/longcolls"
-    run_exectuable(path2build, dataset, executable, configfile)
-    ### ------------------------------------------------------------ ###
-    ### ------------------------------------------------------------ ###
-
-    ### ------------------------------------------------------------ ###
-    ### ----------------------- PLOT RESULTS ----------------------- ###
-    ### ------------------------------------------------------------ ###
-    t2plts = [0, 1200, 2400, 3600]
-    smoothsigconst = 1.5
-    xlims = [1, 5000]
-    plotwitherr = False
-    withgol = False
-    savename = "long_validation_2.png"
-    plot_results(
-        gridfile,
-        setupfile,
-        dataset,
-        numconc_2,
-        volexpr0_2,
+        numconc,
+        volexpr0,
         t2plts,
         smoothsigconst,
         xlims,

--- a/examples/boxmodelcollisions/breakup.sh
+++ b/examples/boxmodelcollisions/breakup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=shima2009
+#SBATCH --job-name=breakup
 #SBATCH --partition=gpu
 #SBATCH --nodes=1
 #SBATCH --gpus=4
@@ -9,8 +9,8 @@
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
 #SBATCH --account=mh1126
-#SBATCH --output=./shima2009_out.%j.out
-#SBATCH --error=./shima2009_err.%j.out
+#SBATCH --output=./breakup_out.%j.out
+#SBATCH --error=./breakup_err.%j.out
 
 ### ---------------------------------------------------- ###
 ### ------------------ Input Parameters ---------------- ###
@@ -22,11 +22,11 @@ buildtype="cuda"
 path2CLEO=${HOME}/CLEO/
 path2build=${HOME}/CLEO/build_colls0D/
 enableyac=false
-executables="golcolls longcolls"
+executables="lowlistcolls"
 
-pythonscript=${path2CLEO}/examples/boxmodelcollisions/shima2009.py
-configfile=${path2CLEO}/examples/boxmodelcollisions/shima2009_config.yaml
-script_args="${configfile} golovin long1 long2"
+pythonscript=${path2CLEO}/examples/boxmodelcollisions/breakup.py
+configfile=${path2CLEO}/examples/boxmodelcollisions/breakup_config.yaml
+script_args="${configfile} lowlist"
 ### ---------------------------------------------------- ###
 ### ---------------------------------------------------- ###
 ### ---------------------------------------------------- ###

--- a/examples/boxmodelcollisions/breakup_config.yaml
+++ b/examples/boxmodelcollisions/breakup_config.yaml
@@ -1,7 +1,7 @@
 # ----- CLEO -----
-# File: shima2009_config.yaml
+# File: breakup_config.yaml
 # Project: config
-# Created Date: Wednesday 17th April 2024
+# Created Date: Friday 14th June 2024
 # Author: Clara Bayley (CB)
 # Additional Contributors:
 # -----
@@ -29,7 +29,7 @@ domain:
 
 timesteps:
   CONDTSTEP: 200                                                # time between SD condensation [s]
-  COLLTSTEP: 0.1                                                # time between SD collision [s]
+  COLLTSTEP: 1                                                  # time between SD collision [s]
   MOTIONTSTEP: 200                                              # time between SDM motion [s]
   COUPLTSTEP: 2000                                              # time between dynamic couplings [s]
   OBSTSTEP: 200                                                 # time between SDM observations [s]
@@ -38,15 +38,15 @@ timesteps:
 ### Initialisation Parameters ###
 inputfiles:
   constants_filename: ../libs/cleoconstants.hpp                 # name of file for values of physical constants
-  grid_filename: ./share/shima2009_dimlessGBxboundaries.dat     # binary filename for initialisation of GBxs / GbxMaps
+  grid_filename: ./share/breakup_dimlessGBxboundaries.dat       # binary filename for initialisation of GBxs / GbxMaps
 
 initsupers:
   type: frombinary                                              # type of initialisation of super-droplets
-  initsupers_filename: /home/m/m300950/CLEO/build_colls0D//share/shima2009_dimlessSDsinit_2.dat # binary filename for initialisation of SDs
+  initsupers_filename: ./share/breakup_dimlessSDsinit.dat       # binary filename for initialisation of SDs
 
 ### Output Parameters ###
 outputdata:
-  setup_filename: ./bin/shima2009_setup.txt                     # .txt filename to copy configuration to
-  stats_filename: ./bin/shima2009_stats.txt                     # .txt file to output runtime statistics to
-  zarrbasedir: ./bin/shima2009_sol.zarr                         # zarr store base directory
+  setup_filename: ./bin/breakup_setup.txt                     # .txt filename to copy configuration to
+  stats_filename: ./bin/breakup_stats.txt                     # .txt file to output runtime statistics to
+  zarrbasedir: ./bin/breakup_sol.zarr                         # zarr store base directory
   maxchunk: 2500000                                             # maximum no. of elements in chunks of zarr store array

--- a/examples/boxmodelcollisions/shima2009.py
+++ b/examples/boxmodelcollisions/shima2009.py
@@ -37,10 +37,11 @@ sys.path.append(
     path2CLEO + "/examples/exampleplotting/"
 )  # for imports from example plotting package
 
+import attrgens_shima2009
 from plotssrc import shima2009fig
 from pySD import editconfigfile
 from pySD.sdmout_src import pyzarr, pysetuptxt, pygbxsdat
-from pySD.initsuperdropsbinary_src import rgens, probdists, attrsgen
+from pySD.initsuperdropsbinary_src import rgens, attrsgen
 from pySD.initsuperdropsbinary_src import create_initsuperdrops as csupers
 from pySD.initsuperdropsbinary_src import read_initsuperdrops as rsupers
 from pySD.gbxboundariesbinary_src import read_gbxboundaries as rgrid
@@ -83,22 +84,26 @@ coord1gen = None
 coord2gen = None
 
 # radius distirbution from exponential in droplet volume for setup 1
-rspan_1 = [1e-7, 9e-5]  # max and min range of radii to sample [m]
+rspan_1 = [0.62e-6, 6.34e-2]  # max and min range of radii to sample [m]
 volexpr0_1 = 30.531e-6  # peak of volume exponential distribution [m]
-numconc_1 = 2 ** (23)  # total no. conc of real droplets [m^-3]
+numconc_1 = 2**23  # total no. conc of real droplets [m^-3]
 params_1 = {"COLLTSTEP": 1, "initsupers_filename": initSDsfile_1}
 
 # radius distirbution from exponential in droplet volume for setup 2
-rspan_2 = [1e-7, 2.5e-5]  # max and min range of radii to sample [m]
+rspan_2 = [0.62e-6, 6.34e-2]  # max and min range of radii to sample [m]
 volexpr0_2 = 10.117e-6  # peak of volume exponential distribution [m]
-numconc_2 = 27 * 2 ** (23)  # total no. conc of real droplets [m^-3]
+numconc_2 = 3**3 * 2**23  # total no. conc of real droplets [m^-3]
 params_2 = {"COLLTSTEP": 0.1, "initsupers_filename": initSDsfile_2}
 
 # attribute generators
-xiprobdist_1 = probdists.VolExponential(volexpr0_1, rspan_1)
-radiigen_1 = rgens.SampleLog10RadiiGen(rspan_1)  # radii are sampled from rspan [m]
-xiprobdist_2 = probdists.VolExponential(volexpr0_2, rspan_2)
-radiigen_2 = rgens.SampleLog10RadiiGen(rspan_2)  # radii are sampled from rspan [m]
+xiprobdist_1 = attrgens_shima2009.SampleXiShima2009()
+radiigen_1 = attrgens_shima2009.SampleRadiiShima2009(
+    volexpr0_1, rspan_1
+)  # radii are sampled from rspan [m]
+xiprobdist_2 = attrgens_shima2009.SampleXiShima2009()
+radiigen_2 = attrgens_shima2009.SampleRadiiShima2009(
+    volexpr0_2, rspan_2
+)  # radii are sampled from rspan [m]
 samplevol = rgrid.calc_domainvol(zgrid, xgrid, ygrid)
 dryradiigen = rgens.MonoAttrGen(dryradius)
 

--- a/examples/boxmodelcollisions/shima2009_config.yaml
+++ b/examples/boxmodelcollisions/shima2009_config.yaml
@@ -25,7 +25,7 @@
 domain:
   nspacedims: 0                                                 # no. of spatial dimensions to model
   ngbxs: 1                                                      # total number of Gbxs
-  maxnsupers: 8192                                              # maximum number of SDs
+  maxnsupers: 16384                                             # maximum number of SDs
 
 timesteps:
   CONDTSTEP: 200                                                # time between SD condensation [s]

--- a/examples/exampleplotting/plotssrc/shima2009fig.py
+++ b/examples/exampleplotting/plotssrc/shima2009fig.py
@@ -6,7 +6,7 @@ Created Date: Friday 17th November 2023
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Monday 15th April 2024
+Last Modified: Friday 14th June 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -39,6 +39,7 @@ def plot_validation_figure(
     n_a,
     r_a,
     smoothsig,
+    xlims=[10, 5000],
     savename="",
     withgol=False,
 ):
@@ -49,7 +50,7 @@ def plot_validation_figure(
     non_nanradius = ak.nan_to_none(sddata["radius"])
     rspan = [ak.min(non_nanradius), ak.max(non_nanradius)]
 
-    fig, ax, ax_err = setup_validation_figure(witherr=witherr)
+    fig, ax, ax_err = setup_validation_figure(witherr, xlims)
 
     for n in range(len(tplt)):
         ind = np.argmin(abs(time - tplt[n]))
@@ -87,7 +88,7 @@ def plot_validation_figure(
     return fig, ax
 
 
-def setup_validation_figure(witherr):
+def setup_validation_figure(witherr, xlims):
     if witherr:
         gd = dict(height_ratios=[5, 1])
         fig, [ax, ax_err] = plt.subplots(
@@ -96,7 +97,6 @@ def setup_validation_figure(witherr):
     else:
         fig, ax = plt.subplots(ncols=1, nrows=1, figsize=(8, 6))
 
-    xlims = [10, 5000]
     ax.set_xscale("log")
     ax.set_xlim(xlims)
     ax.set_xlabel("radius, r, /\u03BCm")

--- a/examples/run_example.sh
+++ b/examples/run_example.sh
@@ -68,5 +68,5 @@ export OMP_PLACES=threads
 
 # TODO(all): add exports to paths required if YAC is enabled
 
-${python}  ${pythonscript} ${path2CLEO} ${path2build} ${script_args}
+${python} ${pythonscript} ${path2CLEO} ${path2build} ${script_args}
 ### ---------------------------------------------------- ###

--- a/libs/initialise/init_all_supers_from_binary.hpp
+++ b/libs/initialise/init_all_supers_from_binary.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 19th April 2024
+ * Last Modified: Saturday 15th June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -78,7 +78,6 @@ struct InitAllSupersFromBinary {
    * Calls constructor for InitAllSupersFromBinary wiht additional assert to sanity check
    * condfiguration matches initialisation expected by this struct.
    *
-   * @param maxnsupers The expected initial total number of super-droplets
    * @param config Configuration for member variables.
    *
    */

--- a/libs/observers/sdmmonitor/do_sdmmonitor_obs.hpp
+++ b/libs/observers/sdmmonitor/do_sdmmonitor_obs.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Thursday 6th June 2024
+ * Last Modified: Saturday 15th June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -64,6 +64,7 @@ class DoSDMMonitorObs {
    * @brief Constructor for DoSDMMonitorObs.
    * @param dataset Dataset to write monitored data to.
    * @param xzarr_ptr Pointer to zarr array in xarray dataset.
+   * @param monitor SDMMonitor to use.
    */
   DoSDMMonitorObs(Dataset<Store> &dataset,
                   const std::shared_ptr<XarrayZarrArray<Store, T>> xzarr_ptr, const SDMMo monitor)

--- a/libs/observers/sdmmonitor/monitor_condensation_observer.hpp
+++ b/libs/observers/sdmmonitor/monitor_condensation_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Thursday 6th June 2024
+ * Last Modified: Saturday 15th June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -68,8 +68,7 @@ struct MonitorCondensation {
   /**
    * @brief Placeholder function to obey SDMMonitor concept does nothing.
    *
-   * @param team_member Kokkkos team member in TeamPolicy parallel loop over gridboxes
-   * @param supers (sub)View of all the superdrops in one gridbox during one motion timestep
+   * @param d_gbxs The view of gridboxes in device memory.
    */
   void monitor_motion(const viewd_constgbx d_gbxs) const {}
 
@@ -91,6 +90,7 @@ struct MonitorCondensation {
  * @param interval Observation timestep.
  * @param dataset Dataset to write time data to.
  * @param maxchunk Maximum number of elements in a chunk (1-D vector size).
+ * @param ngbxs The number of gridboxes.
  * @return Constructed type satisfying observer concept.
  */
 template <typename Store>

--- a/libs/observers/sdmmonitor/monitor_massmoments.hpp
+++ b/libs/observers/sdmmonitor/monitor_massmoments.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Thursday 6th June 2024
+ * Last Modified: Saturday 15th June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -120,8 +120,7 @@ struct MonitorMassMoments {
    * calls fetch_massmoments to monitor the moments of the droplet mass
    * distribution during SDM motion.
    *
-   * @param team_member Kokkkos team member in TeamPolicy parallel loop over gridboxes
-   * @param supers (sub)View of all the superdrops in one gridbox during one motion timestep
+   * @param d_gbxs The view of gridboxes in device memory.
    */
   void monitor_motion(const viewd_constgbx d_gbxs) const {
     const size_t ngbxs(d_gbxs.extent(0));

--- a/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
+++ b/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Thursday 6th June 2024
+ * Last Modified: Saturday 15th June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -101,7 +101,8 @@ class DoMonitorMassMomentsObs {
   /**
    * @brief Constructor for DoMonitorMassMomentsObs.
    * @param dataset Dataset to write monitored data to.
-   * @param monitor_views Views on device for mass moments to monitor.
+   * @param maxchunk The maximum chunk size (number of elements) for Xarrays.
+   * @param ngbxs The number of gridboxes.
    */
   DoMonitorMassMomentsObs(Dataset<Store> &dataset, const size_t maxchunk, const size_t ngbxs)
       : dataset(dataset),
@@ -163,6 +164,7 @@ class DoMonitorMassMomentsObs {
  * @param interval Observation timestep.
  * @param dataset Dataset to write time data to.
  * @param maxchunk Maximum number of elements in a chunk (1-D vector size).
+ * @param ngbxs The number of gridboxes.
  * @return Constructed type satisfying observer concept.
  */
 template <typename Store>

--- a/libs/observers/thermo_observer.hpp
+++ b/libs/observers/thermo_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 22nd May 2024
+ * Last Modified: Saturday 15th June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -50,6 +50,9 @@
  * @param dataset The dataset to write the variable to.
  * @param ffunc The functor function to collect the variable from within a parallel range policy
  * over gridboxes.
+ * @param name The name of the new coordinate.
+ * @param units The units of the coordinate.
+ * @param scale_factor The scale factor of the coordinate data.
  * @param maxchunk The maximum chunk size (number of elements).
  * @param ngbxs The number of gridboxes.
  * @return CollectDataForDataset<Store> An instance satisfying the CollectDataForDataset concept for

--- a/libs/observers/totnsupers_observer.hpp
+++ b/libs/observers/totnsupers_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Saturday 25th May 2024
+ * Last Modified: Saturday 15th June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -123,7 +123,6 @@ class DoTotNsupersObs {
  * @param interval Observation timestep.
  * @param dataset Dataset to write time data to.
  * @param maxchunk Maximum number of elements in a chunk (1-D vector size).
- * @param step2dimlesstime Function to convert model timesteps to real time (assumed seconds).
  * @return Constructed type satisfying observer concept.
  */
 template <typename Store>

--- a/libs/observers/windvel_observer.hpp
+++ b/libs/observers/windvel_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 22nd May 2024
+ * Last Modified: Saturday 15th June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -50,6 +50,7 @@
  * @param dataset The dataset to write the wind velocity component to.
  * @param ffunc The functor function to collect the wind velocity component from within a parallel
  * range policy over gridboxes.
+ * @param name Name of the array in the store where the chunk will be written.
  * @param maxchunk The maximum chunk size (number of elements).
  * @param ngbxs The number of gridboxes.
  * @return CollectDataForDataset<Store> An instance satisfying the CollectDataForDataset concept for

--- a/libs/runcleo/sdmmethods.hpp
+++ b/libs/runcleo/sdmmethods.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors: Tobias Kölling (TK)
  * -----
- * Last Modified: Thursday 6th June 2024
+ * Last Modified: Saturday 15th June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -128,6 +128,7 @@ class SDMMethods {
      * @param t_sdm Current timestep for SDM.
      * @param t_next Next timestep for SDM.
      * @param d_gbxs View of gridboxes on device.
+     * @param mo SDMMonitor to use.
      */
     template <SDMMonitor SDMMo>
     void operator()(const unsigned int t_sdm, const unsigned int t_next, const viewd_gbx d_gbxs,
@@ -159,8 +160,7 @@ class SDMMethods {
    * @param couplstep Coupling timestep.
    * @param gbxmaps object that is type of GridboxMaps.
    * @param microphys object that is type of MicrophysicalProcess.
-   * @param motion object that is type of super-droplets' Motion.
-   * @param boundary_conds object for domain boundary conditions.
+   * @param movesupers object that is type of super-droplets' Motion.
    * @param obs object that is type of Observer.
    */
   SDMMethods(const unsigned int couplstep, const GbxMaps gbxmaps, const Microphys microphys,

--- a/libs/superdrops/superdrop_ids.hpp
+++ b/libs/superdrops/superdrop_ids.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors: Tobias Kölling (TK)
  * -----
- * Last Modified: Friday 3rd May 2024
+ * Last Modified: Saturday 15th June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -68,7 +68,7 @@ struct IntID {
      *
      * _Note:_ This generator assumes the ID was thread-safe generated (i.e., is unique).
      *
-     * @param id The value to use for generating the next SD identity.
+     * @param kk The value to use for generating the next SD identity.
      * @return SD identity.
      */
     KOKKOS_INLINE_FUNCTION IntID set(const unsigned int kk) { return {static_cast<size_t>(kk)}; }

--- a/libs/superdrops/terminalvelocity.cpp
+++ b/libs/superdrops/terminalvelocity.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Tuesday 9th April 2024
+ * Last Modified: Saturday 15th June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -94,7 +94,8 @@ double SimmelTerminalVelocity::operator()(const Superdrop &drop) const {
  * by  R. R. Rogers, D. Baumgardner, S. A. Ethier, D. A. Carter, and W. L. Ecklund (1993).
  * Formulation is approximation of Gunn and Kinzer (1949) tabulated values.
  *
- * @param drop The superdroplet.
+ * @param drop The super-droplet.
+ *
  * @return The (dimensionless) terminal velocity.
  */
 KOKKOS_FUNCTION
@@ -128,7 +129,8 @@ double RogersYauTerminalVelocity::operator()(const Superdrop &drop) const {
  * by  R. R. Rogers, D. Baumgardner, S. A. Ethier, D. A. Carter, and W. L. Ecklund (1993).
  * Formulation is approximation of Gunn and Kinzer (1949) tabulated values.
  *
- * @param drop The superdroplet.
+ * @param drop The super-droplet.
+ *
  * @return The (dimensionless) terminal velocity.
  */
 KOKKOS_FUNCTION

--- a/libs/zarr/buffer.hpp
+++ b/libs/zarr/buffer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Tuesday 9th April 2024
+ * Last Modified: Saturday 15th June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -163,7 +163,7 @@ struct Buffer {
    * @tparam Store The type of the memory store.
    * @param store Reference to the store object.
    * @param name Name of the array in the store.
-   * @param chunk_str Name of the chunk of the array to write in the store.
+   * @param chunk_label Name of the chunk of the array to write in the store.
    */
   template <typename Store>
   void write_buffer_to_chunk(Store& store, std::string_view name, const std::string& chunk_label) {

--- a/libs/zarr/xarray_zarr_array.hpp
+++ b/libs/zarr/xarray_zarr_array.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 22nd May 2024
+ * Last Modified: Saturday 15th June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -47,7 +47,7 @@
  * @tparam Store The type of the store object where the metadata will be written.
  * @param store The store object where the metadata will be written.
  * @param name The name under which the .zarray key will be stored in the store.
- * @param metadata The metadata to write for the .zarray key.
+ * @param attrs The metadata to write for the .zarray key.
  */
 template <typename Store>
 inline void write_zattrs_json(Store& store, std::string_view name, std::string_view attrs) {

--- a/pySD/initsuperdropsbinary_src/read_initsuperdrops.py
+++ b/pySD/initsuperdropsbinary_src/read_initsuperdrops.py
@@ -1,4 +1,4 @@
-'''
+"""
 Copyright (c) 2024 MPI-M, Clara Bayley
 
 
@@ -16,7 +16,7 @@ License: BSD 3-Clause "New" or "Revised" License
 https://opensource.org/licenses/BSD-3-Clause
 -----
 File Description:
-'''
+"""
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/pySD/initsuperdropsbinary_src/read_initsuperdrops.py
+++ b/pySD/initsuperdropsbinary_src/read_initsuperdrops.py
@@ -1,4 +1,4 @@
-"""
+'''
 Copyright (c) 2024 MPI-M, Clara Bayley
 
 
@@ -9,14 +9,14 @@ Created Date: Friday 13th October 2023
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Tuesday 7th May 2024
+Last Modified: Friday 14th June 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
 https://opensource.org/licenses/BSD-3-Clause
 -----
 File Description:
-"""
+'''
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -27,16 +27,37 @@ from ..gbxboundariesbinary_src.read_gbxboundaries import get_gbxvols_from_gridfi
 
 
 def plot_initGBxs_distribs(
-    configfile, constsfile, initsupersfile, gridfile, binpath, savefig, gbxs2plt
+    configfile,
+    constsfile,
+    initsupersfile,
+    gridfile,
+    binpath,
+    savefig,
+    gbxs2plt,
+    savelabel="",
 ):
     """plot initial superdroplet distribution from initsupersfile binary
     of every gridbox with index in gbx2plts"""
 
     plot_initGBxs_attrdistribs(
-        configfile, constsfile, initsupersfile, gridfile, binpath, savefig, gbxs2plt
+        configfile,
+        constsfile,
+        initsupersfile,
+        gridfile,
+        binpath,
+        savefig,
+        gbxs2plt,
+        savelabel,
     )
     plot_initGBxs_dropletmasses(
-        configfile, constsfile, initsupersfile, gridfile, binpath, savefig, gbxs2plt
+        configfile,
+        constsfile,
+        initsupersfile,
+        gridfile,
+        binpath,
+        savefig,
+        gbxs2plt,
+        savelabel,
     )
 
 
@@ -155,7 +176,14 @@ def plot_initdistribs(attrs, gbxvols, gbxidxs):
 
 
 def plot_initGBxs_attrdistribs(
-    configfile, constsfile, initsupersfile, gridfile, binpath, savefig, gbxs2plt
+    configfile,
+    constsfile,
+    initsupersfile,
+    gridfile,
+    binpath,
+    savefig,
+    gbxs2plt,
+    savelabel,
 ):
     """plot initial superdroplet distribution from initsupersfile binary
     of every gridbox with index in gbx2plts"""
@@ -165,13 +193,13 @@ def plot_initGBxs_attrdistribs(
 
     if isinstance(gbxs2plt, int):
         gbxidxs = [gbxs2plt]
-        savename = binpath + "initGBx" + str(gbxs2plt) + "_distrib.png"
+        savename = binpath + "initGBx" + str(gbxs2plt) + "_distrib" + savelabel + ".png"
     elif gbxs2plt == "all":
         gbxidxs = np.unique(attrs.sdgbxindex)
-        savename = binpath + "initallGBxs_distribs.png"
+        savename = binpath + "initallGBxs_distribs" + savelabel + ".png"
     else:
         gbxidxs = gbxs2plt
-        savename = binpath + "initGBxs_distribs.png"
+        savename = binpath + "initGBxs_distribs" + savelabel + ".png"
 
     fig, axs, lines = plot_initdistribs(attrs, gbxvols, gbxidxs)
 
@@ -349,7 +377,14 @@ def plot_coorddist(ax, hedgs, coord3, radius, coordnum):
 
 
 def plot_initGBxs_dropletmasses(
-    configfile, constsfile, initsupersfile, gridfile, binpath, savefig, gbxs2plt
+    configfile,
+    constsfile,
+    initsupersfile,
+    gridfile,
+    binpath,
+    savefig,
+    gbxs2plt,
+    savelabel,
 ):
     """plot initial superdroplet mass distributions
     from initsupersfile binary of every gridbox with index
@@ -361,13 +396,15 @@ def plot_initGBxs_dropletmasses(
 
     if isinstance(gbxs2plt, int):
         gbxidxs = [gbxs2plt]
-        savename = binpath + "initGBx" + str(gbxs2plt) + "_dropletmasses.png"
+        savename = (
+            binpath + "initGBx" + str(gbxs2plt) + "_dropletmasses" + savelabel + ".png"
+        )
     elif gbxs2plt == "all":
         gbxidxs = np.unique(attrs.sdgbxindex)
-        savename = binpath + "initallGBxs_dropletmasses.png"
+        savename = binpath + "initallGBxs_dropletmasses" + savelabel + ".png"
     else:
         gbxidxs = gbxs2plt
-        savename = binpath + "initGBxs_dropletmasses.png"
+        savename = binpath + "initGBxs_dropletmasses" + savelabel + ".png"
 
     fig, axs, lines = plot_massdistribs(
         attrs, gbxvols, gbxidxs, inputs["RHO_L"], inputs["RHO_SOL"]


### PR DESCRIPTION
- separate Fig 2. example from Shima et al. 2009 from other box model collision kernel examples.
- use SD generation as in Shima et al. 2009 (const. multiplicity method).
- don't copy exactly Fig 2(c) since collision efficiency is smaller in Simmel Kernel for small drops so collisions too infrequent.