### PR TITLE
physics calculation fix in breakup algorithm

### DIFF
--- a/libs/superdrops/collisions/breakup.hpp
+++ b/libs/superdrops/collisions/breakup.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Thursday 6th June 2024
+ * Last Modified: Monday 17th June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -133,7 +133,7 @@ irrespective of whether scaled probability, prob > 1 */
 template <NFragments NFrags>
 KOKKOS_FUNCTION unsigned int DoBreakup<NFrags>::breakup_gamma(const double prob,
                                                               const double phi) const {
-  if (phi < (prob - floor(prob))) {
+  if (phi < (prob - Kokkos::floor(prob))) {
     return 1;
   } else {  // if phi >= (prob - floor(prob))
     return 0;

--- a/libs/superdrops/collisions/coalbure.hpp
+++ b/libs/superdrops/collisions/coalbure.hpp
@@ -62,6 +62,20 @@ struct DoCoalBuRe {
   [0, 1].
   * _Note:_ This function is assumed to be consitent with collision_gamma(...) and must be.
   */
+
+  /**
+   * @brief Rescales a random number phi to be in the desired range [0, 1].
+   *
+   * This function adjusts the value of phi to account for the fact that if a collision occurs
+   * (i.e., if gamma != 0), then phi lies in the range [0, prob - floor(prob)] instead of [0, 1].
+   *
+   * @note This function is assumed to be consistent with collision_gamma(...) and must be.
+   *
+   * @param prob The probability of collision.
+   * @param phi Random number, assumed to be in the range [0.0, prob - floor(prob)].
+   *
+   * @return The rescaled value of phi as a uint64_t.
+   */
   KOKKOS_FUNCTION
   uint64_t rescale_phi(const double prob, const double phi) const {
     return phi / (prob - Kokkos::floor(prob));

--- a/libs/superdrops/collisions/coalescence.cpp
+++ b/libs/superdrops/collisions/coalescence.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Sunday 21st April 2024
+ * Last Modified: Monday 17th June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -66,7 +66,7 @@ KOKKOS_FUNCTION bool DoCoalescence::operator()(Superdrop &drop1, Superdrop &drop
 KOKKOS_FUNCTION uint64_t DoCoalescence::coalescence_gamma(const uint64_t xi1, const uint64_t xi2,
                                                           const double prob,
                                                           const double phi) const {
-  uint64_t gamma = floor(prob);  // if phi >= (prob - floor(prob))
+  uint64_t gamma = Kokkos::floor(prob);  // if phi >= (prob - floor(prob))
   if (phi < (prob - gamma)) {
     ++gamma;
   }


### PR DESCRIPTION
add rescaling of phi when using random number again during coalescence / rebound / breakup 