### PR TITLE
tidy includes

### DIFF
--- a/examples/adiabaticparcel/src/CMakeLists.txt
+++ b/examples/adiabaticparcel/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(adia0D EXCLUDE_FROM_ALL "main_adia0D.cpp")
 # Add directories and link libraries to target
 target_link_libraries(adia0D PRIVATE coupldyn_cvode cartesiandomain "${CLEOLIBS}")
 target_link_libraries(adia0D PUBLIC Kokkos::kokkos)
-target_include_directories(adia0D PRIVATE "${CMAKE_SOURCE_DIR}/libs")
+target_include_directories(adia0D PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(adia0D PRIVATE)

--- a/examples/boxmodelcollisions/golovin/src/CMakeLists.txt
+++ b/examples/boxmodelcollisions/golovin/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(golcolls EXCLUDE_FROM_ALL "main_golcolls.cpp")
 # Add directories and link libraries to target
 target_link_libraries(golcolls PRIVATE cartesiandomain "${CLEOLIBS}")
 target_link_libraries(golcolls PUBLIC Kokkos::kokkos)
-target_include_directories(golcolls PRIVATE "${CMAKE_SOURCE_DIR}/libs")
+target_include_directories(golcolls PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(golcolls PRIVATE)

--- a/examples/boxmodelcollisions/long/src/CMakeLists.txt
+++ b/examples/boxmodelcollisions/long/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(longcolls EXCLUDE_FROM_ALL "main_longcolls.cpp")
 # Add directories and link libraries to target
 target_link_libraries(longcolls PRIVATE cartesiandomain "${CLEOLIBS}")
 target_link_libraries(longcolls PUBLIC Kokkos::kokkos)
-target_include_directories(longcolls PRIVATE "${CMAKE_SOURCE_DIR}/libs")
+target_include_directories(longcolls PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(longcolls PRIVATE)

--- a/examples/boxmodelcollisions/lowlist/src/CMakeLists.txt
+++ b/examples/boxmodelcollisions/lowlist/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(lowlistcolls EXCLUDE_FROM_ALL "main_lowlistcolls.cpp")
 # Add directories and link libraries to target
 target_link_libraries(lowlistcolls PRIVATE cartesiandomain "${CLEOLIBS}")
 target_link_libraries(lowlistcolls PUBLIC Kokkos::kokkos)
-target_include_directories(lowlistcolls PRIVATE "${CMAKE_SOURCE_DIR}/libs")
+target_include_directories(lowlistcolls PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(lowlistcolls PRIVATE)

--- a/examples/boxmodelcollisions/szakallurbich/src/CMakeLists.txt
+++ b/examples/boxmodelcollisions/szakallurbich/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(szakallurbichcolls EXCLUDE_FROM_ALL "main_szakallurbichcolls.cpp"
 # Add directories and link libraries to target
 target_link_libraries(szakallurbichcolls PRIVATE cartesiandomain "${CLEOLIBS}")
 target_link_libraries(szakallurbichcolls PUBLIC Kokkos::kokkos)
-target_include_directories(szakallurbichcolls PRIVATE "${CMAKE_SOURCE_DIR}/libs")
+target_include_directories(szakallurbichcolls PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(szakallurbichcolls PRIVATE)

--- a/examples/boxmodelcollisions/testikstraub/src/CMakeLists.txt
+++ b/examples/boxmodelcollisions/testikstraub/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(testikstraubcolls EXCLUDE_FROM_ALL "main_testikstraubcolls.cpp")
 # Add directories and link libraries to target
 target_link_libraries(testikstraubcolls PRIVATE cartesiandomain "${CLEOLIBS}")
 target_link_libraries(testikstraubcolls PUBLIC Kokkos::kokkos)
-target_include_directories(testikstraubcolls PRIVATE "${CMAKE_SOURCE_DIR}/libs")
+target_include_directories(testikstraubcolls PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(testikstraubcolls PRIVATE)

--- a/examples/constthermo2d/src/CMakeLists.txt
+++ b/examples/constthermo2d/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(const2D EXCLUDE_FROM_ALL "main_const2D.cpp")
 # Add directories and link libraries to target
 target_link_libraries(const2D PRIVATE coupldyn_fromfile cartesiandomain "${CLEOLIBS}")
 target_link_libraries(const2D PUBLIC Kokkos::kokkos)
-target_include_directories(const2D PRIVATE "${CMAKE_SOURCE_DIR}/libs")
+target_include_directories(const2D PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(const2D PRIVATE)

--- a/examples/divfreemotion/src/CMakeLists.txt
+++ b/examples/divfreemotion/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(divfree2D EXCLUDE_FROM_ALL "main_divfree2D.cpp")
 # Add directories and link libraries to target
 target_link_libraries(divfree2D PRIVATE coupldyn_fromfile cartesiandomain "${CLEOLIBS}")
 target_link_libraries(divfree2D PUBLIC Kokkos::kokkos)
-target_include_directories(divfree2D PRIVATE "${CMAKE_SOURCE_DIR}/libs")
+target_include_directories(divfree2D PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(divfree2D PRIVATE)

--- a/examples/eurec4a1d/src/CMakeLists.txt
+++ b/examples/eurec4a1d/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(eurec4a1D EXCLUDE_FROM_ALL "main_eurec4a1D.cpp")
 # Add directories and link libraries to target
 target_link_libraries(eurec4a1D PRIVATE coupldyn_fromfile cartesiandomain "${CLEOLIBS}")
 target_link_libraries(eurec4a1D PUBLIC Kokkos::kokkos)
-target_include_directories(eurec4a1D PRIVATE "${CMAKE_SOURCE_DIR}/libs")
+target_include_directories(eurec4a1D PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(eurec4a1D PRIVATE)

--- a/examples/rainshaft1d/src/CMakeLists.txt
+++ b/examples/rainshaft1d/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(rshaft1D EXCLUDE_FROM_ALL "main_rshaft1D.cpp")
 # Add directories and link libraries to target
 target_link_libraries(rshaft1D PRIVATE coupldyn_fromfile cartesiandomain "${CLEOLIBS}")
 target_link_libraries(rshaft1D PUBLIC Kokkos::kokkos)
-target_include_directories(rshaft1D PRIVATE "${CMAKE_SOURCE_DIR}/libs")
+target_include_directories(rshaft1D PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(rshaft1D PRIVATE)

--- a/examples/speedtest/src/CMakeLists.txt
+++ b/examples/speedtest/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(spdtest EXCLUDE_FROM_ALL "main_spdtest.cpp")
 # Add directories and link libraries to target
 target_link_libraries(spdtest PRIVATE coupldyn_fromfile cartesiandomain "${CLEOLIBS}")
 target_link_libraries(spdtest PUBLIC Kokkos::kokkos)
-target_include_directories(spdtest PRIVATE "${CMAKE_SOURCE_DIR}/libs")
+target_include_directories(spdtest PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(spdtest PRIVATE)

--- a/examples/yac/divfreemotion/src/CMakeLists.txt
+++ b/examples/yac/divfreemotion/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(divfree2D_yac EXCLUDE_FROM_ALL "main_divfree2D.cpp")
 # Add directories and link libraries to target
 target_link_libraries(divfree2D_yac PRIVATE coupldyn_yac cartesiandomain "${CLEOLIBS}")
 target_link_libraries(divfree2D_yac PUBLIC Kokkos::kokkos)
-target_include_directories(divfree2D_yac PRIVATE "${CMAKE_SOURCE_DIR}/libs")
+target_include_directories(divfree2D_yac PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(divfree2D PRIVATE)

--- a/examples/yac/fromfile/src/CMakeLists.txt
+++ b/examples/yac/fromfile/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(yac1 EXCLUDE_FROM_ALL "main_yac1.cpp")
 # Add directories and link libraries to target
 target_link_libraries(yac1 PRIVATE coupldyn_fromfile cartesiandomain "${CLEOLIBS}")
 target_link_libraries(yac1 PUBLIC Kokkos::kokkos)
-target_include_directories(yac1 PRIVATE "${CMAKE_SOURCE_DIR}/libs")
+target_include_directories(yac1 PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(yac1 PRIVATE)

--- a/examples/yac/yac_3d/src/CMakeLists.txt
+++ b/examples/yac/yac_3d/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(yac_3d EXCLUDE_FROM_ALL "main_yac1.cpp")
 # Add directories and link libraries to target
 target_link_libraries(yac_3d PRIVATE coupldyn_yac cartesiandomain "${CLEOLIBS}")
 target_link_libraries(yac_3d PUBLIC Kokkos::kokkos)
-target_include_directories(yac_3d PRIVATE "${CMAKE_SOURCE_DIR}/libs")
+target_include_directories(yac_3d PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(yac1 PRIVATE)

--- a/libs/cartesiandomain/CMakeLists.txt
+++ b/libs/cartesiandomain/CMakeLists.txt
@@ -21,7 +21,7 @@ set(SOURCES
 add_library("${LIBNAME}" STATIC ${SOURCES})
 
 # Add directories for target library
-target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+# target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(${LIBNAME} PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # Link libraries to target library

--- a/libs/cartesiandomain/add_supers_at_domain_top.cpp
+++ b/libs/cartesiandomain/add_supers_at_domain_top.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Saturday 25th May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -20,7 +20,7 @@
  * for Cartesian GridBox Maps, Motion of Super-Droplets and MoveSupersInDomain
  */
 
-#include "cartesiandomain/add_supers_at_domain_top.hpp"
+#include "./add_supers_at_domain_top.hpp"
 
 Kokkos::View<unsigned int *> remove_superdrops_from_gridboxes(const CartesianMaps &gbxmaps,
                                                               const viewd_gbx d_gbxs,

--- a/libs/cartesiandomain/cartesianmotion.cpp
+++ b/libs/cartesiandomain/cartesianmotion.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Tuesday 16th April 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License

--- a/libs/coupldyn_cvode/CMakeLists.txt
+++ b/libs/coupldyn_cvode/CMakeLists.txt
@@ -30,7 +30,7 @@ set(SOURCES
 add_library("${LIBNAME}" STATIC ${SOURCES})
 
 # Add directories for target library
-target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+#target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(${LIBNAME} PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # Link libraries to target library

--- a/libs/coupldyn_cvode/cvodecomms.hpp
+++ b/libs/coupldyn_cvode/cvodecomms.hpp
@@ -1,4 +1,6 @@
-/* Copyright (c) 2023 MPI-M, Clara Bayley
+/*
+ * Copyright (c) 2024 MPI-M, Clara Bayley
+ *
  *
  * ----- CLEO -----
  * File: cvodecomms.hpp
@@ -7,15 +9,14 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Tuesday 31st October 2023
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
  * https://opensource.org/licenses/BSD-3-Clause
  * -----
  * File Description:
- * send and receive dynamics functions for
- * SDM when coupled to the CVODE ODE solver
+ * send and receive dynamics functions for SDM when coupled to the CVODE ODE solver
  */
 
 #ifndef LIBS_COUPLDYN_CVODE_CVODECOMMS_HPP_
@@ -25,7 +26,7 @@
 #include <vector>
 
 #include "../kokkosaliases.hpp"
-#include "./cvodedynamics.hpp"
+#include "coupldyn_cvode/cvodedynamics.hpp"
 #include "gridboxes/gridbox.hpp"
 #include "superdrops/state.hpp"
 

--- a/libs/coupldyn_cvode/cvodedynamics.hpp
+++ b/libs/coupldyn_cvode/cvodedynamics.hpp
@@ -9,16 +9,15 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 17th April 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
  * https://opensource.org/licenses/BSD-3-Clause
  * -----
  * File Description:
- * struct obeying coupleddynamics concept for
- * dynamics solver in CLEO where coupling is
- * two-way to cvode adiabatic parcel ODE solver
+ * struct obeying coupleddynamics concept for dynamics solver in CLEO where coupling is two-way
+ * to cvode adiabatic parcel ODE solver
  */
 
 #ifndef LIBS_COUPLDYN_CVODE_CVODEDYNAMICS_HPP_
@@ -37,7 +36,7 @@
 #include <vector>
 
 #include "../cleoconstants.hpp"
-#include "./differentialfuncs.hpp"
+#include "coupldyn_cvode/differentialfuncs.hpp"
 #include "initialise/optional_config_params.hpp"
 
 namespace dlc = dimless_constants;

--- a/libs/coupldyn_fromfile/CMakeLists.txt
+++ b/libs/coupldyn_fromfile/CMakeLists.txt
@@ -19,7 +19,7 @@ set(SOURCES
 add_library("${LIBNAME}" STATIC ${SOURCES})
 
 # Add directories for target library
-target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+#target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(${LIBNAME} PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # Link libraries to target library

--- a/libs/coupldyn_null/nulldyncomms.hpp
+++ b/libs/coupldyn_null/nulldyncomms.hpp
@@ -1,4 +1,6 @@
-/* Copyright (c) 2023 MPI-M, Clara Bayley
+/*
+ * Copyright (c) 2024 MPI-M, Clara Bayley
+ *
  *
  * ----- CLEO -----
  * File: nulldyncomms.hpp
@@ -7,16 +9,15 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 17th November 2023
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
  * https://opensource.org/licenses/BSD-3-Clause
  * -----
  * File Description:
- * struct obeying coupleddynamics concept
- * for dynamics solver in CLEO where there
- * is no coupling / communication to SDM
+ * struct obeying coupleddynamics concept for dynamics solver in CLEO where there is
+ * no coupling / communication to SDM
  */
 
 #ifndef LIBS_COUPLDYN_NULL_NULLDYNCOMMS_HPP_
@@ -25,7 +26,7 @@
 #include <Kokkos_Core.hpp>
 
 #include "../kokkosaliases.hpp"
-#include "./nulldynamics.hpp"
+#include "coupldyn_null/nulldynamics.hpp"
 
 /* empty (no) coupling to/from to CLEO's gridboxes.
 Struct obeys coupling comms concept */

--- a/libs/coupldyn_yac/CMakeLists.txt
+++ b/libs/coupldyn_yac/CMakeLists.txt
@@ -26,7 +26,8 @@ add_library("${LIBNAME}" STATIC ${SOURCES})
 enable_language(C)
 
 # Add directories for target library
-target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" ${YAC_C_INCLUDE_DIR})
+# target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_include_directories(${LIBNAME} PRIVATE ${YAC_C_INCLUDE_DIR}) # YAC source directory
 target_include_directories(${LIBNAME} PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # Link libraries to target library

--- a/libs/gridboxes/CMakeLists.txt
+++ b/libs/gridboxes/CMakeLists.txt
@@ -22,7 +22,7 @@ set(SOURCES
 add_library("${LIBNAME}" STATIC ${SOURCES})
 
 # Add directories for target library
-target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+#target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(${LIBNAME} PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # Link libraries to target library

--- a/libs/gridboxes/cfl_criteria.hpp
+++ b/libs/gridboxes/cfl_criteria.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 6th March 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -21,13 +21,12 @@
  * condition (ie. CFL criteria)
  */
 
-
 #ifndef LIBS_GRIDBOXES_CFL_CRITERIA_HPP_
 #define LIBS_GRIDBOXES_CFL_CRITERIA_HPP_
 
 #include <Kokkos_Core.hpp>
 
-#include "./gridboxmaps.hpp"
+#include "gridboxes/gridboxmaps.hpp"
 
 /* sdstep = change in superdroplet coordinate position.
 returns *false* if cfl criterion, C = sdstep / gridstep, > 1 */
@@ -42,7 +41,8 @@ bool cfl_criterion(const double gridstep, const double sdstep) {
   gridstep is calculated from the gridbox boundaries map */
 template <GridboxMaps GbxMaps>
 KOKKOS_INLINE_FUNCTION bool cfl_criteria(const GbxMaps &gbxmaps, const unsigned int gbxindex,
-                                  const double delta3, const double delta1, const double delta2) {
+                                         const double delta3, const double delta1,
+                                         const double delta2) {
   double gridstep(gbxmaps.coord3bounds(gbxindex).second - gbxmaps.coord3bounds(gbxindex).first);
   bool cfl(cfl_criterion(gridstep, delta3));
 

--- a/libs/gridboxes/gridbox.hpp
+++ b/libs/gridboxes/gridbox.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 8th May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -26,8 +26,8 @@
 #include <Kokkos_Pair.hpp>
 #include <Kokkos_StdAlgorithms.hpp>
 
-#include "./gbxindex.hpp"
-#include "./supersingbx.hpp"
+#include "gridboxes/gbxindex.hpp"
+#include "gridboxes/supersingbx.hpp"
 #include "superdrops/kokkosaliases_sd.hpp"
 #include "superdrops/state.hpp"
 #include "superdrops/superdrop.hpp"

--- a/libs/gridboxes/movesupersindomain.hpp
+++ b/libs/gridboxes/movesupersindomain.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 5th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,9 +28,9 @@
 
 #include "../cleoconstants.hpp"
 #include "../kokkosaliases.hpp"
-#include "./gridbox.hpp"
-#include "./gridboxmaps.hpp"
-#include "./sortsupers.hpp"
+#include "gridboxes/gridbox.hpp"
+#include "gridboxes/gridboxmaps.hpp"
+#include "gridboxes/sortsupers.hpp"
 #include "superdrops/motion.hpp"
 #include "superdrops/sdmmonitor.hpp"
 #include "superdrops/superdrop.hpp"

--- a/libs/gridboxes/predcorr.cpp
+++ b/libs/gridboxes/predcorr.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 11th March 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -33,13 +33,13 @@ limited to lower_bound <= coord <= upper_bound. */
 KOKKOS_FUNCTION
 double interpolation(const Kokkos::pair<double, double> bounds,
                      const Kokkos::pair<double, double> vel, const double sdcoord) {
-    const auto coord = double{Kokkos::fmin(
-        bounds.second, Kokkos::fmax(bounds.first, sdcoord))};   // limit coord to within bounds
+  const auto coord = double{Kokkos::fmin(
+      bounds.second, Kokkos::fmax(bounds.first, sdcoord))};  // limit coord to within bounds
 
-    const auto alpha = double{(coord - bounds.first) / (bounds.second - bounds.first)};
+  const auto alpha = double{(coord - bounds.first) / (bounds.second - bounds.first)};
 
-    const auto interp =
-        double{alpha * vel.second + (1 - alpha) * vel.first};   // simple linear interpolation
+  const auto interp =
+      double{alpha * vel.second + (1 - alpha) * vel.first};  // simple linear interpolation
 
-    return interp;
+  return interp;
 }

--- a/libs/gridboxes/predcorr.hpp
+++ b/libs/gridboxes/predcorr.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 11th March 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -26,14 +26,13 @@
 #ifndef LIBS_GRIDBOXES_PREDCORR_HPP_
 #define LIBS_GRIDBOXES_PREDCORR_HPP_
 
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Pair.hpp>
 #include <cassert>
 #include <functional>
 
-#include <Kokkos_Core.hpp>
-#include <Kokkos_Pair.hpp>
-
-#include "./cfl_criteria.hpp"
-#include "./gridboxmaps.hpp"
+#include "gridboxes/cfl_criteria.hpp"
+#include "gridboxes/gridboxmaps.hpp"
 #include "superdrops/state.hpp"
 #include "superdrops/superdrop.hpp"
 #include "superdrops/terminalvelocity.hpp"
@@ -54,8 +53,8 @@ equations in Grabowski et al. 2018 */
 template <GridboxMaps GbxMaps, VelocityFormula TV>
 struct PredCorr {
  private:
-  const double delt;    // equivalent of motionstep as dimensionless time
-  const TV terminalv;   // returns terminal velocity given a superdroplet
+  const double delt;   // equivalent of motionstep as dimensionless time
+  const TV terminalv;  // returns terminal velocity given a superdroplet
 
   /* method to interpolate coord3 wind velocity component (w)
   defined on coord3 faces of a gridbox to a superdroplet's
@@ -96,7 +95,7 @@ struct PredCorr {
     vel3 -= terminal;
 
     /* predictor coords given velocity at previous coords */
-    coord3 += vel3 * delt;   // move by w wind + terminal velocity
+    coord3 += vel3 * delt;  // move by w wind + terminal velocity
 
     /* corrector velocities based on predicted coords */
     auto corrvel3 = interp_wvel(gbxindex, gbxmaps, state, coord3);
@@ -117,7 +116,7 @@ struct PredCorr {
     const auto vel1 = interp_uvel(gbxindex, gbxmaps, state, coord1);
 
     /* predictor coords given velocity at previous coords */
-    coord1 += vel1 * delt;   // move by u wind
+    coord1 += vel1 * delt;  // move by u wind
 
     /* corrector velocities based on predicted coords */
     const auto corrvel1 = interp_uvel(gbxindex, gbxmaps, state, coord1);
@@ -137,7 +136,7 @@ struct PredCorr {
     const auto vel2 = interp_vvel(gbxindex, gbxmaps, state, coord2);
 
     /* predictor coords given velocity at previous coords */
-    coord2 += vel2 * delt;   // move by v wind
+    coord2 += vel2 * delt;  // move by v wind
 
     /* corrector velocities based on predicted coords */
     const auto corrvel2 = interp_vvel(gbxindex, gbxmaps, state, coord2);
@@ -174,4 +173,4 @@ struct PredCorr {
   }
 };
 
-#endif   // LIBS_GRIDBOXES_PREDCORR_HPP_
+#endif  // LIBS_GRIDBOXES_PREDCORR_HPP_

--- a/libs/gridboxes/predcorrmotion.hpp
+++ b/libs/gridboxes/predcorrmotion.hpp
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2024 MPI-M, Clara Bayley
+ *
+ *
+ * ----- CLEO -----
+ * File: predcorrmotion.hpp
+ * Project: gridboxes
+ * Created Date: Friday 3rd May 2024
+ * Author: Clara Bayley (CB)
+ * Additional Contributors:
+ * -----
+ * Last Modified: Friday 21st June 2024
+ * Modified By: CB
+ * -----
+ * License: BSD 3-Clause "New" or "Revised" License
+ * https://opensource.org/licenses/BSD-3-Clause
+ * -----
+ * File Description:
+ */
+
+
 /* Copyright (c) 2023 MPI-M, Clara Bayley
  *
  * ----- CLEO -----
@@ -24,12 +45,11 @@
 #ifndef LIBS_GRIDBOXES_PREDCORRMOTION_HPP_
 #define LIBS_GRIDBOXES_PREDCORRMOTION_HPP_
 
+#include <Kokkos_Core.hpp>
 #include <cassert>
 #include <functional>
 
-#include <Kokkos_Core.hpp>
-
-#include "./predcorr.hpp"
+#include "gridboxes/predcorr.hpp"
 #include "superdrops/superdrop.hpp"
 #include "superdrops/terminalvelocity.hpp"
 

--- a/libs/gridboxes/supersingbx.hpp
+++ b/libs/gridboxes/supersingbx.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 1st May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -26,7 +26,7 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_StdAlgorithms.hpp>
 
-#include "./findrefs.hpp"
+#include "gridboxes/findrefs.hpp"
 #include "superdrops/kokkosaliases_sd.hpp"
 
 /* References to identify the chunk of memory

--- a/libs/initialise/CMakeLists.txt
+++ b/libs/initialise/CMakeLists.txt
@@ -25,7 +25,7 @@ set(SOURCES
 add_library("${LIBNAME}" STATIC ${SOURCES})
 
 # Add directories for target library
-target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+#target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(${LIBNAME} PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # Link libraries to target library

--- a/libs/initialise/config.hpp
+++ b/libs/initialise/config.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Sunday 16th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,9 +28,9 @@
 #include <string>
 #include <vector>
 
-#include "./copyfiles2txt.hpp"
-#include "./optional_config_params.hpp"
-#include "./required_config_params.hpp"
+#include "initialise/copyfiles2txt.hpp"
+#include "initialise/optional_config_params.hpp"
+#include "initialise/required_config_params.hpp"
 
 /**
  * @brief Struct storing configuration parameters read from a YAML file.

--- a/libs/initialise/init_all_supers_from_binary.hpp
+++ b/libs/initialise/init_all_supers_from_binary.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Saturday 15th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -32,9 +32,9 @@
 #include <string_view>
 #include <vector>
 
-#include "./initialconditions.hpp"
-#include "./optional_config_params.hpp"
-#include "./readbinary.hpp"
+#include "initialise/initialconditions.hpp"
+#include "initialise/optional_config_params.hpp"
+#include "initialise/readbinary.hpp"
 #include "superdrops/superdrop.hpp"
 
 /* check all the vectors in the initdata struct all have sizes consistent with one another

--- a/libs/initialise/init_supers_from_binary.hpp
+++ b/libs/initialise/init_supers_from_binary.hpp
@@ -29,10 +29,10 @@
 #include <string>
 #include <vector>
 
+#include "initialise/init_all_supers_from_binary.hpp"
 #include "initialise/initialconditions.hpp"
 #include "initialise/optional_config_params.hpp"
 #include "initialise/readbinary.hpp"
-#include "initialisse/init_all_supers_from_binary.hpp"
 #include "superdrops/superdrop.hpp"
 
 /* struct containing functions which return data for the initial conditions needed to create

--- a/libs/initialise/init_supers_from_binary.hpp
+++ b/libs/initialise/init_supers_from_binary.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 19th April 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -29,10 +29,10 @@
 #include <string>
 #include <vector>
 
-#include "./init_all_supers_from_binary.hpp"
-#include "./initialconditions.hpp"
-#include "./optional_config_params.hpp"
-#include "./readbinary.hpp"
+#include "initialise/initialconditions.hpp"
+#include "initialise/optional_config_params.hpp"
+#include "initialise/readbinary.hpp"
+#include "initialisse/init_all_supers_from_binary.hpp"
 #include "superdrops/superdrop.hpp"
 
 /* struct containing functions which return data for the initial conditions needed to create

--- a/libs/initialise/timesteps.hpp
+++ b/libs/initialise/timesteps.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 17th April 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -30,7 +30,7 @@
 #include <string>
 
 #include "../cleoconstants.hpp"
-#include "./required_config_params.hpp"
+#include "initialise/required_config_params.hpp"
 
 namespace dlc = dimless_constants;
 

--- a/libs/observers/CMakeLists.txt
+++ b/libs/observers/CMakeLists.txt
@@ -22,7 +22,7 @@ set(SOURCES
 add_library("${LIBNAME}" STATIC ${SOURCES})
 
 # Add directories for target library
-target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+#target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(${LIBNAME} PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # Link libraries to target library

--- a/libs/observers/create_massmoments_arrays.hpp
+++ b/libs/observers/create_massmoments_arrays.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Tuesday 28th May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -29,11 +29,11 @@
 
 #include "../cleoconstants.hpp"
 #include "../kokkosaliases.hpp"
-#include "./collect_data_for_dataset.hpp"
-#include "./generic_collect_data.hpp"
-#include "./observers.hpp"
-#include "./write_to_dataset_observer.hpp"
 #include "gridboxes/gridbox.hpp"
+#include "observers/collect_data_for_dataset.hpp"
+#include "observers/generic_collect_data.hpp"
+#include "observers/observers.hpp"
+#include "observers/write_to_dataset_observer.hpp"
 #include "superdrops/superdrop.hpp"
 #include "zarr/dataset.hpp"
 

--- a/libs/observers/gbxindex_observer.hpp
+++ b/libs/observers/gbxindex_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Saturday 25th May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,8 +28,8 @@
 #include <memory>
 
 #include "../kokkosaliases.hpp"
-#include "./observers.hpp"
 #include "gridboxes/gridbox.hpp"
+#include "observers/observers.hpp"
 #include "superdrops/sdmmonitor.hpp"
 #include "zarr/buffer.hpp"
 #include "zarr/dataset.hpp"

--- a/libs/observers/massmoments_observer.cpp
+++ b/libs/observers/massmoments_observer.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Thursday 6th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License

--- a/libs/observers/massmoments_observer.hpp
+++ b/libs/observers/massmoments_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Thursday 6th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -29,12 +29,12 @@
 
 #include "../cleoconstants.hpp"
 #include "../kokkosaliases.hpp"
-#include "./collect_data_for_dataset.hpp"
-#include "./create_massmoments_arrays.hpp"
-#include "./generic_collect_data.hpp"
-#include "./observers.hpp"
-#include "./write_to_dataset_observer.hpp"
 #include "gridboxes/gridbox.hpp"
+#include "observers/collect_data_for_dataset.hpp"
+#include "observers/create_massmoments_arrays.hpp"
+#include "observers/generic_collect_data.hpp"
+#include "observers/observers.hpp"
+#include "observers/write_to_dataset_observer.hpp"
 #include "superdrops/superdrop.hpp"
 #include "zarr/dataset.hpp"
 

--- a/libs/observers/nsupers_observer.hpp
+++ b/libs/observers/nsupers_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 22nd May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -32,10 +32,10 @@
 
 #include "../cleoconstants.hpp"
 #include "../kokkosaliases.hpp"
-#include "./collect_data_for_dataset.hpp"
-#include "./generic_collect_data.hpp"
-#include "./write_to_dataset_observer.hpp"
 #include "gridboxes/gridbox.hpp"
+#include "observers/collect_data_for_dataset.hpp"
+#include "observers/generic_collect_data.hpp"
+#include "observers/write_to_dataset_observer.hpp"
 #include "zarr/dataset.hpp"
 
 /**

--- a/libs/observers/sdmmonitor/CMakeLists.txt
+++ b/libs/observers/sdmmonitor/CMakeLists.txt
@@ -24,7 +24,6 @@ target_include_directories(${LIBNAME} PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO
 # Link libraries to target library
 set(LINKLIBS zarr)
 target_link_libraries(${LIBNAME} PUBLIC "${LINKLIBS}")
-target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(${LIBNAME} PUBLIC Kokkos::kokkos)
 
 # set specific C++ compiler options for target (optional)

--- a/libs/observers/sdmmonitor/CMakeLists.txt
+++ b/libs/observers/sdmmonitor/CMakeLists.txt
@@ -18,7 +18,7 @@ set(SOURCES
 add_library("${LIBNAME}" STATIC ${SOURCES})
 
 # Add directories for target library
-target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+#target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(${LIBNAME} PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # Link libraries to target library

--- a/libs/observers/sdmmonitor/monitor_condensation_observer.cpp
+++ b/libs/observers/sdmmonitor/monitor_condensation_observer.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Thursday 6th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License

--- a/libs/observers/sdmmonitor/monitor_condensation_observer.hpp
+++ b/libs/observers/sdmmonitor/monitor_condensation_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Saturday 15th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,9 +28,9 @@
 #include <memory>
 
 #include "../../kokkosaliases.hpp"
-#include "../consttstep_observer.hpp"
-#include "../observers.hpp"
-#include "./do_sdmmonitor_obs.hpp"
+#include "observers/consttstep_observer.hpp"
+#include "observers/observers.hpp"
+#include "sdmmonitor/do_sdmmonitor_obs.hpp"
 
 /* struct satisfies SDMMonitor concept for use in do_sdmmonitor_obs to make observer */
 struct MonitorCondensation {

--- a/libs/observers/sdmmonitor/monitor_condensation_observer.hpp
+++ b/libs/observers/sdmmonitor/monitor_condensation_observer.hpp
@@ -30,7 +30,7 @@
 #include "../../kokkosaliases.hpp"
 #include "observers/consttstep_observer.hpp"
 #include "observers/observers.hpp"
-#include "sdmmonitor/do_sdmmonitor_obs.hpp"
+#include "observers/sdmmonitor/do_sdmmonitor_obs.hpp"
 
 /* struct satisfies SDMMonitor concept for use in do_sdmmonitor_obs to make observer */
 struct MonitorCondensation {

--- a/libs/observers/sdmmonitor/monitor_massmoments.hpp
+++ b/libs/observers/sdmmonitor/monitor_massmoments.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Saturday 15th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -29,7 +29,7 @@
 #include <memory>
 
 #include "../../kokkosaliases.hpp"
-#include "../massmoments_observer.hpp"
+#include "observers/massmoments_observer.hpp"
 #include "zarr/buffer.hpp"
 
 struct MonitorMassMomentViews {

--- a/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
+++ b/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
@@ -32,7 +32,7 @@
 #include "observers/consttstep_observer.hpp"
 #include "observers/create_massmoments_arrays.hpp"
 #include "observers/observers.hpp"
-#include "sdmmonitor/monitor_massmoments.hpp"
+#include "observers/sdmmonitor/monitor_massmoments.hpp"
 #include "superdrops/sdmmonitor.hpp"
 #include "zarr/buffer.hpp"
 #include "zarr/dataset.hpp"

--- a/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
+++ b/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Saturday 15th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -29,10 +29,10 @@
 #include <memory>
 
 #include "../../kokkosaliases.hpp"
-#include "../consttstep_observer.hpp"
-#include "../create_massmoments_arrays.hpp"
-#include "../observers.hpp"
-#include "./monitor_massmoments.hpp"
+#include "observers/consttstep_observer.hpp"
+#include "observers/create_massmoments_arrays.hpp"
+#include "observers/observers.hpp"
+#include "sdmmonitor/monitor_massmoments.hpp"
 #include "superdrops/sdmmonitor.hpp"
 #include "zarr/buffer.hpp"
 #include "zarr/dataset.hpp"

--- a/libs/observers/state_observer.hpp
+++ b/libs/observers/state_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 17th April 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -32,12 +32,12 @@
 
 #include "../cleoconstants.hpp"
 #include "../kokkosaliases.hpp"
-#include "./collect_data_for_dataset.hpp"
-#include "./generic_collect_data.hpp"
-#include "./thermo_observer.hpp"
-#include "./windvel_observer.hpp"
-#include "./write_to_dataset_observer.hpp"
 #include "gridboxes/gridbox.hpp"
+#include "observers/collect_data_for_dataset.hpp"
+#include "observers/generic_collect_data.hpp"
+#include "observers/thermo_observer.hpp"
+#include "observers/windvel_observer.hpp"
+#include "observers/write_to_dataset_observer.hpp"
 #include "zarr/dataset.hpp"
 
 /**

--- a/libs/observers/superdrops_observer.hpp
+++ b/libs/observers/superdrops_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 22nd May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -33,9 +33,9 @@
 
 #include "../cleoconstants.hpp"
 #include "../kokkosaliases.hpp"
-#include "./collect_data_for_dataset.hpp"
-#include "./generic_collect_data.hpp"
-#include "./write_to_dataset_observer.hpp"
+#include "observers/collect_data_for_dataset.hpp"
+#include "observers/generic_collect_data.hpp"
+#include "observers/write_to_dataset_observer.hpp"
 #include "superdrops/superdrop.hpp"
 #include "zarr/dataset.hpp"
 

--- a/libs/observers/thermo_observer.hpp
+++ b/libs/observers/thermo_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Saturday 15th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -32,10 +32,10 @@
 
 #include "../cleoconstants.hpp"
 #include "../kokkosaliases.hpp"
-#include "./collect_data_for_dataset.hpp"
-#include "./generic_collect_data.hpp"
-#include "./write_to_dataset_observer.hpp"
 #include "gridboxes/gridbox.hpp"
+#include "observers/collect_data_for_dataset.hpp"
+#include "observers/generic_collect_data.hpp"
+#include "observers/write_to_dataset_observer.hpp"
 #include "zarr/dataset.hpp"
 
 /**

--- a/libs/observers/time_observer.hpp
+++ b/libs/observers/time_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Saturday 25th May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -32,9 +32,9 @@
 #include <utility>
 
 #include "../kokkosaliases.hpp"
-#include "./consttstep_observer.hpp"
-#include "./observers.hpp"
 #include "gridboxes/gridbox.hpp"
+#include "observers/consttstep_observer.hpp"
+#include "observers/observers.hpp"
 #include "superdrops/sdmmonitor.hpp"
 #include "zarr/dataset.hpp"
 #include "zarr/xarray_zarr_array.hpp"

--- a/libs/observers/totnsupers_observer.hpp
+++ b/libs/observers/totnsupers_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Saturday 15th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -29,9 +29,9 @@
 #include <memory>
 
 #include "../kokkosaliases.hpp"
-#include "./consttstep_observer.hpp"
-#include "./observers.hpp"
 #include "gridboxes/gridbox.hpp"
+#include "observers/consttstep_observer.hpp"
+#include "observers/observers.hpp"
 #include "superdrops/sdmmonitor.hpp"
 #include "zarr/buffer.hpp"
 #include "zarr/dataset.hpp"

--- a/libs/observers/windvel_observer.hpp
+++ b/libs/observers/windvel_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Saturday 15th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -32,10 +32,10 @@
 
 #include "../cleoconstants.hpp"
 #include "../kokkosaliases.hpp"
-#include "./collect_data_for_dataset.hpp"
-#include "./generic_collect_data.hpp"
-#include "./write_to_dataset_observer.hpp"
 #include "gridboxes/gridbox.hpp"
+#include "observers/collect_data_for_dataset.hpp"
+#include "observers/generic_collect_data.hpp"
+#include "observers/write_to_dataset_observer.hpp"
 #include "zarr/dataset.hpp"
 
 /**

--- a/libs/observers/write_to_dataset_observer.hpp
+++ b/libs/observers/write_to_dataset_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Saturday 25th May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,10 +28,10 @@
 #include <iostream>
 
 #include "../kokkosaliases.hpp"
-#include "./collect_data_for_dataset.hpp"
-#include "./consttstep_observer.hpp"
-#include "./observers.hpp"
-#include "./parallel_write_data.hpp"
+#include "observers/collect_data_for_dataset.hpp"
+#include "observers/consttstep_observer.hpp"
+#include "observers/observers.hpp"
+#include "observers/parallel_write_data.hpp"
 #include "superdrops/sdmmonitor.hpp"
 #include "zarr/dataset.hpp"
 

--- a/libs/runcleo/CMakeLists.txt
+++ b/libs/runcleo/CMakeLists.txt
@@ -20,7 +20,7 @@ set(SOURCES
 add_library("${LIBNAME}" STATIC ${SOURCES})
 
 # Add directories for target library
-target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+#target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(${LIBNAME} PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # Link libraries to target library

--- a/libs/runcleo/couplingcomms.hpp
+++ b/libs/runcleo/couplingcomms.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Thursday 8th February 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -27,7 +27,7 @@
 #include <concepts>
 
 #include "../kokkosaliases.hpp"
-#include "./coupleddynamics.hpp"
+#include "runcleo/coupleddynamics.hpp"
 
 /**
  * @concept CouplingComms
@@ -43,11 +43,10 @@
  * @tparam CD The type for the dyanmics solver to check against the CoupledDynamics concept.
  */
 template <typename Comms, typename CD>
-concept CouplingComms =
-    requires(Comms s, CD &coupldyn, viewh_gbx h_gbxs) {
-      { s.template send_dynamics<CD>(h_gbxs, coupldyn) } -> std::same_as<void>;
-      { s.template receive_dynamics<CD>(coupldyn, h_gbxs) } -> std::same_as<void>;
-    };
+concept CouplingComms = requires(Comms s, CD &coupldyn, viewh_gbx h_gbxs) {
+  { s.template send_dynamics<CD>(h_gbxs, coupldyn) } -> std::same_as<void>;
+  { s.template receive_dynamics<CD>(coupldyn, h_gbxs) } -> std::same_as<void>;
+};
 
 /**
  * @struct NullComms

--- a/libs/runcleo/runcleo.hpp
+++ b/libs/runcleo/runcleo.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors: Tobias Kölling (TK)
  * -----
- * Last Modified: Wednesday 8th May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -31,16 +31,16 @@
 #include <string>
 
 #include "../kokkosaliases.hpp"
-#include "./coupleddynamics.hpp"
-#include "./couplingcomms.hpp"
-#include "./creategbxs.hpp"
-#include "./createsupers.hpp"
-#include "./sdmmethods.hpp"
 #include "gridboxes/gridbox.hpp"
 #include "gridboxes/gridboxmaps.hpp"
 #include "gridboxes/movesupersindomain.hpp"
 #include "initialise/initialconditions.hpp"
 #include "observers/observers.hpp"
+#include "runcleo/coupleddynamics.hpp"
+#include "runcleo/couplingcomms.hpp"
+#include "runcleo/creategbxs.hpp"
+#include "runcleo/createsupers.hpp"
+#include "runcleo/sdmmethods.hpp"
 #include "superdrops/microphysicalprocess.hpp"
 #include "superdrops/motion.hpp"
 #include "superdrops/superdrop.hpp"

--- a/libs/superdrops/CMakeLists.txt
+++ b/libs/superdrops/CMakeLists.txt
@@ -7,8 +7,6 @@ endif()
 set(LIBNAME "superdrops")
 message("${LIBNAME} LIBRARY_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
 
-add_subdirectory(collisions)
-
 # explicitly set library executables path to /lib in top level of build tree
 set(LIBRARY_OUTPUT_PATH  ${CMAKE_BINARY_DIR}/lib)
 
@@ -25,10 +23,10 @@ set(SOURCES
 add_library("${LIBNAME}" STATIC ${SOURCES})
 
 # Add directories and link libraries for target library
+# target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 set(LINKLIBS collisions)
 target_link_libraries(${LIBNAME} PUBLIC "${LINKLIBS}")
 target_link_libraries(${LIBNAME} PUBLIC Kokkos::kokkos)
-target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(${LIBNAME} PRIVATE)
@@ -38,3 +36,5 @@ set_target_properties(${LIBNAME} PROPERTIES
   CMAKE_CXX_STANDARD_REQUIRED ON
   CMAKE_CXX_EXTENSIONS ON
   CXX_STANDARD 20)
+
+add_subdirectory(collisions)

--- a/libs/superdrops/collisions/CMakeLists.txt
+++ b/libs/superdrops/collisions/CMakeLists.txt
@@ -23,7 +23,6 @@ set(SOURCES
 add_library("${LIBNAME}" STATIC ${SOURCES})
 
 # Add directories and link libraries for target library
-target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(${LIBNAME} PUBLIC Kokkos::kokkos)
 
 # set specific C++ compiler options for target (optional)

--- a/libs/superdrops/collisions/breakup.hpp
+++ b/libs/superdrops/collisions/breakup.hpp
@@ -29,10 +29,10 @@
 #include <concepts>
 #include <functional>
 
-#include "collisions/breakup_nfrags.hpp"
-#include "collisions/collisions.hpp"
-#include "superdrops/microphysicalprocess.hpp"
-#include "superdrops/superdrop.hpp"
+#include "../microphysicalprocess.hpp"
+#include "../superdrop.hpp"
+#include "./breakup_nfrags.hpp"
+#include "./collisions.hpp"
 
 template <NFragments NFrags>
 struct DoBreakup {

--- a/libs/superdrops/collisions/breakup.hpp
+++ b/libs/superdrops/collisions/breakup.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 17th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -29,10 +29,10 @@
 #include <concepts>
 #include <functional>
 
-#include "../microphysicalprocess.hpp"
-#include "../superdrop.hpp"
-#include "./breakup_nfrags.hpp"
-#include "./collisions.hpp"
+#include "collisions/breakup_nfrags.hpp"
+#include "collisions/collisions.hpp"
+#include "superdrops/microphysicalprocess.hpp"
+#include "superdrops/superdrop.hpp"
 
 template <NFragments NFrags>
 struct DoBreakup {

--- a/libs/superdrops/collisions/breakup_nfrags.hpp
+++ b/libs/superdrops/collisions/breakup_nfrags.hpp
@@ -26,7 +26,7 @@
 #include <Kokkos_Core.hpp>
 #include <concepts>
 
-#include "collisions/collisionkinetics.hpp"
+#include "./collisionkinetics.hpp"
 
 /* Objects that are of type 'NFragments'
 take a pair of superdroplets and returns

--- a/libs/superdrops/collisions/breakup_nfrags.hpp
+++ b/libs/superdrops/collisions/breakup_nfrags.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 11th March 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -20,14 +20,13 @@
  * Used e.g. by the DoBreakup struct.
  */
 
-
 #ifndef LIBS_SUPERDROPS_COLLISIONS_BREAKUP_NFRAGS_HPP_
 #define LIBS_SUPERDROPS_COLLISIONS_BREAKUP_NFRAGS_HPP_
 
-#include <concepts>
 #include <Kokkos_Core.hpp>
+#include <concepts>
 
-#include "./collisionkinetics.hpp"
+#include "collisions/collisionkinetics.hpp"
 
 /* Objects that are of type 'NFragments'
 take a pair of superdroplets and returns
@@ -74,8 +73,8 @@ struct CollisionKineticEnergyNFrags {
   double operator()(const Superdrop &drop1, const Superdrop &drop2) const {
     constexpr double alpha = 1.5;
     constexpr double beta = 0.135;
-    constexpr double ckemax = 16.49789599/1000000;  // [J]
-    constexpr double epsilon = 11.0 / 6.0;  // = 2.5 - 2/3
+    constexpr double ckemax = 16.49789599 / 1000000;  // [J]
+    constexpr double epsilon = 11.0 / 6.0;            // = 2.5 - 2/3
 
     const auto terminalv = RogersGKTerminalVelocity{};
     const auto cke = collision_kinetic_energy(drop1.get_radius(), drop2.get_radius(),
@@ -83,7 +82,7 @@ struct CollisionKineticEnergyNFrags {
 
     const auto cke_cap = double{Kokkos::fmin(ckemax, cke)};  // limit cke to less than ckemax
 
-    const auto gamma = double{Kokkos::pow(cke_cap*1e6, beta)};  // cke converted to micro-Joules
+    const auto gamma = double{Kokkos::pow(cke_cap * 1e6, beta)};  // cke converted to micro-Joules
     const auto nfrags = double{1.0 / (alpha - gamma) + epsilon};
 
     return nfrags;

--- a/libs/superdrops/collisions/coalbure.hpp
+++ b/libs/superdrops/collisions/coalbure.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 17th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -30,14 +30,14 @@
 #include <concepts>
 #include <functional>
 
-#include "../microphysicalprocess.hpp"
-#include "../superdrop.hpp"
-#include "./breakup.hpp"
-#include "./breakup_nfrags.hpp"
-#include "./coalbure_flag.hpp"
-#include "./coalescence.hpp"
-#include "./collisionkinetics.hpp"
-#include "./collisions.hpp"
+#include "collisions/breakup.hpp"
+#include "collisions/breakup_nfrags.hpp"
+#include "collisions/coalbure_flag.hpp"
+#include "collisions/coalescence.hpp"
+#include "collisions/collisionkinetics.hpp"
+#include "collisions/collisions.hpp"
+#include "superdrops/microphysicalprocess.hpp"
+#include "superdrops/superdrop.hpp"
 
 /**
  * @brief DoCoalBuRe = DoCoalescenceBreakupRebound, i.e. enacts collision-coalescence, breakup, or

--- a/libs/superdrops/collisions/coalbure.hpp
+++ b/libs/superdrops/collisions/coalbure.hpp
@@ -30,14 +30,14 @@
 #include <concepts>
 #include <functional>
 
-#include "collisions/breakup.hpp"
-#include "collisions/breakup_nfrags.hpp"
-#include "collisions/coalbure_flag.hpp"
-#include "collisions/coalescence.hpp"
-#include "collisions/collisionkinetics.hpp"
-#include "collisions/collisions.hpp"
-#include "superdrops/microphysicalprocess.hpp"
-#include "superdrops/superdrop.hpp"
+#include "../microphysicalprocess.hpp"
+#include "../superdrop.hpp"
+#include "./breakup.hpp"
+#include "./breakup_nfrags.hpp"
+#include "./coalbure_flag.hpp"
+#include "./coalescence.hpp"
+#include "./collisionkinetics.hpp"
+#include "./collisions.hpp"
 
 /**
  * @brief DoCoalBuRe = DoCoalescenceBreakupRebound, i.e. enacts collision-coalescence, breakup, or

--- a/libs/superdrops/collisions/coalbure_flag.cpp
+++ b/libs/superdrops/collisions/coalbure_flag.cpp
@@ -9,27 +9,26 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 11th March 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
  * https://opensource.org/licenses/BSD-3-Clause
  * -----
  * File Description:
- * functions included in returning a flag used
- * in DoCoalBuRe to decide whether breakup,
- * coalescence or rebound should occur.
+ * functions included in returning a flag used in DoCoalBuRe to decide whether breakup, coalescence
+ * or rebound should occur.
  */
-
 
 #include "./coalbure_flag.hpp"
 
-/*  function returns flag indicating rebound or
-coalescence or breakup. If flag = 1 -> coalescence.
+/*
+function returns flag indicating rebound or coalescence or breakup.
+If flag = 1 -> coalescence.
 If flag = 2 -> breakup. Otherwise -> rebound.
-Flag decided based on the kinetic arguments in
-section 2.2 of Szakáll and Urbich 2018
-(neglecting grazing angle considerations) */
+Flag decided based on the kinetic arguments in section 2.2 of Szakáll and Urbich 2018 (neglecting
+grazing angle considerations)
+*/
 KOKKOS_FUNCTION unsigned int SUCoalBuReFlag::operator()(const Superdrop &drop1,
                                                         const Superdrop &drop2) const {
   const auto r1 = drop1.get_radius();
@@ -37,14 +36,14 @@ KOKKOS_FUNCTION unsigned int SUCoalBuReFlag::operator()(const Superdrop &drop1,
   const auto terminalv = RogersGKTerminalVelocity{};
 
   const auto cke = collision_kinetic_energy(r1, r2, terminalv(drop1),
-                                            terminalv(drop2));   // [J]
+                                            terminalv(drop2));  // [J]
 
-  if (cke < surfenergy(Kokkos::fmin(r1, r2))) {    // cke < surface energy of small drop
-    return 0;   // rebound
-  } else if (cke < coal_surfenergy(r1, r2)) {      // Weber number < 1
-    return 1;   // coalescence
-  } else {                                         // Weber number > 1
-    return 2;   // breakup
+  if (cke < surfenergy(Kokkos::fmin(r1, r2))) {  // cke < surface energy of small drop
+    return 0;                                    // rebound
+  } else if (cke < coal_surfenergy(r1, r2)) {    // Weber number < 1
+    return 1;                                    // coalescence
+  } else {                                       // Weber number > 1
+    return 2;                                    // breakup
   }
 }
 
@@ -54,8 +53,7 @@ If flag = 2 -> breakup. Otherwise -> rebound.
 Flag decided based on the kinetic arguments from
 section 4 of Testik et al. 2011 (figure 12) as well
 as coalescence efficiency from Straub et al. 2010 */
-KOKKOS_FUNCTION unsigned int TSCoalBuReFlag::operator()(const double phi,
-                                                        const Superdrop &drop1,
+KOKKOS_FUNCTION unsigned int TSCoalBuReFlag::operator()(const double phi, const Superdrop &drop1,
                                                         const Superdrop &drop2) const {
   const auto r1 = drop1.get_radius();
   const auto r2 = drop2.get_radius();
@@ -63,12 +61,12 @@ KOKKOS_FUNCTION unsigned int TSCoalBuReFlag::operator()(const double phi,
 
   const auto cke = collision_kinetic_energy(r1, r2, terminalv(drop1), terminalv(drop2));
 
-  if (cke < surfenergy(Kokkos::fmin(r1, r2))) {              // cke < surface energy of small drop
-    return rebound_or_coalescence(drop1, drop2, phi, cke);   // below DE2 boundary
-  } else if (cke < surfenergy(Kokkos::fmax(r1, r2))) {       // cke < surface energy of large drop
-    return coalescence_or_breakup(drop1, drop2, phi, cke);   // below DE1 boundary
-  } else {                                                   // above DE1 boundary
-    return 2;                                                // breakup
+  if (cke < surfenergy(Kokkos::fmin(r1, r2))) {             // cke < surface energy of small drop
+    return rebound_or_coalescence(drop1, drop2, phi, cke);  // below DE2 boundary
+  } else if (cke < surfenergy(Kokkos::fmax(r1, r2))) {      // cke < surface energy of large drop
+    return coalescence_or_breakup(drop1, drop2, phi, cke);  // below DE1 boundary
+  } else {                                                  // above DE1 boundary
+    return 2;                                               // breakup
   }
 }
 
@@ -82,7 +80,7 @@ KOKKOS_FUNCTION double TSCoalBuReFlag::coalescence_efficiency(const Superdrop &d
   constexpr double beta = -1.15;
 
   const auto surf_c = coal_surfenergy(drop1.get_radius(),
-                                      drop2.get_radius());   // [J] S_c
+                                      drop2.get_radius());  // [J] S_c
   const auto weber = double{cke / surf_c};
   const auto ecoal = double{Kokkos::exp(beta * weber)};
 
@@ -92,9 +90,8 @@ KOKKOS_FUNCTION double TSCoalBuReFlag::coalescence_efficiency(const Superdrop &d
 /* returns truw if comparison of random numnber
 with coalescence efficiency from Straub et al. 2010
 indicates coalescence should occur */
-KOKKOS_FUNCTION bool TSCoalBuReFlag::is_coalescence(const Superdrop &drop1,
-                                                    const Superdrop &drop2, const double phi,
-                                                    const double cke) const {
+KOKKOS_FUNCTION bool TSCoalBuReFlag::is_coalescence(const Superdrop &drop1, const Superdrop &drop2,
+                                                    const double phi, const double cke) const {
   const auto ecoal = coalescence_efficiency(drop1, drop2, cke);
 
   if (phi < ecoal) {
@@ -112,9 +109,9 @@ KOKKOS_FUNCTION unsigned int TSCoalBuReFlag::rebound_or_coalescence(const Superd
                                                                     const double phi,
                                                                     const double cke) const {
   if (is_coalescence(drop1, drop2, phi, cke)) {
-    return 1;   // coalescence
+    return 1;  // coalescence
   } else {
-    return 0;   // rebound
+    return 0;  // rebound
   }
 }
 
@@ -126,8 +123,8 @@ KOKKOS_FUNCTION unsigned int TSCoalBuReFlag::coalescence_or_breakup(const Superd
                                                                     const double phi,
                                                                     const double cke) const {
   if (is_coalescence(drop1, drop2, phi, cke)) {
-    return 1;   // coalescence
+    return 1;  // coalescence
   } else {
-    return 2;   // breakup
+    return 2;  // breakup
   }
 }

--- a/libs/superdrops/collisions/coalbure_flag.hpp
+++ b/libs/superdrops/collisions/coalbure_flag.hpp
@@ -29,9 +29,9 @@
 #include <functional>
 #include <random>
 
-#include "collisions/collisionkinetics.hpp"
-#include "superdrops/superdrop.hpp"
-#include "superdrops/terminalvelocity.hpp"
+#include "../superdrop.hpp"
+#include "../terminalvelocity.hpp"
+#include "./collisionkinetics.hpp"
 
 /* operator returns flag indicating rebound or
 coalescence or breakup. If flag = 1 -> coalescence.

--- a/libs/superdrops/collisions/coalbure_flag.hpp
+++ b/libs/superdrops/collisions/coalbure_flag.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 11th March 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -21,28 +21,24 @@
  * coalescence or rebound should occur.
  */
 
-
 #ifndef LIBS_SUPERDROPS_COLLISIONS_COALBURE_FLAG_HPP_
 #define LIBS_SUPERDROPS_COLLISIONS_COALBURE_FLAG_HPP_
 
+#include <Kokkos_Core.hpp>
 #include <concepts>
 #include <functional>
 #include <random>
 
-#include <Kokkos_Core.hpp>
-
-#include "./collisionkinetics.hpp"
-#include "../superdrop.hpp"
-#include "../terminalvelocity.hpp"
+#include "collisions/collisionkinetics.hpp"
+#include "superdrops/superdrop.hpp"
+#include "superdrops/terminalvelocity.hpp"
 
 /* operator returns flag indicating rebound or
 coalescence or breakup. If flag = 1 -> coalescence.
 If flag = 2 -> breakup. Otherwise -> rebound. */
 template <typename F>
 concept CoalBuReFlag = requires(F f, const double phi, const Superdrop &d1, const Superdrop &d2) {
-  {
-    f(phi, d1, d2)
-  } -> std::convertible_to<unsigned int>;
+  { f(phi, d1, d2) } -> std::convertible_to<unsigned int>;
 };
 
 struct SUCoalBuReFlag {
@@ -107,4 +103,4 @@ struct TSCoalBuReFlag {
   unsigned int operator()(const double phi, const Superdrop &drop1, const Superdrop &drop2) const;
 };
 
-#endif   // LIBS_SUPERDROPS_COLLISIONS_COALBURE_FLAG_HPP_
+#endif  // LIBS_SUPERDROPS_COLLISIONS_COALBURE_FLAG_HPP_

--- a/libs/superdrops/collisions/coalescence.hpp
+++ b/libs/superdrops/collisions/coalescence.hpp
@@ -27,9 +27,9 @@
 #include <cassert>
 #include <functional>
 
-#include "collisions/collisions.hpp"
-#include "superdrops/microphysicalprocess.hpp"
-#include "superdrops/superdrop.hpp"
+#include "../microphysicalprocess.hpp"
+#include "../superdrop.hpp"
+#include "./collisions.hpp"
 
 /**
  * @brief Raises an error if the multiplicity of the super-droplet is 0.

--- a/libs/superdrops/collisions/coalescence.hpp
+++ b/libs/superdrops/collisions/coalescence.hpp
@@ -27,9 +27,9 @@
 #include <cassert>
 #include <functional>
 
-#include "../microphysicalprocess.hpp"
-#include "../superdrop.hpp"
-#include "./collisions.hpp"
+#include "collisions/collisions.hpp"
+#include "superdrops/microphysicalprocess.hpp"
+#include "superdrops/superdrop.hpp"
 
 /**
  * @brief Raises an error if the multiplicity of the super-droplet is 0.

--- a/libs/superdrops/collisions/collisionkinetics.cpp
+++ b/libs/superdrops/collisions/collisionkinetics.cpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Sunday 21st April 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License

--- a/libs/superdrops/collisions/collisionkinetics.hpp
+++ b/libs/superdrops/collisions/collisionkinetics.hpp
@@ -25,8 +25,8 @@
 #include <Kokkos_Core.hpp>
 
 #include "../../cleoconstants.hpp"
-#include "superdrops/superdrop.hpp"
-#include "superdrops/terminalvelocity.hpp"
+#include "../superdrop.hpp"
+#include "../terminalvelocity.hpp"
 
 namespace dlc = dimless_constants;
 namespace DC = dimmed_constants;

--- a/libs/superdrops/collisions/collisionkinetics.hpp
+++ b/libs/superdrops/collisions/collisionkinetics.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Sunday 21st April 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -25,8 +25,8 @@
 #include <Kokkos_Core.hpp>
 
 #include "../../cleoconstants.hpp"
-#include "../superdrop.hpp"
-#include "../terminalvelocity.hpp"
+#include "superdrops/superdrop.hpp"
+#include "superdrops/terminalvelocity.hpp"
 
 namespace dlc = dimless_constants;
 namespace DC = dimmed_constants;

--- a/libs/superdrops/collisions/collisions.hpp
+++ b/libs/superdrops/collisions/collisions.hpp
@@ -28,11 +28,11 @@
 #include <random>
 
 #include "../../cleoconstants.hpp"
-#include "superdrops/kokkosaliases_sd.hpp"
-#include "superdrops/sdmmonitor.hpp"
-#include "superdrops/state.hpp"
-#include "superdrops/superdrop.hpp"
-#include "superdrops/urbg.hpp"
+#include "../kokkosaliases_sd.hpp"
+#include "../sdmmonitor.hpp"
+#include "../state.hpp"
+#include "../superdrop.hpp"
+#include "../urbg.hpp"
 
 namespace dlc = dimless_constants;
 

--- a/libs/superdrops/collisions/collisions.hpp
+++ b/libs/superdrops/collisions/collisions.hpp
@@ -28,11 +28,11 @@
 #include <random>
 
 #include "../../cleoconstants.hpp"
-#include "../kokkosaliases_sd.hpp"
-#include "../sdmmonitor.hpp"
-#include "../state.hpp"
-#include "../superdrop.hpp"
-#include "../urbg.hpp"
+#include "superdrops/kokkosaliases_sd.hpp"
+#include "superdrops/sdmmonitor.hpp"
+#include "superdrops/state.hpp"
+#include "superdrops/superdrop.hpp"
+#include "superdrops/urbg.hpp"
 
 namespace dlc = dimless_constants;
 

--- a/libs/superdrops/collisions/constprob.hpp
+++ b/libs/superdrops/collisions/constprob.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 11th March 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -21,13 +21,12 @@
  * (see collisions.hpp)
  */
 
-
 #ifndef LIBS_SUPERDROPS_COLLISIONS_CONSTPROB_HPP_
 #define LIBS_SUPERDROPS_COLLISIONS_CONSTPROB_HPP_
 
 #include <Kokkos_Core.hpp>
 
-#include "../superdrop.hpp"
+#include "superdrops/superdrop.hpp"
 
 /* Probability of collision of a pair of droplets
 as formulated in Shima et al. 2009 equation 3,

--- a/libs/superdrops/collisions/constprob.hpp
+++ b/libs/superdrops/collisions/constprob.hpp
@@ -26,7 +26,7 @@
 
 #include <Kokkos_Core.hpp>
 
-#include "superdrops/superdrop.hpp"
+#include "../superdrop.hpp"
 
 /* Probability of collision of a pair of droplets
 as formulated in Shima et al. 2009 equation 3,

--- a/libs/superdrops/collisions/golovinprob.cpp
+++ b/libs/superdrops/collisions/golovinprob.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 11th March 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -23,7 +23,6 @@
  * that satisfy the requirements of the
  * PairProbability concept (see collisions.hpp)
  */
-
 
 #include "./golovinprob.hpp"
 

--- a/libs/superdrops/collisions/golovinprob.hpp
+++ b/libs/superdrops/collisions/golovinprob.hpp
@@ -28,7 +28,7 @@
 #define LIBS_SUPERDROPS_COLLISIONS_GOLOVINPROB_HPP_
 
 #include "../../cleoconstants.hpp"
-#include "superdrops/superdrop.hpp"
+#include "../superdrop.hpp"
 
 namespace dlc = dimless_constants;
 

--- a/libs/superdrops/collisions/golovinprob.hpp
+++ b/libs/superdrops/collisions/golovinprob.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 11th March 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -24,12 +24,11 @@
  * PairProbability concept (see collisions.hpp)
  */
 
-
 #ifndef LIBS_SUPERDROPS_COLLISIONS_GOLOVINPROB_HPP_
 #define LIBS_SUPERDROPS_COLLISIONS_GOLOVINPROB_HPP_
 
 #include "../../cleoconstants.hpp"
-#include "../superdrop.hpp"
+#include "superdrops/superdrop.hpp"
 
 namespace dlc = dimless_constants;
 

--- a/libs/superdrops/collisions/hydrodynamicprob.hpp
+++ b/libs/superdrops/collisions/hydrodynamicprob.hpp
@@ -26,8 +26,8 @@
 #include <Kokkos_Core.hpp>
 
 #include "../../cleoconstants.hpp"
-#include "superdrops/superdrop.hpp"
-#include "superdrops/terminalvelocity.hpp"
+#include "../superdrop.hpp"
+#include "../terminalvelocity.hpp"
 
 namespace dlc = dimless_constants;
 

--- a/libs/superdrops/collisions/hydrodynamicprob.hpp
+++ b/libs/superdrops/collisions/hydrodynamicprob.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 11th March 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -20,15 +20,14 @@
  * using the hydrodynamic (i.e. gravitational) kernel
  */
 
-
 #ifndef LIBS_SUPERDROPS_COLLISIONS_HYDRODYNAMICPROB_HPP_
 #define LIBS_SUPERDROPS_COLLISIONS_HYDRODYNAMICPROB_HPP_
 
 #include <Kokkos_Core.hpp>
 
 #include "../../cleoconstants.hpp"
-#include "../superdrop.hpp"
-#include "../terminalvelocity.hpp"
+#include "superdrops/superdrop.hpp"
+#include "superdrops/terminalvelocity.hpp"
 
 namespace dlc = dimless_constants;
 

--- a/libs/superdrops/collisions/longhydroprob.cpp
+++ b/libs/superdrops/collisions/longhydroprob.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 11th March 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -21,7 +21,6 @@
  * of Long's Hydrodynamic Kernel. Probability calculations are contained in structures
  * that satisfy the requirements of the PairProbability concept (see collisions.hpp)
  */
-
 
 #include "./longhydroprob.hpp"
 

--- a/libs/superdrops/collisions/longhydroprob.hpp
+++ b/libs/superdrops/collisions/longhydroprob.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 11th March 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -22,16 +22,15 @@
  * that satisfy the requirements of the PairProbability concept (see collisions.hpp)
  */
 
-
 #ifndef LIBS_SUPERDROPS_COLLISIONS_LONGHYDROPROB_HPP_
 #define LIBS_SUPERDROPS_COLLISIONS_LONGHYDROPROB_HPP_
 
 #include <Kokkos_Core.hpp>
 
 #include "../../cleoconstants.hpp"
-#include "../superdrop.hpp"
-#include "../terminalvelocity.hpp"
-#include "./hydrodynamicprob.hpp"
+#include "collisions/hydrodynamicprob.hpp"
+#include "superdrops/superdrop.hpp"
+#include "superdrops/terminalvelocity.hpp"
 
 namespace dlc = dimless_constants;
 

--- a/libs/superdrops/collisions/longhydroprob.hpp
+++ b/libs/superdrops/collisions/longhydroprob.hpp
@@ -28,9 +28,9 @@
 #include <Kokkos_Core.hpp>
 
 #include "../../cleoconstants.hpp"
-#include "collisions/hydrodynamicprob.hpp"
-#include "superdrops/superdrop.hpp"
-#include "superdrops/terminalvelocity.hpp"
+#include "../superdrop.hpp"
+#include "../terminalvelocity.hpp"
+#include "./hydrodynamicprob.hpp"
 
 namespace dlc = dimless_constants;
 

--- a/libs/superdrops/collisions/lowlistprob.cpp
+++ b/libs/superdrops/collisions/lowlistprob.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 11th March 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -20,7 +20,6 @@
  * and List . Calculations is contained in structure that satisfies the requirements of the
  * PairProbability concept (see collisions.hpp)
  */
-
 
 #include "./lowlistprob.hpp"
 

--- a/libs/superdrops/collisions/lowlistprob.hpp
+++ b/libs/superdrops/collisions/lowlistprob.hpp
@@ -26,9 +26,9 @@
 
 #include <Kokkos_Core.hpp>
 
-#include "collisions/collisionkinetics.hpp"
-#include "collisions/longhydroprob.hpp"
-#include "superdrops/superdrop.hpp"
+#include "../superdrop.hpp"
+#include "./collisionkinetics.hpp"
+#include "./longhydroprob.hpp"
 
 /* Probability of collision-coalescence of a pair of
 droplets as formulated in Shima et al. 2009 equation 3,

--- a/libs/superdrops/collisions/lowlistprob.hpp
+++ b/libs/superdrops/collisions/lowlistprob.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 11th March 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -21,15 +21,14 @@
  * concept (see collisions.hpp)
  */
 
-
 #ifndef LIBS_SUPERDROPS_COLLISIONS_LOWLISTPROB_HPP_
 #define LIBS_SUPERDROPS_COLLISIONS_LOWLISTPROB_HPP_
 
 #include <Kokkos_Core.hpp>
 
-#include "./collisionkinetics.hpp"
-#include "./longhydroprob.hpp"
-#include "../superdrop.hpp"
+#include "collisions/collisionkinetics.hpp"
+#include "collisions/longhydroprob.hpp"
+#include "superdrops/superdrop.hpp"
 
 /* Probability of collision-coalescence of a pair of
 droplets as formulated in Shima et al. 2009 equation 3,

--- a/libs/superdrops/condensation.cpp
+++ b/libs/superdrops/condensation.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Saturday 25th May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License

--- a/libs/superdrops/condensation.cpp
+++ b/libs/superdrops/condensation.cpp
@@ -20,7 +20,7 @@
  * microphysical process in SDM
  */
 
-#include "./condensation.hpp"
+#include "condensation.hpp"
 
 /**
  * @brief Changes super-droplet radii according to condensation / evaporation and returns the

--- a/libs/superdrops/condensation.hpp
+++ b/libs/superdrops/condensation.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors: Shin-ichiro Shima (SiS)
  * -----
- * Last Modified: Tuesday 18th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -30,13 +30,13 @@
 #include <concepts>
 
 #include "../cleoconstants.hpp"
-#include "./impliciteuler.hpp"
-#include "./kokkosaliases_sd.hpp"
-#include "./microphysicalprocess.hpp"
-#include "./sdmmonitor.hpp"
-#include "./state.hpp"
-#include "./superdrop.hpp"
-#include "./thermodynamic_equations.hpp"
+#include "superdrops/impliciteuler.hpp"
+#include "superdrops/kokkosaliases_sd.hpp"
+#include "superdrops/microphysicalprocess.hpp"
+#include "superdrops/sdmmonitor.hpp"
+#include "superdrops/state.hpp"
+#include "superdrops/superdrop.hpp"
+#include "superdrops/thermodynamic_equations.hpp"
 
 namespace dlc = dimless_constants;
 

--- a/libs/superdrops/condensation.hpp
+++ b/libs/superdrops/condensation.hpp
@@ -30,13 +30,13 @@
 #include <concepts>
 
 #include "../cleoconstants.hpp"
-#include "superdrops/impliciteuler.hpp"
-#include "superdrops/kokkosaliases_sd.hpp"
-#include "superdrops/microphysicalprocess.hpp"
-#include "superdrops/sdmmonitor.hpp"
-#include "superdrops/state.hpp"
-#include "superdrops/superdrop.hpp"
-#include "superdrops/thermodynamic_equations.hpp"
+#include "impliciteuler.hpp"
+#include "kokkosaliases_sd.hpp"
+#include "microphysicalprocess.hpp"
+#include "sdmmonitor.hpp"
+#include "state.hpp"
+#include "superdrop.hpp"
+#include "thermodynamic_equations.hpp"
 
 namespace dlc = dimless_constants;
 

--- a/libs/superdrops/impliciteuler.cpp
+++ b/libs/superdrops/impliciteuler.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Tuesday 18th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License

--- a/libs/superdrops/impliciteuler.cpp
+++ b/libs/superdrops/impliciteuler.cpp
@@ -22,7 +22,7 @@
  * Luond and Mahrt, 1st edition." and Shima et al. 2009
  */
 
-#include "./impliciteuler.hpp"
+#include "impliciteuler.hpp"
 
 /**
  * @brief Integrates the condensation / evaporation ODE employing the Implicit Euler method

--- a/libs/superdrops/kokkosaliases_sd.hpp
+++ b/libs/superdrops/kokkosaliases_sd.hpp
@@ -27,7 +27,7 @@
 #include <Kokkos_Pair.hpp>
 #include <Kokkos_Random.hpp>
 
-#include "superdrops/superdrop.hpp"
+#include "superdrop.hpp"
 
 /* Defines aliases for the (default Kokkos) execution spaces and memory spaces for parallelism. */
 using ExecSpace =

--- a/libs/superdrops/kokkosaliases_sd.hpp
+++ b/libs/superdrops/kokkosaliases_sd.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Sunday 21st April 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -27,7 +27,7 @@
 #include <Kokkos_Pair.hpp>
 #include <Kokkos_Random.hpp>
 
-#include "./superdrop.hpp"
+#include "superdrops/superdrop.hpp"
 
 /* Defines aliases for the (default Kokkos) execution spaces and memory spaces for parallelism. */
 using ExecSpace =

--- a/libs/superdrops/microphysicalprocess.hpp
+++ b/libs/superdrops/microphysicalprocess.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors: Tobias Kölling (TK)
  * -----
- * Last Modified: Saturday 25th May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,10 +28,10 @@
 #include <concepts>
 
 #include "../cleoconstants.hpp"
-#include "./kokkosaliases_sd.hpp"
-#include "./sdmmonitor.hpp"
-#include "./state.hpp"
-#include "./superdrop.hpp"
+#include "superdrops/kokkosaliases_sd.hpp"
+#include "superdrops/sdmmonitor.hpp"
+#include "superdrops/state.hpp"
+#include "superdrops/superdrop.hpp"
 
 /**
  * @brief Concept of a microphysical process.

--- a/libs/superdrops/microphysicalprocess.hpp
+++ b/libs/superdrops/microphysicalprocess.hpp
@@ -28,10 +28,10 @@
 #include <concepts>
 
 #include "../cleoconstants.hpp"
-#include "superdrops/kokkosaliases_sd.hpp"
-#include "superdrops/sdmmonitor.hpp"
-#include "superdrops/state.hpp"
-#include "superdrops/superdrop.hpp"
+#include "kokkosaliases_sd.hpp"
+#include "sdmmonitor.hpp"
+#include "state.hpp"
+#include "superdrop.hpp"
 
 /**
  * @brief Concept of a microphysical process.

--- a/libs/superdrops/motion.hpp
+++ b/libs/superdrops/motion.hpp
@@ -1,4 +1,6 @@
-/* Copyright (c) 2023 MPI-M, Clara Bayley
+/*
+ * Copyright (c) 2024 MPI-M, Clara Bayley
+ *
  *
  * ----- CLEO -----
  * File: motion.hpp
@@ -7,15 +9,14 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Tuesday 19th December 2023
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
  * https://opensource.org/licenses/BSD-3-Clause
  * -----
  * File Description:
- * concept for motion of superdroplets
- * by changing their spatial coordinates
+ * concept for motion of superdroplets by changing their spatial coordinates
  */
 
 #ifndef LIBS_SUPERDROPS_MOTION_HPP_
@@ -24,8 +25,8 @@
 #include <concepts>
 
 #include "../cleoconstants.hpp"
-#include "./state.hpp"
-#include "./superdrop.hpp"
+#include "superdrops/state.hpp"
+#include "superdrops/superdrop.hpp"
 
 /* concept for superdrop motion is all types that
 meet requirements (constraints) of these two timstepping

--- a/libs/superdrops/motion.hpp
+++ b/libs/superdrops/motion.hpp
@@ -25,8 +25,8 @@
 #include <concepts>
 
 #include "../cleoconstants.hpp"
-#include "superdrops/state.hpp"
-#include "superdrops/superdrop.hpp"
+#include "state.hpp"
+#include "superdrop.hpp"
 
 /* concept for superdrop motion is all types that
 meet requirements (constraints) of these two timstepping

--- a/libs/superdrops/sdmmonitor.hpp
+++ b/libs/superdrops/sdmmonitor.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Thursday 6th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -24,7 +24,7 @@
 
 #include <concepts>
 
-#include "./kokkosaliases_sd.hpp"
+#include "kokkosaliases_sd.hpp"
 
 /**
  * @brief Concept of SDMmonitor to monitor various SDM processes.

--- a/libs/superdrops/superdrop.hpp
+++ b/libs/superdrops/superdrop.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 29th April 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -25,8 +25,8 @@
 #ifndef LIBS_SUPERDROPS_SUPERDROP_HPP_
 #define LIBS_SUPERDROPS_SUPERDROP_HPP_
 
-#include "./superdrop_attrs.hpp"
-#include "./superdrop_ids.hpp"
+#include "superdrops/superdrop_attrs.hpp"
+#include "superdrops/superdrop_ids.hpp"
 
 /**
  * @brief Class representing a super-droplet (synonyms: superdroplet, superdrop, SD).

--- a/libs/superdrops/superdrop.hpp
+++ b/libs/superdrops/superdrop.hpp
@@ -25,8 +25,8 @@
 #ifndef LIBS_SUPERDROPS_SUPERDROP_HPP_
 #define LIBS_SUPERDROPS_SUPERDROP_HPP_
 
-#include "superdrops/superdrop_attrs.hpp"
-#include "superdrops/superdrop_ids.hpp"
+#include "superdrop_attrs.hpp"
+#include "superdrop_ids.hpp"
 
 /**
  * @brief Class representing a super-droplet (synonyms: superdroplet, superdrop, SD).

--- a/libs/superdrops/superdrop_attrs.cpp
+++ b/libs/superdrops/superdrop_attrs.cpp
@@ -22,8 +22,7 @@
  * to Climate" by Lohmann, Luond and Mahrt, 1st edition.
  */
 
-
-#include "./superdrop_attrs.hpp"
+#include "superdrop_attrs.hpp"
 
 /**
  * @brief Change the radius of droplet.

--- a/libs/superdrops/superdrop_attrs.cpp
+++ b/libs/superdrops/superdrop_attrs.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 11th March 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License

--- a/libs/superdrops/terminalvelocity.cpp
+++ b/libs/superdrops/terminalvelocity.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Saturday 15th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License

--- a/libs/superdrops/terminalvelocity.cpp
+++ b/libs/superdrops/terminalvelocity.cpp
@@ -23,7 +23,7 @@
  * requirements of the VelocityFormula concept
  */
 
-#include "./terminalvelocity.hpp"
+#include "terminalvelocity.hpp"
 
 /**
  * @brief Returns the mass of a droplet as if it's all water [gramms] to use as 'x' according to

--- a/libs/superdrops/terminalvelocity.hpp
+++ b/libs/superdrops/terminalvelocity.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Tuesday 9th April 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -26,7 +26,7 @@
 #include <concepts>
 
 #include "../cleoconstants.hpp"
-#include "./superdrop.hpp"
+#include "superdrops/superdrop.hpp"
 
 namespace dlc = dimless_constants;
 

--- a/libs/superdrops/terminalvelocity.hpp
+++ b/libs/superdrops/terminalvelocity.hpp
@@ -26,7 +26,7 @@
 #include <concepts>
 
 #include "../cleoconstants.hpp"
-#include "superdrops/superdrop.hpp"
+#include "superdrop.hpp"
 
 namespace dlc = dimless_constants;
 

--- a/libs/superdrops/thermodynamic_equations.cpp
+++ b/libs/superdrops/thermodynamic_equations.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Tuesday 9th April 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License

--- a/libs/superdrops/thermodynamic_equations.cpp
+++ b/libs/superdrops/thermodynamic_equations.cpp
@@ -23,7 +23,7 @@
  * and Mahrt, 1st edition.
  */
 
-#include "./thermodynamic_equations.hpp"
+#include "thermodynamic_equations.hpp"
 
 /**
  * @brief Calculate the equilibrium vapor pressure of water over liquid water,

--- a/libs/superdrops/thermodynamic_equations.hpp
+++ b/libs/superdrops/thermodynamic_equations.hpp
@@ -28,7 +28,7 @@
 #include <cassert>
 
 #include "../cleoconstants.hpp"
-#include "superdrops/superdrop.hpp"
+#include "superdrop.hpp"
 
 namespace dlc = dimless_constants;
 namespace DC = dimmed_constants;

--- a/libs/superdrops/thermodynamic_equations.hpp
+++ b/libs/superdrops/thermodynamic_equations.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Tuesday 9th April 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,7 +28,7 @@
 #include <cassert>
 
 #include "../cleoconstants.hpp"
-#include "./superdrop.hpp"
+#include "superdrops/superdrop.hpp"
 
 namespace dlc = dimless_constants;
 namespace DC = dimmed_constants;

--- a/libs/superdrops/urbg.hpp
+++ b/libs/superdrops/urbg.hpp
@@ -27,8 +27,8 @@
 #include <Kokkos_Random.hpp>
 #include <Kokkos_StdAlgorithms.hpp>
 
-#include "superdrops/kokkosaliases_sd.hpp"
-#include "superdrops/superdrop.hpp"
+#include "kokkosaliases_sd.hpp"
+#include "superdrop.hpp"
 
 /**
  * @brief Struct wrapping Kokkos random number generator.

--- a/libs/superdrops/urbg.hpp
+++ b/libs/superdrops/urbg.hpp
@@ -8,7 +8,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 8th May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -27,8 +27,8 @@
 #include <Kokkos_Random.hpp>
 #include <Kokkos_StdAlgorithms.hpp>
 
-#include "./kokkosaliases_sd.hpp"
-#include "./superdrop.hpp"
+#include "superdrops/kokkosaliases_sd.hpp"
+#include "superdrops/superdrop.hpp"
 
 /**
  * @brief Struct wrapping Kokkos random number generator.

--- a/libs/zarr/CMakeLists.txt
+++ b/libs/zarr/CMakeLists.txt
@@ -20,7 +20,7 @@ set(SOURCES
 add_library("${LIBNAME}" STATIC ${SOURCES})
 
 # Add directories for target library
-target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+#target_include_directories(${LIBNAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(${LIBNAME} PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 
 # Link libraries to target library

--- a/libs/zarr/chunks.hpp
+++ b/libs/zarr/chunks.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Tuesday 9th April 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -29,7 +29,7 @@
 #include <string_view>
 #include <vector>
 
-#include "./buffer.hpp"
+#include "zarr/buffer.hpp"
 
 /**
  * @brief Calculates the product of all elements in a vector of size_t numbers.

--- a/libs/zarr/dataset.hpp
+++ b/libs/zarr/dataset.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 22nd May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -30,8 +30,8 @@
 #include <utility>
 #include <vector>
 
-#include "./xarray_zarr_array.hpp"
-#include "./zarr_group.hpp"
+#include "zarr/xarray_zarr_array.hpp"
+#include "zarr/zarr_group.hpp"
 
 /**
  * @brief A class representing a dataset made from a Zarr group (i.e. collection of Zarr arrays)

--- a/libs/zarr/fsstore.cpp
+++ b/libs/zarr/fsstore.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors: Tobias Kölling (TB)
  * -----
- * Last Modified: Tuesday 9th April 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License

--- a/libs/zarr/fsstore.hpp
+++ b/libs/zarr/fsstore.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors: Tobias Kölling (TB)
  * -----
- * Last Modified: Tuesday 9th April 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,7 +28,7 @@
 #include <span>
 #include <string_view>
 
-#include "./store_accessor.hpp"
+#include "zarr/store_accessor.hpp"
 
 /**
  * @brief A file system store e.g. for Zarr arrays or groups.

--- a/libs/zarr/xarray_metadata.cpp
+++ b/libs/zarr/xarray_metadata.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 22nd May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License

--- a/libs/zarr/xarray_zarr_array.hpp
+++ b/libs/zarr/xarray_zarr_array.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Saturday 15th June 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -32,8 +32,8 @@
 #include <unordered_map>
 #include <vector>
 
-#include "./xarray_metadata.hpp"
-#include "./zarr_array.hpp"
+#include "zarr/xarray_metadata.hpp"
+#include "zarr/zarr_array.hpp"
 
 /**
  * @brief Write attributes string to a store under a .zattrs key.

--- a/libs/zarr/zarr_array.hpp
+++ b/libs/zarr/zarr_array.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 22nd May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -33,9 +33,9 @@
 #include <string_view>
 #include <vector>
 
-#include "./buffer.hpp"
-#include "./chunks.hpp"
-#include "./zarr_metadata.hpp"
+#include "zarr/buffer.hpp"
+#include "zarr/chunks.hpp"
+#include "zarr/zarr_metadata.hpp"
 
 /**
  * @brief Given maximum chunk size 'maxchunk' and length of inner dimension of one chunk of

--- a/libs/zarr/zarr_metadata.cpp
+++ b/libs/zarr/zarr_metadata.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 22nd May 2024
+ * Last Modified: Friday 21st June 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License

--- a/roughpaper/scratch/CMakeLists.txt
+++ b/roughpaper/scratch/CMakeLists.txt
@@ -21,7 +21,7 @@ add_executable(test main.cpp)
 # Add directories and link libraries to target
 target_link_libraries(test PRIVATE ${CLEOLIBS})
 target_link_libraries(test PUBLIC Kokkos::kokkos)
-target_include_directories(test PRIVATE "${CMAKE_SOURCE_DIR}/libs")
+target_include_directories(test PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 target_include_directories(test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 
 # set C++ properties for target

--- a/roughpaper/src/CMakeLists.txt
+++ b/roughpaper/src/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(cleocoupledsdm main.cpp)
 # Add directories and link libraries to target
 target_link_libraries(cleocoupledsdm PRIVATE coupldyn_fromfile cartesiandomain ${CLEOLIBS})
 target_link_libraries(cleocoupledsdm PUBLIC Kokkos::kokkos)
-target_include_directories(cleocoupledsdm PRIVATE "${CMAKE_SOURCE_DIR}/libs")
+target_include_directories(cleocoupledsdm PRIVATE "${CMAKE_SOURCE_DIR}/libs") # CLEO libs directory
 target_include_directories(cleocoupledsdm PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 # set specific C++ compiler options for target (optional)


### PR DESCRIPTION
- don't include unnecessary directories in cmake
- only use relative paths in rare cases, or to include "kokkosaliases.hpp" or "cleoconstants.hpp"