### PR TITLE
New observer for monitoring mass moments of raindrop size distribution during motion and microphysics

### DIFF
--- a/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
+++ b/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
@@ -202,4 +202,26 @@ inline Observer auto MonitorMassMomentsObserver(const unsigned int interval,
   return ConstTstepObserver(interval, do_obs);
 }
 
+/**
+ * @brief Constructs an observer which writes data monitoring the mass moments of the raindrop's
+ * distributions during microphysics and super-droplet motion to arrays with a constant observation
+ * timestep "interval".
+ *
+ * @tparam Store Type of store for dataset.
+ * @param interval Observation timestep.
+ * @param dataset Dataset to write time data to.
+ * @param maxchunk Maximum number of elements in a chunk (1-D vector size).
+ * @param ngbxs The number of gridboxes.
+ * @return Constructed type satisfying observer concept.
+ */
+template <typename Store>
+inline Observer auto MonitorRainMassMomentsObserver(const unsigned int interval,
+                                                    Dataset<Store> &dataset, const size_t maxchunk,
+                                                    const size_t ngbxs) {
+  const auto do_obs =
+      DoMonitorMassMomentsObs<Store, MonitorRainMassMomentXarrays, MonitorRainMassMomentViews>(
+          dataset, maxchunk, ngbxs);
+  return ConstTstepObserver(interval, do_obs);
+}
+
 #endif  // LIBS_OBSERVERS_SDMMONITOR_MONITOR_MASSMOMENTS_OBSERVER_HPP_

--- a/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
+++ b/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 21st June 2024
+ * Last Modified: Friday 19th July 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -54,6 +54,29 @@ struct MonitorMassMomentXarrays {
         mom0_motion(create_massmom0_xarray(dataset, "massmom0_motion", maxchunk, ngbxs)),
         mom1_motion(create_massmom1_xarray(dataset, "massmom1_motion", maxchunk, ngbxs)),
         mom2_motion(create_massmom2_xarray(dataset, "massmom2_motion", maxchunk, ngbxs)) {}
+};
+
+template <typename Store>
+struct MonitorRainMassMomentXarrays {
+  XarrayZarrArray<Store, uint64_t> mom0_microphys; /**< 0th mass moment from microphysics Xarray */
+  XarrayZarrArray<Store, float> mom1_microphys;    /**< 1st mass moment from microphysics Xarray */
+  XarrayZarrArray<Store, float> mom2_microphys;    /**< 2nd mass moment from microphysics Xarray */
+  XarrayZarrArray<Store, uint64_t> mom0_motion;    /**< 0th mass moment from motion Xarray */
+  XarrayZarrArray<Store, float> mom1_motion;       /**< 1st mass moment from motion Xarray */
+  XarrayZarrArray<Store, float> mom2_motion;       /**< 2nd mass moment from motion Xarray */
+
+  MonitorRainMassMomentXarrays(const Dataset<Store> &dataset, const size_t maxchunk,
+                               const size_t ngbxs)
+      : mom0_microphys(
+            create_massmom0_xarray(dataset, "massmom0_raindrops_microphys", maxchunk, ngbxs)),
+        mom1_microphys(
+            create_massmom1_xarray(dataset, "massmom1_raindrops_microphys", maxchunk, ngbxs)),
+        mom2_microphys(
+            create_massmom2_xarray(dataset, "massmom2_raindrops_microphys", maxchunk, ngbxs)),
+        mom0_motion(create_massmom0_xarray(dataset, "massmom0_raindrops_motion", maxchunk, ngbxs)),
+        mom1_motion(create_massmom1_xarray(dataset, "massmom1_raindrops_motion", maxchunk, ngbxs)),
+        mom2_motion(create_massmom2_xarray(dataset, "massmom2_raindrops_motion", maxchunk, ngbxs)) {
+  }
 };
 
 /**

--- a/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
+++ b/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
@@ -84,12 +84,14 @@ struct MonitorRainMassMomentXarrays {
  * @brief Class for functionality to observe data from a mass moments monitor of a SDM
  * process at the start of each timestep and write it to a Zarr array in an Xarray dataset.
  * @tparam Store Type of store for dataset.
+ * @tparam MonitorXarraysType Type for xarrays for mass moments in dataset.
+ * @tparam MonitorViewsType Type for views which calculate mass moments for xarrays.
  */
-template <typename Store, typename MonitorViewsType>
+template <typename Store, typename MonitorXarraysType, typename MonitorViewsType>
 class DoMonitorMassMomentsObs {
  private:
-  Dataset<Store> &dataset; /**< Dataset to write time data to. */
-  std::shared_ptr<MonitorMassMomentXarrays<Store>> xzarrs_ptr; /**< Pointer to arrays in dataset. */
+  Dataset<Store> &dataset;                               /**< Dataset to write time data to. */
+  std::shared_ptr<MonitorXarraysType<Store>> xzarrs_ptr; /**< Pointer to arrays in dataset. */
   MonitorMassMoments<MonitorViewsType> monitor;
 
   /**
@@ -129,7 +131,7 @@ class DoMonitorMassMomentsObs {
    */
   DoMonitorMassMomentsObs(Dataset<Store> &dataset, const size_t maxchunk, const size_t ngbxs)
       : dataset(dataset),
-        xzarrs_ptr(std::make_shared<MonitorMassMomentXarrays<Store>>(dataset, maxchunk, ngbxs)),
+        xzarrs_ptr(std::make_shared<MonitorXarraysType<Store>>(dataset, maxchunk, ngbxs)),
         monitor(ngbxs) {}
 
   /**
@@ -195,7 +197,8 @@ inline Observer auto MonitorMassMomentsObserver(const unsigned int interval,
                                                 Dataset<Store> &dataset, const size_t maxchunk,
                                                 const size_t ngbxs) {
   const auto do_obs =
-      DoMonitorMassMomentsObs<Store, MonitorMassMomentViews>(dataset, maxchunk, ngbxs);
+      DoMonitorMassMomentsObs<Store, MonitorMassMomentXarrays, MonitorMassMomentViews>(
+          dataset, maxchunk, ngbxs);
   return ConstTstepObserver(interval, do_obs);
 }
 

--- a/roughpaper/src/main_impl.hpp
+++ b/roughpaper/src/main_impl.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 21st June 2024
+ * Last Modified: Friday 19th July 2024
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -209,8 +209,10 @@ inline Observer auto create_sdmmonitor_observer(const unsigned int interval,
                                                 const size_t ngbxs) {
   const Observer auto obs_cond = MonitorCondensationObserver(interval, dataset, maxchunk, ngbxs);
   const Observer auto obs_massmoms = MonitorMassMomentsObserver(interval, dataset, maxchunk, ngbxs);
+  const Observer auto obs_rainmassmoms =
+      MonitorRainMassMomentsObserver(interval, dataset, maxchunk, ngbxs);
 
-  return obs_cond >> obs_massmoms;
+  return obs_cond >> obs_massmoms >> obs_rainmassmoms;
 }
 
 template <typename Store>


### PR DESCRIPTION
New observer for monitoring mass moments of raindrop size distribution during motion and microphysics:
- templated over xarrays used to write monitored mass moments to array in xarray dataset.
- completely analogous to observer for MonitorMassMomentsObserver but only for raindrops (as calculated by the calculate_rainmassmoments function, which currently gives the 0th, 3rd and 6th moments of the droplet size distribution excluding droplets < 40 microns).