### PR TITLE
roughpaper .hpp file to print sizes

### DIFF
--- a/roughpaper/cleotypes_sizes.hpp
+++ b/roughpaper/cleotypes_sizes.hpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2024 MPI-M, Clara Bayley
+ *
+ *
+ * ----- CLEO -----
+ * File: cleotypes_sizes.hpp
+ * Project: roughpaper
+ * Created Date: Friday 21st June 2024
+ * Author: Clara Bayley (CB)
+ * Additional Contributors:
+ * -----
+ * Last Modified: Friday 21st June 2024
+ * Modified By: CB
+ * -----
+ * License: BSD 3-Clause "New" or "Revised" License
+ * https://opensource.org/licenses/BSD-3-Clause
+ * -----
+ * File Description:
+ */
+
+#ifndef ROUGHPAPER_CLEOTYPES_SIZES_HPP_
+#define ROUGHPAPER_CLEOTYPES_SIZES_HPP_
+
+#include <Kokkos_Core.hpp>
+#include <iostream>
+
+#include "gridboxes/gbxindex.hpp"
+#include "gridboxes/gridbox.hpp"
+#include "kokkosaliases.hpp"
+#include "superdrops/state.hpp"
+#include "superdrops/superdrop.hpp"
+
+struct Gridbox2 {
+  /* gbx with different ordering of members to see if padding is reduced */
+  Gbxindex gbxindex;
+  SupersInGbx supersingbx;
+  State state;
+};
+
+struct SupersInGbx2 {
+  /* supersingbx with different ordering of members to see if padding is reduced */
+  unsigned int idx;
+  kkpair_size_t refs;
+  viewd_supers totsupers;
+};
+
+struct Superdrop2 {
+  /* superdrop with different ordering of members to see if padding is reduced */
+  SuperdropAttrs attrs;
+  double coord3;
+  double coord1;
+  double coord2;
+  unsigned int sdgbxindex;
+  using IDType = IntID;
+  // using IDType = EmptyID;
+  [[no_unique_address]] IDType sdId;
+};
+
+struct SuperdropAttrs2 {
+  uint64_t xi;
+  double radius;
+  double msol;
+  SoluteProperties solute;
+};
+
+void print_type_sizes(int argc, char *argv[]) {
+  Kokkos::initialize(argc, argv);
+  {
+    std::cout << "GBx: " << sizeof(Gridbox) << "\n";
+    std::cout << "re-ordered GBx: " << sizeof(Gridbox2) << "\n";
+    std::cout << "no padding: " << sizeof(State) + sizeof(SupersInGbx) + sizeof(Gbxindex) << "\n";
+    std::cout << "  State: " << sizeof(State) << "\n";
+    std::cout << "  SupersInGBx: " << sizeof(SupersInGbx) << "\n";
+    std::cout << "  gbxindex: " << sizeof(Gbxindex) << "\n";
+
+    std::cout << "\nSupersInGBx: " << sizeof(SupersInGbx) << "\n";
+    std::cout << "re-ordered SupersInGBx: " << sizeof(SupersInGbx2) << "\n";
+    std::cout << "no padding: "
+              << sizeof(viewd_supers) + sizeof(kkpair_size_t) + sizeof(unsigned int) << "\n";
+    std::cout << "  View: " << sizeof(viewd_supers) << "\n";
+    std::cout << "  refs: " << sizeof(kkpair_size_t) << "\n";
+    std::cout << "  idx: " << sizeof(unsigned int) << "\n";
+
+    std::cout << "\nSD: " << sizeof(Superdrop) << "\n";
+    std::cout << "re-ordered SD: " << sizeof(Superdrop2) << "\n";
+    std::cout << "no padding: "
+              << sizeof(unsigned int) + sizeof(double) * 3 + sizeof(SuperdropAttrs) + sizeof(IntID);
+    std::cout << " or "
+              << sizeof(unsigned int) + sizeof(double) * 3 + sizeof(SuperdropAttrs) +
+                     sizeof(EmptyID)
+              << "\n";
+    std::cout << "  sdgbxindex: " << sizeof(unsigned int) << "\n";
+    std::cout << "  coords: " << sizeof(double) * 3 << "\n";
+    std::cout << "  attrs: " << sizeof(SuperdropAttrs) << "\n";
+    std::cout << "  id: " << sizeof(IntID) << " or " << sizeof(EmptyID) << "\n";
+
+    std::cout << "\nSDAttrs: " << sizeof(SuperdropAttrs) << "\n";
+    std::cout << "re-ordered SDAttrs: " << sizeof(SuperdropAttrs2) << "\n";
+    std::cout << "no padding: " << sizeof(uint64_t) + 2 * sizeof(double) + sizeof(SoluteProperties)
+              << " <- is solute actually 8 bytes?? \n";
+    std::cout << "  xi: " << sizeof(uint64_t) << "\n";
+    std::cout << "  radius: " << sizeof(double) << "\n";
+    std::cout << "  msol: " << sizeof(double) << "\n";
+    std::cout << "  SoluteProperties: " << sizeof(SoluteProperties) << "\n";
+  }
+  Kokkos::finalize();
+}
+
+#endif  // ROUGHPAPER_CLEOTYPES_SIZES_HPP_

--- a/roughpaper/cleotypes_sizes.hpp
+++ b/roughpaper/cleotypes_sizes.hpp
@@ -57,10 +57,10 @@ struct Superdrop2 {
 };
 
 struct SuperdropAttrs2 {
+  SoluteProperties solute;
   uint64_t xi;
   double radius;
   double msol;
-  SoluteProperties solute;
 };
 
 void print_type_sizes(int argc, char *argv[]) {
@@ -97,7 +97,7 @@ void print_type_sizes(int argc, char *argv[]) {
     std::cout << "\nSDAttrs: " << sizeof(SuperdropAttrs) << "\n";
     std::cout << "re-ordered SDAttrs: " << sizeof(SuperdropAttrs2) << "\n";
     std::cout << "no padding: " << sizeof(uint64_t) + 2 * sizeof(double) + sizeof(SoluteProperties)
-              << " <- is solute actually 8 bytes?? \n";
+              << "\n";
     std::cout << "  xi: " << sizeof(uint64_t) << "\n";
     std::cout << "  radius: " << sizeof(double) << "\n";
     std::cout << "  msol: " << sizeof(double) << "\n";

--- a/roughpaper/main.cpp
+++ b/roughpaper/main.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 19th April 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -24,6 +24,7 @@
 #include <concepts>
 #include <iostream>
 
+#include "./cleotypes_sizes.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/null_boundary_conditions.hpp"
@@ -171,6 +172,8 @@ inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<St
 }
 
 int main(int argc, char *argv[]) {
+  print_type_sizes(argc, argv);
+
   Kokkos::Timer kokkostimer;
 
   /* Read input parameters from configuration file(s) */
@@ -206,6 +209,8 @@ int main(int argc, char *argv[]) {
   std::cout << "-------------------------------\n"
                "Total Program Duration: "
             << ttot << "s \n-------------------------------\n";
+
+  return 0;
 }
-/* ---------------------------------------------------------------------------------------------- */
-/* ---------------------------------------------------------------------------------------------- */
+/* ----------------------------------------------------------------------------------------------*/
+/* ----------------------------------------------------------------------------------------------*/


### PR DESCRIPTION
hpp file added in roughpaper to print the sizes of gridboxes and superdroplets and their member variables