### PR TITLE
refactor: improve Python examples with pathlib and improve CI build order

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-name: Python test
+name: CI (pytest and documentation)
 
 on: [push, pull_request]
 
@@ -39,7 +39,7 @@ jobs:
         run: |
           cd docs && make html
       - name: Archive build artifacts (i.e. documentation)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: html-docs
           path: docs/build/html/
@@ -58,7 +58,7 @@ jobs:
           name: html-docs
           path: docs/build/html/
       - name: Publish docs on GitHub pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/build/html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,92 +1,133 @@
-name: Build
+name: build
 
 on: pull_request
 
 jobs:
-  build:
+  setup:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Setup
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-        cmake libnetcdff-dev liblapack-dev python3-dev \
-        python3-numpy python3-mpi4py python3-pip curl \
-        libfyaml-dev libopenmpi-dev openmpi-bin
+      - name: Cache YAXT
+        id: cache_yaxt
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/yaxt/
+          key: ${{ runner.os }}-yaxt-cache-v0.11.1
+          restore-keys: |
+            ${{ runner.os }}-yaxt-
 
-    - name: Build YAXT
-      run: |
-        curl -s -L https://swprojects.dkrz.de/redmine/attachments/download/534/yaxt-0.11.1.tar.gz | tar xvz
-        cd yaxt-0.11.1
-        ./configure --without-regard-for-quality --without-example-programs --without-perf-programs --with-pic \
-        --prefix=$HOME/yaxt
-        make -j 4
-        make install
+      - name: Cache YAC
+        id: cache_yac
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/yac/
+          key: ${{ runner.os }}-yac-cache-v3.2.0
+          restore-keys: |
+            ${{ runner.os }}-yac-
 
-    - name: Build YAC
-      run: |
-        curl -s -L https://gitlab.dkrz.de/dkrz-sw/yac/-/archive/v3.2.0/yac-v3.2.0.tar.gz | tar xvz
-        cd yac-v3.2.0
-        ./configure CFLAGS="-fPIC" CC=mpicc FC=mpif90 --disable-mpi-checks --with-yaxt-root=${HOME}/yaxt \
-        --prefix=$HOME/yac
-        make -j 4
-        make install
+      - name: Setup
+        if: steps.cache_yaxt.outputs.cache-hit != 'true' || steps.cache_yac.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+          cmake libnetcdff-dev liblapack-dev python3-dev \
+          python3-numpy python3-mpi4py python3-pip curl \
+          libfyaml-dev libopenmpi-dev openmpi-bin
 
-    - name: Build main
-      run: |
-        mkdir build && cd build
-        cmake \
-        -DCMAKE_C_COMPILER=gcc \
-        -DCMAKE_CXX_COMPILER=g++ \
-        -DCMAKE_CXX_FLAGS="-Werror -Wall -pedantic -O3" \
-        -DKokkos_ENABLE_SERIAL=ON \
-        -DENABLE_YAC_COUPLING=ON \
-        -DYAXT_ROOT=${HOME}/yaxt \
-        -DYAC_ROOT=${HOME}/yac \
-        -DCMAKE_MODULE_PATH=${PWD}/../libs/coupldyn_yac/cmake ..
-        make
+      - name: Build YAXT
+        if: steps.cache_yaxt.outputs.cache-hit != 'true'
+        run: |
+          curl -s -L https://swprojects.dkrz.de/redmine/attachments/download/534/yaxt-0.11.1.tar.gz | tar xvz
+          cd yaxt-0.11.1
+          ./configure --without-regard-for-quality --without-example-programs \
+            --without-perf-programs --with-pic --prefix=${{ runner.temp }}/yaxt
+          make -j 4
+          make install
 
-    - name: Build example adia0d
-      run: cd build && make adia0d
+      - name: Build YAC
+        if: steps.cache_yac.outputs.cache-hit != 'true'
+        run: |
+          curl -s -L https://gitlab.dkrz.de/dkrz-sw/yac/-/archive/v3.2.0/yac-v3.2.0.tar.gz | tar xvz
+          cd yac-v3.2.0
+          ./configure CFLAGS="-fPIC" CC=mpicc FC=mpif90 --disable-mpi-checks \
+            --with-yaxt-root=${{ runner.temp }}/yaxt --prefix=${{ runner.temp }}/yac
+          make -j 4
+          make install
 
-    - name: Build example golcolls
-      run: cd build && make golcolls
+  build_basic_examples:
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      matrix:
+        target: [all, adia0d, golcolls, longcolls, lowlistcolls, szakallurbichcolls,
+                testikstraubcolls, const2d, divfree2d, eurec4a1d, rshaft1d, spdtest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Build example longcolls
-      run: cd build && make longcolls
+      - name: Setup
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+          cmake libopenmpi-dev openmpi-bin
 
-    - name: Build example lowlistcolls
-      run: cd build && make lowlistcolls
+      - name: Build Example
+        run: |
+          mkdir build
+          cmake -S ./ -B ./build \
+          -DCMAKE_C_COMPILER=gcc \
+          -DCMAKE_CXX_COMPILER=g++ \
+          -DCMAKE_CXX_FLAGS="-Werror -Wall -pedantic -O3" \
+          -DKokkos_ENABLE_SERIAL=ON \
+          -DENABLE_YAC_COUPLING=OFF
 
-    - name: Build example szakallurbichcolls
-      run: cd build && make szakallurbichcolls
+      - name: Compile Example
+        run: cd build && make ${{ matrix.target }}
 
-    - name: Build example testikstraubcolls
-      run: cd build && make testikstraubcolls
+  build_yac_examples:
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      matrix:
+        target: [all, bubble3d, fromfile, fromfile_irreg]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Build example const2d
-      run: cd build && make const2d
+      - name: Setup
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+          cmake libnetcdff-dev liblapack-dev python3-dev \
+          python3-numpy python3-mpi4py python3-pip curl \
+          libfyaml-dev libopenmpi-dev openmpi-bin
 
-    - name: Build example divfree2d
-      run: cd build && make divfree2d
+      - name: Restore YAXT Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/yaxt/
+          key: ${{ runner.os }}-yaxt-cache-v0.11.1
 
-    - name: Build example eurec4a1d
-      run: cd build && make eurec4a1d
+      - name: Restore YAC Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/yac/
+          key: ${{ runner.os }}-yac-cache-v3.2.0
 
-    - name: Build example rshaft1d
-      run: cd build && make rshaft1d
+      - name: Build YAC Example
+        run: |
+          mkdir build
+          cmake -S ./ -B ./build \
+          -DCMAKE_C_COMPILER=gcc \
+          -DCMAKE_CXX_COMPILER=g++ \
+          -DCMAKE_CXX_FLAGS="-Werror -Wall -pedantic -O3" \
+          -DKokkos_ENABLE_SERIAL=ON \
+          -DENABLE_YAC_COUPLING=ON \
+          -DYAXT_ROOT=${{ runner.temp }}/yaxt \
+          -DYAC_ROOT=${{ runner.temp }}/yac \
+          -DCMAKE_MODULE_PATH=${PWD}/libs/coupldyn_yac/cmake
 
-    - name: Build example spdtest
-      run: cd build && make spdtest
-
-    - name: Build example bubble3d
-      run: cd build && make bubble3d
-
-    - name: Build example fromfile
-      run: cd build && make fromfile
-
-    - name: Build example fromfile_irreg
-      run: cd build && make fromfile_irreg
+      - name: Compile YAC Example
+        run: cd build && make ${{ matrix.target }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Python setup
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
 
     - name: Pre-commit run
-      uses: pre-commit/action@v3.0.0
+      uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,10 @@ repos:
     rev: 0.8.0
     hooks:
     -   id: cpplint
-        args: [--linelength=100, "--filter=-runtime/references,-readability/braces,-build/include,-build/c++17"]
+        args:
+            - --linelength=100
+            - --filter=-runtime/references,-readability/braces,-whitespace/indent_namespace,
+              -build/include,-build/c++11,-build/c++17
         types_or: [c, c++, cuda]
 -   repo: https://github.com/compilerla/conventional-pre-commit
     rev: v3.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     rev: 0.8.0
     hooks:
     -   id: cpplint
-        args: [--linelength=100, "--filter=-runtime/references,-readability/braces,-build/include,-build/c++11"]
+        args: [--linelength=100, "--filter=-runtime/references,-readability/braces,-build/include,-build/c++17"]
         types_or: [c, c++, cuda]
 -   repo: https://github.com/compilerla/conventional-pre-commit
     rev: v3.4.0

--- a/examples/adiabaticparcel/as2017.sh
+++ b/examples/adiabaticparcel/as2017.sh
@@ -7,7 +7,7 @@
 #SBATCH --time=00:10:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./as2017_out.%j.out
 #SBATCH --error=./as2017_err.%j.out
 

--- a/examples/adiabaticparcel/cuspbifurc.sh
+++ b/examples/adiabaticparcel/cuspbifurc.sh
@@ -7,7 +7,7 @@
 #SBATCH --time=00:10:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./cuspbifurc_out.%j.out
 #SBATCH --error=./cuspbifurc_err.%j.out
 

--- a/examples/adiabaticparcel/src/config/as2017_config.yaml
+++ b/examples/adiabaticparcel/src/config/as2017_config.yaml
@@ -46,9 +46,9 @@ initsupers:
 
 ### Output Parameters ###
 outputdata:
-  setup_filename: /home/m/m300950/CLEO/build_adia0d//bin/as2017_setup.txt   # .txt filename to copy configuration to
+  setup_filename: /home/m/m300950/CLEO/build_adia0d/bin/as2017_setup.txt    # .txt filename to copy configuration to
   stats_filename: /home/m/m300950/CLEO/build_adia0d//bin/as2017_stats.txt   # .txt file to output runtime statistics to
-  zarrbasedir: /home/m/m300950/CLEO/build_adia0d//bin/as2017_sol8.zarr      # zarr store base directory
+  zarrbasedir: /home/m/m300950/CLEO/build_adia0d/bin/as2017_sol8.zarr       # zarr store base directory
   maxchunk: 2500000                                                         # maximum no. of elements in chunks of zarr store array
 
 ### Microphysics Parameters ###

--- a/examples/boxmodelcollisions/breakup.sh
+++ b/examples/boxmodelcollisions/breakup.sh
@@ -8,7 +8,7 @@
 #SBATCH --time=00:10:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./breakup_out.%j.out
 #SBATCH --error=./breakup_err.%j.out
 

--- a/examples/boxmodelcollisions/breakup.sh
+++ b/examples/boxmodelcollisions/breakup.sh
@@ -5,7 +5,7 @@
 #SBATCH --gpus=4
 #SBATCH --ntasks-per-node=128
 #SBATCH --mem=30G
-#SBATCH --time=00:10:00
+#SBATCH --time=00:15:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
 #SBATCH --account=bm1183

--- a/examples/boxmodelcollisions/shima2009.sh
+++ b/examples/boxmodelcollisions/shima2009.sh
@@ -5,7 +5,7 @@
 #SBATCH --gpus=4
 #SBATCH --ntasks-per-node=128
 #SBATCH --mem=30G
-#SBATCH --time=00:10:00
+#SBATCH --time=00:20:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
 #SBATCH --account=bm1183

--- a/examples/boxmodelcollisions/shima2009.sh
+++ b/examples/boxmodelcollisions/shima2009.sh
@@ -8,7 +8,7 @@
 #SBATCH --time=00:10:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./shima2009_out.%j.out
 #SBATCH --error=./shima2009_err.%j.out
 

--- a/examples/boxmodelcollisions/shima2009_config.yaml
+++ b/examples/boxmodelcollisions/shima2009_config.yaml
@@ -42,7 +42,7 @@ inputfiles:
 
 initsupers:
   type: frombinary                                              # type of initialisation of super-droplets
-  initsupers_filename: /home/m/m300950/CLEO/build_colls0d//share/shima2009_dimlessSDsinit_2.dat # binary filename for initialisation of SDs
+  initsupers_filename: /home/m/m300950/CLEO/build_colls0d/share/shima2009_dimlessSDsinit_2.dat  # binary filename for initialisation of SDs
 
 ### Output Parameters ###
 outputdata:

--- a/examples/bubble3d/bubble3d.py
+++ b/examples/bubble3d/bubble3d.py
@@ -21,12 +21,13 @@ piggyback ICON bubble test case
 """
 
 import os
+import shutil
 import sys
 from pathlib import Path
 
-path2CLEO = sys.argv[1]
-path2build = sys.argv[2]
-configfile = sys.argv[3]
+path2CLEO = Path(sys.argv[1])
+path2build = Path(sys.argv[2])
+configfile = Path(sys.argv[3])
 icon_grid_file = sys.argv[4]  # TODO(CB): move to config file
 
 import bubble3d_inputfiles
@@ -36,16 +37,16 @@ import bubble3d_inputfiles
 ### ---------------------------------------------------------------- ###
 ### --- essential paths and filenames --- ###
 # path and filenames for creating initial SD conditions
-binpath = path2build + "/bin/"
-sharepath = path2build + "/share/"
-gridfile = sharepath + "bubble3d_dimlessGBxboundaries.dat"
-initSDsfile = sharepath + "bubble3d_dimlessSDsinit.dat"
-savefigpath = path2build + "/bin/"  # directory for saving figures
+binpath = path2build / "bin"
+sharepath = path2build / "share"
+gridfile = sharepath / "bubble3d_dimlessGBxboundaries.dat"
+initSDsfile = sharepath / "bubble3d_dimlessSDsinit.dat"
+savefigpath = path2build / "bin"  # directory for saving figures
 SDgbxs2plt = [0]  # gbxindex of SDs to plot (nb. "all" can be very slow)
 
 # path and file names for plotting results
-setupfile = binpath + "bubble3d_setup.txt"
-dataset = binpath + "bubble3d_sol.zarr"
+setupfile = binpath / "bubble3d_setup.txt"
+dataset = binpath / "bubble3d_sol.zarr"
 
 ### ---------------------------------------------------------------- ###
 ### ------------------- BINARY FILES GENERATION--------------------- ###
@@ -54,14 +55,14 @@ dataset = binpath + "bubble3d_sol.zarr"
 if path2CLEO == path2build:
     raise ValueError("build directory cannot be CLEO")
 else:
-    Path(path2build).mkdir(exist_ok=True)
-    Path(sharepath).mkdir(exist_ok=True)
-    Path(binpath).mkdir(exist_ok=True)
-    Path(savefigpath).mkdir(exist_ok=True)
+    path2build.mkdir(exist_ok=True)
+    sharepath.mkdir(exist_ok=True)
+    binpath.mkdir(exist_ok=True)
+    savefigpath.mkdir(exist_ok=True)
 
 ### --- delete any existing initial conditions --- ###
-os.system("rm " + gridfile)
-os.system("rm " + initSDsfile)
+shutil.rmtree(gridfile, ignore_errors=True)
+shutil.rmtree(initSDsfile, ignore_errors=True)
 
 bubble3d_inputfiles.main(
     path2CLEO, path2build, configfile, gridfile, initSDsfile, icon_grid_file, SDgbxs2plt
@@ -77,10 +78,11 @@ def run_exectuable(path2CLEO, path2build, configfile, dataset):
     """delete existing dataset, the run exectuable with given config file"""
     os.chdir(path2build)
     os.system("pwd")
-    os.system("rm -rf " + dataset)  # delete any existing dataset
-    executable = path2build + "/examples/yac/bubble3d/src/bubble3d"
-    print("Executable: " + executable)
-    print("Config file: " + configfile)
+    shutil.rmtree(dataset, ignore_errors=True)  # delete any existing dataset
+    executable = str(path2build / "examples" / "yac" / "bubble3d" / "src" / "bubble3d")
+    configfile = str(configfile)
+    print("Executable: " + str(executable))
+    print("Config file: " + str(configfile))
 
     cleoproc = executable + " " + configfile
     pythonproc = path2CLEO + "/examples/yac/bubble3d/yac_icon_data_reader.py"

--- a/examples/bubble3d/bubble3d.sh
+++ b/examples/bubble3d/bubble3d.sh
@@ -7,7 +7,7 @@
 #SBATCH --time=00:05:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./bubble3d_out.%j.out
 #SBATCH --error=./bubble3d_err.%j.out
 

--- a/examples/bubble3d/bubble3d_inputfiles.py
+++ b/examples/bubble3d/bubble3d_inputfiles.py
@@ -42,7 +42,7 @@ def main(
 ):
     import matplotlib.pyplot as plt
 
-    sys.path.append(path2CLEO)  # for imports from pySD package
+    sys.path.append(str(path2CLEO))  # for imports from pySD package
 
     from pySD.gbxboundariesbinary_src import read_gbxboundaries as rgrid
     from pySD.gbxboundariesbinary_src import create_gbxboundaries as cgrid
@@ -61,12 +61,12 @@ def main(
     ### ---------------------------------------------------------------- ###
     ### --- essential paths and filenames --- ###
     # path and filenames for creating initial SD conditions
-    constsfile = path2CLEO + "/libs/cleoconstants.hpp"
+    constsfile = path2CLEO / "libs" / "cleoconstants.hpp"
 
     ### --- plotting initialisation figures --- ###
     # booleans for [making, saving] initialisation figures
     isfigures = [True, True]
-    savefigpath = path2build + "/bin/"  # directory for saving figures
+    savefigpath = path2build / "bin"  # directory for saving figures
 
     ### --- settings for 3-D gridbox boundaries --- ###
     num_vertical_levels = 24  # TODO(CB): move to config file (?)
@@ -139,5 +139,5 @@ def main(
 
 
 if __name__ == "__main__":
-    ### args = path2CLEO, path2build, configfile, binpath, gridfile, initSDsfile, thermofile
+    ### args = path2CLEO, path2build, configfile, binpath, gridfile, initSDsfile, thermofiles
     main(*sys.argv[1:])

--- a/examples/bubble3d/run_bubble_tmp.sh
+++ b/examples/bubble3d/run_bubble_tmp.sh
@@ -13,11 +13,11 @@
 
 action=$1
 path2CLEO=${2:-${HOME}/CLEO}
-path2yac=${3:-/work/mh1126/m300950/yac}
+path2yac=${3:-/work/bm1183/m300950/yac}
 path2build=${4:-${HOME}/CLEO/build_bubble3d}
 
-icon_grid_file=/work/mh1126/m300950/icon/build/experiments/aes_bubble/aes_bubble_atm_cgrid_ml.nc
-icon_data_file=/work/mh1126/m300950/icon/build/experiments/aes_bubble/aes_bubble_atm_3d_ml_20080801T000000Z.nc
+icon_grid_file=/work/bm1183/m300950/icon/build/experiments/aes_bubble/aes_bubble_atm_cgrid_ml.nc
+icon_data_file=/work/bm1183/m300950/icon/build/experiments/aes_bubble/aes_bubble_atm_3d_ml_20080801T000000Z.nc
 icon_grid_file_copy=${path2build}/share/icon_grid_file_aes_bubble_atm_cgrid_ml.nc
 icon_data_file_copy=${path2build}/share/icon_data_file_aes_bubble_atm_3d_ml_20080801T000000Z.nc
 
@@ -41,15 +41,15 @@ then
   spack load openblas@0.3.18%gcc@=11.2.0
 
   ${path2CLEO}/scripts/bash/compile_cleo.sh \
-     /work/mh1126/m300950/cleoenv openmp ${path2build} bubble3d
+     /work/bm1183/m300950/mambaenvs/cleoenv openmp ${path2build} bubble3d
 
 elif [ "${action}" == "inputfiles" ]
 then
   cp ${icon_grid_file} ${icon_grid_file_copy}
   cp ${icon_data_file} ${icon_data_file_copy}
 
-  source activate /work/mh1126/m300950/cleoenv
-  /work/mh1126/m300950/cleoenv/bin/python ${path2CLEO}/examples/bubble3d/bubble3d_inputfiles.py \
+  source activate /work/bm1183/m300950/mambaenvs/cleoenv
+  /work/bm1183/m300950/mambaenvs/cleoenv/bin/python ${path2CLEO}/examples/bubble3d/bubble3d_inputfiles.py \
    ${path2CLEO} \
    ${path2build} \
    ${path2CLEO}/examples/bubble3d/src/config/bubble3d_config.yaml \

--- a/examples/constthermo2d/constthermo2d.sh
+++ b/examples/constthermo2d/constthermo2d.sh
@@ -5,7 +5,7 @@
 #SBATCH --gpus=4
 #SBATCH --ntasks-per-node=128
 #SBATCH --mem=30G
-#SBATCH --time=00:05:00
+#SBATCH --time=00:10:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
 #SBATCH --account=bm1183

--- a/examples/constthermo2d/constthermo2d.sh
+++ b/examples/constthermo2d/constthermo2d.sh
@@ -8,7 +8,7 @@
 #SBATCH --time=00:05:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./const2d_out.%j.out
 #SBATCH --error=./const2d_err.%j.out
 

--- a/examples/divfreemotion/divfree2d.sh
+++ b/examples/divfreemotion/divfree2d.sh
@@ -5,7 +5,7 @@
 #SBATCH --gpus=4
 #SBATCH --ntasks-per-node=128
 #SBATCH --mem=30G
-#SBATCH --time=00:05:00
+#SBATCH --time=00:10:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
 #SBATCH --account=bm1183

--- a/examples/divfreemotion/divfree2d.sh
+++ b/examples/divfreemotion/divfree2d.sh
@@ -8,7 +8,7 @@
 #SBATCH --time=00:05:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./divfree2d_out.%j.out
 #SBATCH --error=./divfree2d_err.%j.out
 

--- a/examples/divfreemotion/divfree2d_inputfiles.py
+++ b/examples/divfreemotion/divfree2d_inputfiles.py
@@ -22,11 +22,11 @@ a 2-D divergence free wind field.
 import sys
 
 
-def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
+def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofiles):
     import numpy as np
     import matplotlib.pyplot as plt
 
-    sys.path.append(path2CLEO)  # for imports from pySD package
+    sys.path.append(str(path2CLEO))  # for imports from pySD package
 
     from pySD.gbxboundariesbinary_src import read_gbxboundaries as rgrid
     from pySD.gbxboundariesbinary_src import create_gbxboundaries as cgrid
@@ -48,11 +48,11 @@ def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
     ### ---------------------------------------------------------------- ###
     ### --- essential paths and filenames --- ###
     # path and filenames for creating initial SD conditions
-    constsfile = path2CLEO + "/libs/cleoconstants.hpp"
+    constsfile = path2CLEO / "libs" / "cleoconstants.hpp"
 
     ### --- plotting initialisation figures --- ###
     isfigures = [True, True]  # booleans for [making, saving] initialisation figures
-    savefigpath = path2build + "/bin/"  # directory for saving figures
+    savefigpath = path2build / "bin"  # directory for saving figures
     SDgbxs2plt = [0]  # gbxindex of SDs to plot (nb. "all" can be very slow)
 
     ### --- settings for 2-D gridbox boundaries --- ###
@@ -115,7 +115,7 @@ def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
         VVEL,
     )
     cthermo.write_thermodynamics_binary(
-        thermofile, thermodyngen, configfile, constsfile, gridfile
+        thermofiles, thermodyngen, configfile, constsfile, gridfile
     )
 
     ### ----- write initial superdroplets binary ----- ###
@@ -138,7 +138,7 @@ def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
     if isfigures[0]:
         rgrid.plot_gridboxboundaries(constsfile, gridfile, savefigpath, isfigures[1])
         rthermo.plot_thermodynamics(
-            constsfile, configfile, gridfile, thermofile, savefigpath, isfigures[1]
+            constsfile, configfile, gridfile, thermofiles, savefigpath, isfigures[1]
         )
         rsupers.plot_initGBxs_distribs(
             configfile,
@@ -155,5 +155,5 @@ def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
 
 
 if __name__ == "__main__":
-    ### args = path2CLEO, path2build, configfile, binpath, gridfile, initSDsfile, thermofile
+    ### args = path2CLEO, path2build, configfile, binpath, gridfile, initSDsfile, thermofiles
     main(*sys.argv[1:])

--- a/examples/eurec4a1d/eurec4a1d.sh
+++ b/examples/eurec4a1d/eurec4a1d.sh
@@ -5,7 +5,7 @@
 #SBATCH --gpus=4
 #SBATCH --ntasks-per-node=128
 #SBATCH --mem=30G
-#SBATCH --time=00:05:00
+#SBATCH --time=00:10:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
 #SBATCH --account=bm1183

--- a/examples/eurec4a1d/eurec4a1d.sh
+++ b/examples/eurec4a1d/eurec4a1d.sh
@@ -8,7 +8,7 @@
 #SBATCH --time=00:05:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./eurec4a1d_out.%j.out
 #SBATCH --error=./eurec4a1d_err.%j.out
 

--- a/examples/exampleplotting/exampleplotting.py
+++ b/examples/exampleplotting/exampleplotting.py
@@ -21,6 +21,7 @@ File Description:
 import os
 import sys
 import awkward as ak
+from pathlib import Path
 
 path2pySD = os.path.dirname(os.path.realpath(__file__)) + "/../../"
 sys.path.append(path2pySD)
@@ -29,13 +30,13 @@ from plotssrc import pltsds, pltdist
 
 ### ---------------------- input parameters ------------------------ ###
 ### paths to data for plotting
-dataset = "/home/m/m300950/CLEO/build/bin/SDMdata.zarr"
-setuptxt = "/home/m/m300950/CLEO/build/bin/setup.txt"
-gridfile = "/home/m/m300950/CLEO/build/share/dimlessGBxboundaries.dat"
+dataset = Path("/home/m/m300950/CLEO/build/bin/SDMdata.zarr")
+setuptxt = Path("/home/m/m300950/CLEO/build/bin/setup.txt")
+gridfile = Path("/home/m/m300950/CLEO/build/share/dimlessGBxboundaries.dat")
 
 ### whether and where to save figures
 savefig = False
-savefigpath = "./"
+savefigpath = Path.cwd()
 
 ### individual superdroplet plotting parameters
 nsample = 50
@@ -69,12 +70,12 @@ sddata = pyzarr.get_supers(ds, consts)
 ### ----------------- plot individual superdroplets ---------------- ###
 savename = ""
 if savefig:
-    savename = savefigpath + "/randomsample_attrs.png"
+    savename = savefigpath / "randomsample_attrs.png"
 pltsds.plot_randomsample_superdrops(
     time, sddata, config["maxnsupers"], nsample, savename=savename
 )
 if savefig:
-    savename = savefigpath + "/randomsample_2dmotion.png"
+    savename = savefigpath / "randomsample_2dmotion.png"
 pltsds.plot_randomsample_superdrops_2dmotion(
     sddata, config["maxnsupers"], nsample, arrows=False
 )
@@ -88,7 +89,7 @@ if rspan == ["min", "max"]:
 if smoothsig_mass:
     smoothsig_mass = smoothsig_mass * (config["maxnsupers"] ** (-1 / 5))
 if savefig:
-    savename = savefigpath + "/domain_mass_distrib.png"
+    savename = savefigpath / "domain_mass_distrib.png"
 fig, ax = pltdist.plot_domainmass_distribs(
     time.secs,
     sddata,
@@ -105,7 +106,7 @@ fig, ax = pltdist.plot_domainmass_distribs(
 if smoothsig_num:
     smoothsig_num = smoothsig_num * (config["maxnsupers"] ** (-1 / 5))
 if savefig:
-    savename = savefigpath + "/domain_numconc_distrib.png"
+    savename = savefigpath / "domain_numconc_distrib.png"
 fig, ax = pltdist.plot_domainnumconc_distribs(
     time.secs,
     sddata,

--- a/examples/exampleplotting/plotssrc/animations.py
+++ b/examples/exampleplotting/plotssrc/animations.py
@@ -36,9 +36,9 @@ def animate_me(
     )
 
     if saveani:
-        print("saving animation as " + savename + ".gif")
+        print(f"saving animation as {savename}.gif")
         ani.save(
-            savename + ".gif",
+            f"{savename}.gif",
             writer=animation.PillowWriter(fps=fps, bitrate=5000, codec="h264"),
             dpi=100,
             savefig_kwargs={"transparent": True},

--- a/examples/exampleplotting/plotssrc/as2017fig.py
+++ b/examples/exampleplotting/plotssrc/as2017fig.py
@@ -189,7 +189,7 @@ def arabas_shima_2017_fig(
 
     if savename != "":
         fig.savefig(savename, dpi=400, bbox_inches="tight", facecolor="w", format="png")
-        print("Figure .png saved as: " + savename)
+        print("Figure .png saved as: " + str(savename))
 
     plt.show()
 

--- a/examples/exampleplotting/plotssrc/pltdist.py
+++ b/examples/exampleplotting/plotssrc/pltdist.py
@@ -183,7 +183,7 @@ def plot_domainmass_distribs(
 
     if savename != "":
         fig.savefig(savename, dpi=400, bbox_inches="tight", facecolor="w", format="png")
-        print("Figure .png saved as: " + savename)
+        print("Figure .png saved as: " + str(savename))
 
     plt.show()
 
@@ -231,7 +231,7 @@ def plot_domainnsupers_distribs(
 
     if savename != "":
         fig.savefig(savename, dpi=400, bbox_inches="tight", facecolor="w", format="png")
-        print("Figure .png saved as: " + savename)
+        print("Figure .png saved as: " + str(savename))
 
     plt.show()
 
@@ -279,7 +279,7 @@ def plot_domainnumconc_distribs(
 
     if savename != "":
         fig.savefig(savename, dpi=400, bbox_inches="tight", facecolor="w", format="png")
-        print("Figure .png saved as: " + savename)
+        print("Figure .png saved as: " + str(savename))
 
     plt.show()
 

--- a/examples/exampleplotting/plotssrc/pltmoms.py
+++ b/examples/exampleplotting/plotssrc/pltmoms.py
@@ -33,7 +33,7 @@ def plot_totnsupers(time, totnsupers, savename=""):
     fig.tight_layout()
     if savename != "":
         fig.savefig(savename, dpi=400, bbox_inches="tight", facecolor="w", format="png")
-        print("Figure .png saved as: " + savename)
+        print("Figure .png saved as: " + str(savename))
 
     plt.show()
 
@@ -65,6 +65,6 @@ def plot_domainmassmoments(time, massmoms, savename=""):
     fig.tight_layout()
     if savename != "":
         fig.savefig(savename, dpi=400, bbox_inches="tight", facecolor="w", format="png")
-        print("Figure .png saved as: " + savename)
+        print("Figure .png saved as: " + str(savename))
 
     plt.show()

--- a/examples/exampleplotting/plotssrc/pltsds.py
+++ b/examples/exampleplotting/plotssrc/pltsds.py
@@ -63,7 +63,7 @@ def individ_radiusgrowths_figure(time, radii, savename=""):
 
     if savename != "":
         fig.savefig(savename, dpi=400, bbox_inches="tight", facecolor="w", format="png")
-        print("Figure .png saved as: " + savename)
+        print("Figure .png saved as: " + str(savename))
 
     plt.show()
 
@@ -116,7 +116,7 @@ def plot_randomsample_superdrops(time, sddata, totnsupers, nsample, savename="")
 
     if savename != "":
         fig.savefig(savename, dpi=400, bbox_inches="tight", facecolor="w", format="png")
-        print("Figure .png saved as: " + savename)
+        print("Figure .png saved as: " + str(savename))
 
     plt.show()
 
@@ -181,7 +181,7 @@ def plot_randomsample_superdrops_2dmotion(
 
     if savename != "":
         fig.savefig(savename, dpi=400, bbox_inches="tight", facecolor="w", format="png")
-        print("Figure .png saved as: " + savename)
+        print("Figure .png saved as: " + str(savename))
 
     plt.show()
 

--- a/examples/exampleplotting/plotssrc/shima2009fig.py
+++ b/examples/exampleplotting/plotssrc/shima2009fig.py
@@ -83,7 +83,7 @@ def plot_validation_figure(
 
     if savename != "":
         fig.savefig(savename, dpi=400, bbox_inches="tight", facecolor="w", format="png")
-        print("Figure .png saved as: " + savename)
+        print("Figure .png saved as: " + str(savename))
     plt.show()
 
     return fig, ax

--- a/examples/fromfile/fromfile.py
+++ b/examples/fromfile/fromfile.py
@@ -22,17 +22,20 @@ files for visual checks.
 """
 
 import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 import fromfile_inputfiles
 
-path2CLEO = sys.argv[1]
-path2build = sys.argv[2]
-configfile = sys.argv[3]
+path2CLEO = Path(sys.argv[1])
+path2build = Path(sys.argv[2])
+configfile = Path(sys.argv[3])
 
-sys.path.append(path2CLEO)  # for imports from pySD package
-# for imports from example plotting package
-sys.path.append(path2CLEO + "/examples/exampleplotting/")
+sys.path.append(str(path2CLEO))  # imports from pySD
+sys.path.append(
+    str(path2CLEO / "examples" / "exampleplotting")
+)  # imports from example plots package
 
 from src import plot_output_thermo
 from plotssrc import pltsds, pltmoms
@@ -43,16 +46,16 @@ from pySD.sdmout_src import pyzarr, pysetuptxt, pygbxsdat
 ### ---------------------------------------------------------------- ###
 ### --- essential paths and filenames --- ###
 # path and filenames for creating initial SD conditions
-binpath = path2build + "/bin/"
-sharepath = path2build + "/share/"
-gridfile = sharepath + "fromfile_dimlessGBxboundaries.dat"
-initSDsfile = sharepath + "fromfile_dimlessSDsinit.dat"
-thermofile = sharepath + "/fromfile_dimlessthermo.dat"
-savefigpath = path2build + "/bin/"  # directory for saving figures
+binpath = path2build / "bin"
+sharepath = path2build / "share"
+gridfile = sharepath / "fromfile_dimlessGBxboundaries.dat"
+initSDsfile = sharepath / "fromfile_dimlessSDsinit.dat"
+thermofiles = sharepath / "fromfile_dimlessthermo.dat"
+savefigpath = path2build / "bin"  # directory for saving figures
 
 # path and file names for plotting results
-setupfile = binpath + "fromfile_setup.txt"
-dataset = binpath + "fromfile_sol.zarr"
+setupfile = binpath / "fromfile_setup.txt"
+dataset = binpath / "fromfile_sol.zarr"
 ### ---------------------------------------------------------------- ###
 ### ---------------------------------------------------------------- ###
 
@@ -63,18 +66,20 @@ dataset = binpath + "fromfile_sol.zarr"
 if path2CLEO == path2build:
     raise ValueError("build directory cannot be CLEO")
 else:
-    Path(path2build).mkdir(exist_ok=True)
-    Path(sharepath).mkdir(exist_ok=True)
-    Path(binpath).mkdir(exist_ok=True)
-    Path(savefigpath).mkdir(exist_ok=True)
+    path2build.mkdir(exist_ok=True)
+    sharepath.mkdir(exist_ok=True)
+    binpath.mkdir(exist_ok=True)
+    savefigpath.mkdir(exist_ok=True)
 
 ### --- delete any existing initial conditions --- ###
-os.system("rm " + gridfile)
-os.system("rm " + initSDsfile)
-os.system("rm " + thermofile[:-4] + "*")
+shutil.rmtree(gridfile, ignore_errors=True)
+shutil.rmtree(initSDsfile, ignore_errors=True)
+shutil.rmtree(
+    str(thermofiles)[:-4] + "*", ignore_errors=True
+)  # delete any existing dataset
 
 fromfile_inputfiles.main(
-    path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile
+    path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofiles
 )
 ### ---------------------------------------------------------------- ###
 ### ---------------------------------------------------------------- ###
@@ -83,12 +88,12 @@ fromfile_inputfiles.main(
 ### ---------------------- RUN CLEO EXECUTABLE --------------------- ###
 ### ---------------------------------------------------------------- ###
 os.chdir(path2build)
-os.system("pwd")
-os.system("rm -rf " + dataset)  # delete any existing dataset
-executable = path2build + "/examples/fromfile/src/fromfile"
-print("Executable: " + executable)
-print("Config file: " + configfile)
-os.system(executable + " " + configfile)
+subprocess.run(["pwd"])
+shutil.rmtree(dataset, ignore_errors=True)  # delete any existing dataset
+executable = path2build / "examples" / "fromfile" / "src" / "fromfile"
+print("Executable: " + str(executable))
+print("Config file: " + str(configfile))
+subprocess.run([executable, configfile])
 ### ---------------------------------------------------------------- ###
 ### ---------------------------------------------------------------- ###
 
@@ -109,11 +114,11 @@ thermo, winds = pyzarr.get_thermodata(
 )
 
 # plot super-droplet results
-savename = savefigpath + "fromfile_maxnsupers_validation.png"
+savename = savefigpath / "fromfile_maxnsupers_validation.png"
 pltmoms.plot_totnsupers(time, maxnsupers, savename=savename)
 
 nsample = 1000
-savename = savefigpath + "fromfile_motion2d_validation.png"
+savename = savefigpath / "fromfile_motion2d_validation.png"
 pltsds.plot_randomsample_superdrops_2dmotion(
     sddata,
     config["maxnsupers"],

--- a/examples/fromfile/fromfile.sh
+++ b/examples/fromfile/fromfile.sh
@@ -7,7 +7,7 @@
 #SBATCH --time=00:05:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./fromfile_out.%j.out
 #SBATCH --error=./fromfile_err.%j.out
 

--- a/examples/fromfile/fromfile_inputfiles.py
+++ b/examples/fromfile/fromfile_inputfiles.py
@@ -23,11 +23,11 @@ read from binary files.
 import sys
 
 
-def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
+def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofiles):
     import numpy as np
     import matplotlib.pyplot as plt
 
-    sys.path.append(path2CLEO)  # for imports from pySD package
+    sys.path.append(str(path2CLEO))  # for imports from pySD package
 
     from src import gen_input_thermo
     from pySD.gbxboundariesbinary_src import read_gbxboundaries as rgrid
@@ -48,12 +48,12 @@ def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
     ### ---------------------------------------------------------------- ###
     ### --- essential paths and filenames --- ###
     # path and filenames for creating initial SD conditions
-    constsfile = path2CLEO + "/libs/cleoconstants.hpp"
+    constsfile = path2CLEO / "libs" / "cleoconstants.hpp"
 
     ### --- plotting initialisation figures --- ###
     # booleans for [making, saving] initialisation figures
     isfigures = [True, True]
-    savefigpath = path2build + "/bin/"  # directory for saving figures
+    savefigpath = path2build / "bin"  # directory for saving figures
 
     ### --- settings for 3-D gridbox boundaries --- ###
     zgrid = [0, 1500, 60]  # evenly spaced zhalf coords [zmin, zmax, zdelta] [m]
@@ -98,7 +98,7 @@ def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
         PRESSz0, TEMPz0, qvapz0, qcondz0, WMAX, Zlength, Xlength, VMAX, Ylength
     )
     cthermo.write_thermodynamics_binary(
-        thermofile, thermodyngen, configfile, constsfile, gridfile
+        thermofiles, thermodyngen, configfile, constsfile, gridfile
     )
 
     ### ----- write initial superdroplets binary ----- ###
@@ -121,7 +121,7 @@ def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
     if isfigures[0]:
         rgrid.plot_gridboxboundaries(constsfile, gridfile, savefigpath, isfigures[1])
         rthermo.plot_thermodynamics(
-            constsfile, configfile, gridfile, thermofile, savefigpath, isfigures[1]
+            constsfile, configfile, gridfile, thermofiles, savefigpath, isfigures[1]
         )
         plt.close()
     ### ---------------------------------------------------------------- ###
@@ -129,5 +129,5 @@ def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
 
 
 if __name__ == "__main__":
-    ### args = path2CLEO, path2build, configfile, binpath, gridfile, initSDsfile, thermofile
+    ### args = path2CLEO, path2build, configfile, binpath, gridfile, initSDsfile, thermofiles
     main(*sys.argv[1:])

--- a/examples/fromfile/src/plot_output_thermo.py
+++ b/examples/fromfile/src/plot_output_thermo.py
@@ -24,6 +24,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.gridspec import GridSpec
 from matplotlib import colors
+from pathlib import Path
 
 
 def plot_domain_thermodynamics_timeseries(time, gbxs, thermo, winds, savedir):
@@ -99,9 +100,9 @@ def plot_timeseries_domain_slices(
     fig.tight_layout()
 
     if savedir != "":
-        savename = savedir + "/timeseries_" + key + ".png"
+        savename = savedir / Path(f"timeseries_{key}.png")
         fig.savefig(savename, dpi=400, bbox_inches="tight", facecolor="w", format="png")
-        print("Figure .png saved as: " + savename)
+        print("Figure .png saved as: " + str(savename))
         plt.show()
 
 

--- a/examples/fromfile_irreg/fromfile_irreg.py
+++ b/examples/fromfile_irreg/fromfile_irreg.py
@@ -22,17 +22,20 @@ Plots output data as .png files for visual checks.
 """
 
 import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 import fromfile_irreg_inputfiles
 
-path2CLEO = sys.argv[1]
-path2build = sys.argv[2]
-configfile = sys.argv[3]
+path2CLEO = Path(sys.argv[1])
+path2build = Path(sys.argv[2])
+configfile = Path(sys.argv[3])
 
-sys.path.append(path2CLEO)  # for imports from pySD package
-# for imports from example plotting package
-sys.path.append(path2CLEO + "/examples/exampleplotting/")
+sys.path.append(str(path2CLEO))  # imports from pySD
+sys.path.append(
+    str(path2CLEO / "examples" / "exampleplotting")
+)  # imports from example plots package
 
 from src import plot_output_thermo
 from plotssrc import pltsds, pltmoms
@@ -43,16 +46,16 @@ from pySD.sdmout_src import pyzarr, pysetuptxt, pygbxsdat
 ### ---------------------------------------------------------------- ###
 ### --- essential paths and filenames --- ###
 # path and filenames for creating initial SD conditions
-binpath = path2build + "/bin/"
-sharepath = path2build + "/share/"
-gridfile = sharepath + "fromfile_irreg_dimlessGBxboundaries.dat"
-initSDsfile = sharepath + "fromfile_irreg_dimlessSDsinit.dat"
-thermofile = sharepath + "/fromfile_irreg_dimlessthermo.dat"
-savefigpath = path2build + "/bin/"  # directory for saving figures
+binpath = path2build / "bin"
+sharepath = path2build / "share"
+gridfile = sharepath / "fromfile_irreg_dimlessGBxboundaries.dat"
+initSDsfile = sharepath / "fromfile_irreg_dimlessSDsinit.dat"
+thermofiles = sharepath / "fromfile_irreg_dimlessthermo.dat"
+savefigpath = path2build / "bin"  # directory for saving figures
 
 # path and file names for plotting results
-setupfile = binpath + "fromfile_irreg_setup.txt"
-dataset = binpath + "fromfile_irreg_sol.zarr"
+setupfile = binpath / "fromfile_irreg_setup.txt"
+dataset = binpath / "fromfile_irreg_sol.zarr"
 ### ---------------------------------------------------------------- ###
 ### ---------------------------------------------------------------- ###
 
@@ -63,18 +66,19 @@ dataset = binpath + "fromfile_irreg_sol.zarr"
 if path2CLEO == path2build:
     raise ValueError("build directory cannot be CLEO")
 else:
-    Path(path2build).mkdir(exist_ok=True)
-    Path(sharepath).mkdir(exist_ok=True)
-    Path(binpath).mkdir(exist_ok=True)
-    Path(savefigpath).mkdir(exist_ok=True)
+    path2build.mkdir(exist_ok=True)
+    sharepath.mkdir(exist_ok=True)
+    binpath.mkdir(exist_ok=True)
+    savefigpath.mkdir(exist_ok=True)
 
 ### --- delete any existing initial conditions --- ###
-os.system("rm " + gridfile)
-os.system("rm " + initSDsfile)
-os.system("rm " + thermofile[:-4] + "*")
+shutil.rmtree(gridfile, ignore_errors=True)
+shutil.rmtree(initSDsfile, ignore_errors=True)
+all_thermofiles = thermofiles.parent / Path(f"{thermofiles.stem}*{thermofiles.suffix}")
+shutil.rmtree(all_thermofiles, ignore_errors=True)
 
 fromfile_irreg_inputfiles.main(
-    path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile
+    path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofiles
 )
 ### ---------------------------------------------------------------- ###
 ### ---------------------------------------------------------------- ###
@@ -83,12 +87,12 @@ fromfile_irreg_inputfiles.main(
 ### ---------------------- RUN CLEO EXECUTABLE --------------------- ###
 ### ---------------------------------------------------------------- ###
 os.chdir(path2build)
-os.system("pwd")
-os.system("rm -rf " + dataset)  # delete any existing dataset
-executable = path2build + "/examples/fromfile_irreg/src/fromfile_irreg"
-print("Executable: " + executable)
-print("Config file: " + configfile)
-os.system(executable + " " + configfile)
+subprocess.run(["pwd"])
+shutil.rmtree(dataset, ignore_errors=True)  # delete any existing dataset
+executable = path2build / "examples" / "fromfile_irreg" / "src" / "fromfile_irreg"
+print("Executable: " + str(executable))
+print("Config file: " + str(configfile))
+subprocess.run([executable, configfile])
 ### ---------------------------------------------------------------- ###
 ### ---------------------------------------------------------------- ###
 
@@ -109,11 +113,11 @@ thermo, winds = pyzarr.get_thermodata(
 )
 
 # plot super-droplet results
-savename = savefigpath + "fromfile_irreg_maxnsupers_validation.png"
+savename = savefigpath / "fromfile_irreg_maxnsupers_validation.png"
 pltmoms.plot_totnsupers(time, maxnsupers, savename=savename)
 
 nsample = 1000
-savename = savefigpath + "fromfile_irreg_motion2d_validation.png"
+savename = savefigpath / "fromfile_irreg_motion2d_validation.png"
 pltsds.plot_randomsample_superdrops_2dmotion(
     sddata,
     config["maxnsupers"],

--- a/examples/fromfile_irreg/fromfile_irreg.sh
+++ b/examples/fromfile_irreg/fromfile_irreg.sh
@@ -7,7 +7,7 @@
 #SBATCH --time=00:05:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./fromfile_irreg_out.%j.out
 #SBATCH --error=./fromfile_irreg_err.%j.out
 

--- a/examples/fromfile_irreg/fromfile_irreg_inputfiles.py
+++ b/examples/fromfile_irreg/fromfile_irreg_inputfiles.py
@@ -23,11 +23,11 @@ time varying thermodynamics read from binary files.
 import sys
 
 
-def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
+def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofiles):
     import numpy as np
     import matplotlib.pyplot as plt
 
-    sys.path.append(path2CLEO)  # for imports from pySD package
+    sys.path.append(str(path2CLEO))  # for imports from pySD package
 
     from src import gen_input_thermo
     from pySD.gbxboundariesbinary_src import read_gbxboundaries as rgrid
@@ -48,12 +48,12 @@ def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
     ### ---------------------------------------------------------------- ###
     ### --- essential paths and filenames --- ###
     # path and filenames for creating initial SD conditions
-    constsfile = path2CLEO + "/libs/cleoconstants.hpp"
+    constsfile = path2CLEO / "libs" / "cleoconstants.hpp"
 
     ### --- plotting initialisation figures --- ###
     # booleans for [making, saving] initialisation figures
     isfigures = [True, True]
-    savefigpath = path2build + "/bin/"  # directory for saving figures
+    savefigpath = path2build / "bin"  # directory for saving figures
 
     ### --- settings for 3-D irregular gridbox boundaries --- ###
     zgrid = np.array([0, 20, 30, 45, 60, 80, 90, 120, 140, 180, 360, 500, 1000, 1500])
@@ -100,7 +100,7 @@ def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
         PRESSz0, TEMPz0, qvapz0, qcondz0, WMAX, Zlength, Xlength, VMAX, Ylength
     )
     cthermo.write_thermodynamics_binary(
-        thermofile, thermodyngen, configfile, constsfile, gridfile
+        thermofiles, thermodyngen, configfile, constsfile, gridfile
     )
 
     ### ----- write initial superdroplets binary ----- ###
@@ -123,7 +123,7 @@ def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
     if isfigures[0]:
         rgrid.plot_gridboxboundaries(constsfile, gridfile, savefigpath, isfigures[1])
         rthermo.plot_thermodynamics(
-            constsfile, configfile, gridfile, thermofile, savefigpath, isfigures[1]
+            constsfile, configfile, gridfile, thermofiles, savefigpath, isfigures[1]
         )
         plt.close()
     ### ---------------------------------------------------------------- ###
@@ -131,5 +131,5 @@ def main(path2CLEO, path2build, configfile, gridfile, initSDsfile, thermofile):
 
 
 if __name__ == "__main__":
-    ### args = path2CLEO, path2build, configfile, binpath, gridfile, initSDsfile, thermofile
+    ### args = path2CLEO, path2build, configfile, binpath, gridfile, initSDsfile, thermofiles
     main(*sys.argv[1:])

--- a/examples/fromfile_irreg/src/plot_output_thermo.py
+++ b/examples/fromfile_irreg/src/plot_output_thermo.py
@@ -24,6 +24,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.gridspec import GridSpec
 from matplotlib import colors
+from pathlib import Path
 
 
 def plot_domain_thermodynamics_timeseries(time, gbxs, thermo, winds, savedir):
@@ -97,9 +98,9 @@ def plot_timeseries_domain_slices(
     plt.colorbar(pcm, cax=cax, orientation="horizontal")
 
     if savedir != "":
-        savename = savedir + "/timeseries_" + key + ".png"
+        savename = savedir / Path(f"timeseries_{key}.png")
         fig.savefig(savename, dpi=400, bbox_inches="tight", facecolor="w", format="png")
-        print("Figure .png saved as: " + savename)
+        print("Figure .png saved as: " + str(savename))
         plt.show()
 
 

--- a/examples/rainshaft1d/rainshaft1d.sh
+++ b/examples/rainshaft1d/rainshaft1d.sh
@@ -8,7 +8,7 @@
 #SBATCH --time=00:10:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./rain1d_out.%j.out
 #SBATCH --error=./rain1d_err.%j.out
 

--- a/examples/run_example.sh
+++ b/examples/run_example.sh
@@ -7,7 +7,7 @@
 #SBATCH --time=00:10:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./runexample_out.%j.out
 #SBATCH --error=./runexample_err.%j.out
 
@@ -30,9 +30,9 @@ executables="$5"
 pythonscript=$6
 script_args="$7"
 
-cleoenv=/work/mh1126/m300950/cleoenv
+cleoenv=/work/bm1183/m300950/mambaenvs/cleoenv
 python=${cleoenv}/bin/python3
-yacyaxtroot=/work/mh1126/m300950/yac
+yacyaxtroot=/work/bm1183/m300950/yac
 spack load cmake@3.23.1%gcc
 module load python3/2022.01-gcc-11.2.0
 source activate ${cleoenv}

--- a/examples/speedtest/speedtest.sh
+++ b/examples/speedtest/speedtest.sh
@@ -8,7 +8,7 @@
 #SBATCH --time=00:30:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./speedtest_out.%j.out
 #SBATCH --error=./speedtest_err.%j.out
 

--- a/libs/cartesiandomain/add_supers_at_domain_top.cpp
+++ b/libs/cartesiandomain/add_supers_at_domain_top.cpp
@@ -290,7 +290,7 @@ std::pair<size_t, double> CreateSuperdrop::new_xi_radius(const double gbxvolume)
   const auto radius = double{std::pow(10.0, log10r)};
 
   const auto nconc = dist.droplet_numconc_distribution(log10r, log10rup, log10rlow);
-  const auto xi = (uint64_t)std::round(nconc * gbxvolume);  // cast double to uint64_t
+  const auto xi =  static_cast<uint64_t>(std::round(nconc * gbxvolume));
 
   return std::make_pair(xi, radius);  // xi_radius
 }

--- a/libs/cleoconstants.hpp
+++ b/libs/cleoconstants.hpp
@@ -114,10 +114,8 @@ constexpr double surfconst = 4.0 * DC::SURFSIGMA * std::numbers::pi * R0 * R0;
  *
  */
 namespace LIMITVALUES {
-constexpr unsigned int uintmax =
-    std::numeric_limits<unsigned int>::max(); /**< Maximum unsigned int. */
-constexpr uint64_t uint64_t_max =
-    std::numeric_limits<uint64_t>::max(); /**< Maximum 64 byte unsigned int. */
+constexpr unsigned int uintmax = std::numeric_limits<unsigned int>::max(); /**< Max unsigned int. */
+constexpr uint64_t uint64_t_max = std::numeric_limits<uint64_t>::max(); /**< Max 64 byte u-int. */
 
 constexpr double llim = -1.0 * std::numeric_limits<double>::max(); /**< Maximum negative double. */
 constexpr double ulim = std::numeric_limits<double>::max();        /**< Maximum positive double. */

--- a/libs/superdrops/collisions/breakup.hpp
+++ b/libs/superdrops/collisions/breakup.hpp
@@ -167,8 +167,8 @@ KOKKOS_FUNCTION void DoBreakup<NFrags>::twin_superdroplet_breakup(Superdrop &dro
   const auto totnfrags = double{nfrags(drop1, drop2) * old_xi};
   assert(((totnfrags / old_xi) > 2.5) && "nfrags must be > 2.5");
 
-  const auto new_xi1 = (uint64_t)Kokkos::round(totnfrags / 2);        // cast double to uint64_t
-  const auto new_xi2 = (uint64_t)Kokkos::round(totnfrags - new_xi1);  // cast double to uint64_t
+  const auto new_xi1 = static_cast<uint64_t>(Kokkos::round(totnfrags / 2));
+  const auto new_xi2 = static_cast<uint64_t>(Kokkos::round(totnfrags - new_xi1));
   const auto new_xitot = new_xi1 + new_xi2;
   assert((new_xi2 > old_xi) && "nfrags must increase the drop2's multiplicity during breakup");
   assert((new_xitot > (old_xi * 2)) && "nfrags must increase total multiplicity during breakup");
@@ -205,7 +205,7 @@ KOKKOS_FUNCTION void DoBreakup<NFrags>::different_superdroplet_breakup(Superdrop
   drop1.set_xi(new_xi1);
 
   const auto totnfrags = double{nfrags(drop1, drop2) * old_xi2};
-  const auto new_xi2 = (uint64_t)Kokkos::round(totnfrags);  // cast double to uint64_t
+  const auto new_xi2 = static_cast<uint64_t>(Kokkos::round(totnfrags));
   assert(((totnfrags / old_xi2) > 2.5) && "nfrags must be > 2.5");
 
   assert((new_xi2 > old_xi2) && "nfrags must increase the drop2's multiplicity during breakup");

--- a/pySD/gbxboundariesbinary_src/read_gbxboundaries.py
+++ b/pySD/gbxboundariesbinary_src/read_gbxboundaries.py
@@ -222,14 +222,15 @@ def plot_gridboxboundaries(constsfile, gridfile, binpath, savefig):
 
     fig.tight_layout()
     if savefig:
+        savename = binpath / "gridboxboundaries.png"
         fig.savefig(
-            binpath + "gridboxboundaries.png",
+            savename,
             dpi=400,
             bbox_inches="tight",
             facecolor="w",
             format="png",
         )
-        print("Figure .png saved as: " + binpath + "gridboxboundaries.png")
+        print("Figure .png saved as: " + str(savename))
     plt.show()
 
 

--- a/pySD/initsuperdropsbinary_src/read_initsuperdrops.py
+++ b/pySD/initsuperdropsbinary_src/read_initsuperdrops.py
@@ -193,20 +193,21 @@ def plot_initGBxs_attrdistribs(
 
     if isinstance(gbxs2plt, int):
         gbxidxs = [gbxs2plt]
-        savename = binpath + "initGBx" + str(gbxs2plt) + "_distrib" + savelabel + ".png"
+        savename = "initGBx" + str(gbxs2plt) + "_distrib" + savelabel + ".png"
     elif gbxs2plt == "all":
         gbxidxs = np.unique(attrs.sdgbxindex)
-        savename = binpath + "initallGBxs_distribs" + savelabel + ".png"
+        savename = "initallGBxs_distribs" + savelabel + ".png"
     else:
         gbxidxs = [int(g) for g in gbxs2plt]
-        savename = binpath + "initGBxs_distribs" + savelabel + ".png"
+        savename = "initGBxs_distribs" + savelabel + ".png"
 
     fig, axs, lines = plot_initdistribs(attrs, gbxvols, gbxidxs)
 
     fig.tight_layout()
     if savefig:
+        savename = binpath / savename
         fig.savefig(savename, dpi=400, bbox_inches="tight", facecolor="w", format="png")
-        print("Figure .png saved as: " + savename)
+        print("Figure .png saved as: " + str(savename))
     plt.show()
 
 
@@ -396,15 +397,13 @@ def plot_initGBxs_dropletmasses(
 
     if isinstance(gbxs2plt, int):
         gbxidxs = [gbxs2plt]
-        savename = (
-            binpath + "initGBx" + str(gbxs2plt) + "_dropletmasses" + savelabel + ".png"
-        )
+        savename = "initGBx" + str(gbxs2plt) + "_dropletmasses" + savelabel + ".png"
     elif gbxs2plt == "all":
         gbxidxs = np.unique(attrs.sdgbxindex)
-        savename = binpath + "initallGBxs_dropletmasses" + savelabel + ".png"
+        savename = "initallGBxs_dropletmasses" + savelabel + ".png"
     else:
         gbxidxs = [int(g) for g in gbxs2plt]
-        savename = binpath + "initGBxs_dropletmasses" + savelabel + ".png"
+        savename = "initGBxs_dropletmasses" + savelabel + ".png"
 
     fig, axs, lines = plot_massdistribs(
         attrs, gbxvols, gbxidxs, inputs["RHO_L"], inputs["RHO_SOL"]
@@ -412,8 +411,9 @@ def plot_initGBxs_dropletmasses(
 
     fig.tight_layout()
     if savefig:
+        savename = binpath / savename
         fig.savefig(savename, dpi=400, bbox_inches="tight", facecolor="w", format="png")
-        print("Figure .png saved as: " + savename)
+        print("Figure .png saved as: " + str(savename))
     plt.show()
 
 

--- a/pySD/readbinary.py
+++ b/pySD/readbinary.py
@@ -8,7 +8,7 @@ def readbinary(filename, isprint=True):
     """return list of vectors containing dimenionsless
     data read from binary file"""
 
-    print("Reading binary file:\n " + filename)
+    print("Reading binary file:\n " + str(filename))
 
     nvars, metabytes, metapervar = read_metadata(filename, isprint=isprint)
 

--- a/pySD/sdmout_src/ensembzarr.py
+++ b/pySD/sdmout_src/ensembzarr.py
@@ -20,7 +20,7 @@ functions to write a new zarr dataset and
 setuptxt file for an ensemble of datasets
 """
 
-import os
+import shutil
 import sys
 import numpy as np
 import zarr
@@ -55,7 +55,7 @@ def write_ensemb_setupfile(ensembsetupfile, setupfile, datasets):
     """copy setupfile to ensembsetupfile and then edit / add
     information relevant to datasets used to make ensemble"""
 
-    os.system("cp " + setupfile + " " + ensembsetupfile)
+    shutil.copy(setupfile, ensembsetupfile)
     params = {
         "initsupers_filename": "[ensemble, see below]",
         "setup_filename": "[ensemble, see below]",
@@ -129,7 +129,7 @@ def write_matchingarray_to_storage(arrayname, arr, refz, zattrs):
     )
     z[:] = arr
 
-    os.system("cp " + zattrs + " " + arrayname + "/.zattrs")
+    shutil.copy(zattrs, arrayname + "/.zattrs")
 
 
 def write_meanvars_to_ensembzarr(ensembdataset, vars4ensemb, datasets, refset):

--- a/pySD/sdmout_src/massmoms.py
+++ b/pySD/sdmout_src/massmoms.py
@@ -21,6 +21,7 @@ python class to handle mass moments data from SDM zarr store in cartesian domain
 
 import numpy as np
 import xarray as xr
+from pathlib import Path
 
 
 class MassMoms:
@@ -53,7 +54,7 @@ class MassMoms:
         )  # probably grams
 
     def tryopen_dataset(self, dataset):
-        if isinstance(dataset, str):
+        if isinstance(dataset, str) or isinstance(dataset, Path):
             print("mass moments dataset: ", dataset)
             return xr.open_dataset(dataset, engine="zarr", consolidated=False)
         else:

--- a/pySD/sdmout_src/pyzarr.py
+++ b/pySD/sdmout_src/pyzarr.py
@@ -23,6 +23,7 @@ of superdroplet attributes
 import numpy as np
 import xarray as xr
 import awkward as ak
+from pathlib import Path
 
 from . import thermodata
 from . import supersdata
@@ -46,7 +47,7 @@ def get_rawdata4raggedkey(dataset, key):
 def raggedvar_fromzarr(ds, raggedcount, var):
     """returns ragged ak.Array dims [time, ragged]
     for a variable "var" in zarr ds"""
-    if isinstance(ds, str):
+    if isinstance(ds, str) or isinstance(ds, Path):
         ds = get_rawdataset(ds)
 
     return ak.unflatten(ds[var].values, raggedcount)
@@ -55,7 +56,7 @@ def raggedvar_fromzarr(ds, raggedcount, var):
 def var4d_fromzarr(ds, ntime, ndims, key):
     """' returns 4D variable with dims
     [time, y, x, z] from zarr dataset "ds" """
-    if isinstance(ds, str):
+    if isinstance(ds, str) or isinstance(ds, Path):
         ds = get_rawdataset(ds)
 
     reshape = [ntime] + list(ndims)
@@ -65,7 +66,7 @@ def var4d_fromzarr(ds, ntime, ndims, key):
 def var3d_fromzarr(ds, ndims, key):
     """' returns 3D variable with dims
     [y, x, z] from zarr dataset "ds" """
-    if isinstance(ds, str):
+    if isinstance(ds, str) or isinstance(ds, Path):
         ds = get_rawdataset(ds)
 
     return np.reshape(ds[key].values, ndims)
@@ -111,7 +112,7 @@ def get_gbxindex(dataset, ndims):
 
 
 def get_totnsupers(dataset):
-    if isinstance(dataset, str):
+    if isinstance(dataset, str) or isinstance(dataset, Path):
         dataset = get_rawdataset(dataset)
     try:
         return dataset["totnsupers"].values

--- a/pySD/sdmout_src/supersdata.py
+++ b/pySD/sdmout_src/supersdata.py
@@ -22,6 +22,7 @@ python class to handle superdroplet attributes data from SDM zarr store in ragge
 import numpy as np
 import xarray as xr
 import awkward as ak
+from pathlib import Path
 
 
 class SuperdropProperties:
@@ -126,7 +127,7 @@ class SupersData(SuperdropProperties):
         self.coord2_units = self.tryunits(ds, "coord2")  # probably meters
 
     def tryopen_dataset(self, dataset):
-        if isinstance(dataset, str):
+        if isinstance(dataset, str) or isinstance(dataset, Path):
             print("supers dataset: ", dataset)
             return xr.open_dataset(dataset, engine="zarr", consolidated=False)
         else:

--- a/pySD/sdmout_src/thermodata.py
+++ b/pySD/sdmout_src/thermodata.py
@@ -21,12 +21,13 @@ python class to handle thermodynamics and wind fields data from SDM zarr store i
 
 import numpy as np
 import xarray as xr
+from pathlib import Path
 
 from . import thermoeqns
 
 
 def thermotryopen_dataset(dataset):
-    if isinstance(dataset, str):
+    if isinstance(dataset, str) or isinstance(dataset, Path):
         print("thermodynamic fields dataset: ", dataset)
         return xr.open_dataset(dataset, engine="zarr", consolidated=False)
     else:

--- a/pySD/sdmout_src/timedata.py
+++ b/pySD/sdmout_src/timedata.py
@@ -20,6 +20,7 @@ python class to get time data from SDM zarr store and return in various formats
 """
 
 import xarray as xr
+from pathlib import Path
 
 
 class Time:
@@ -36,7 +37,7 @@ class Time:
     def tryopen_time(self, dataset):
         """returns time variable (with metadata) from xarray dataset"""
 
-        if isinstance(dataset, str):
+        if isinstance(dataset, str) or isinstance(dataset, Path):
             print("time from dataset: ", dataset)
             timeds = xr.open_dataset(dataset, engine="zarr", consolidated=False)["time"]
         else:

--- a/pySD/thermobinary_src/create_thermodynamics.py
+++ b/pySD/thermobinary_src/create_thermodynamics.py
@@ -190,7 +190,7 @@ def check_datashape(thermodata, ndata, ndims, ntime):
 
 
 def write_thermodynamics_binary(
-    thermofile, thermogen, configfile, constsfile, gridfile
+    thermofiles, thermogen, configfile, constsfile, gridfile
 ):
     """write binarys for thermodynamic data over time on C staggered
     grid. So that pressure, temperature, qvap and qcond are defined at
@@ -220,8 +220,6 @@ def write_thermodynamics_binary(
     units += [b"m"] * 3  # velocity units
     scale_factors = np.asarray(scale_factors, dtype=np.double)
 
-    idot = [i for i, ltr in enumerate(thermofile) if ltr == "."][-1]
-    filestem, filetype = thermofile[:idot], thermofile[idot:]
     varat = ["centres"] * 4 + ["z-faces", "x-faces", "y-faces"]
     for v, var in enumerate(thermodata.keys()):
         if thermodata[var] != []:
@@ -247,7 +245,8 @@ def write_thermodynamics_binary(
                 + str(inputs["ntime"])
                 + " time steps)"
             )
-            filename = filestem + "_" + var + filetype
+            filename = f"{thermofiles.stem}_{var}{thermofiles.suffix}"
+            filename = thermofiles.parent / filename
             writebinary.writebinary(
                 filename,
                 thermodata[var],

--- a/pySD/writebinary.py
+++ b/pySD/writebinary.py
@@ -44,7 +44,7 @@ def writebinary(filename, data, ndata, datatypes, units, scale_factors, metastr)
     array2write = metadata + data
     format = metaformat + dataformat
 
-    print("Writing gridbox boundaries binary file to:\n " + filename)
+    print("Writing gridbox boundaries binary file to:\n " + str(filename))
     s = struct.pack(format, *array2write)
     f = open(filename, "wb")
     f.write(s)

--- a/roughpaper/scratch/build_compile_test.sh
+++ b/roughpaper/scratch/build_compile_test.sh
@@ -8,7 +8,7 @@
 #SBATCH --time=00:05:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./roughCLEO_out.%j.out
 #SBATCH --error=./roughCLEO_err.%j.out
 
@@ -22,7 +22,7 @@ dobuild=$1 # == "build" or otherwise
 module load gcc/11.2.0-gcc-11.2.0
 module load nvhpc/23.9-gcc-11.2.0
 spack load cmake@3.23.1%gcc
-source activate /work/mh1126/m300950/cleoenv
+source activate /work/bm1183/m300950/mambaenvs/cleoenv
 path2CLEO=${HOME}/CLEO/
 path2build=${HOME}/CLEO/roughpaper/scratch/build/
 gxx="/sw/spack-levante/gcc-11.2.0-bcn7mb/bin/g++"

--- a/scripts/bash/build_cleo.sh
+++ b/scripts/bash/build_cleo.sh
@@ -7,7 +7,7 @@
 #SBATCH --time=00:05:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./build/bin/build_cleo_out.%j.out
 #SBATCH --error=./build/bin/build_cleo_err.%j.out
 

--- a/scripts/bash/build_cleo_cuda_openmp.sh
+++ b/scripts/bash/build_cleo_cuda_openmp.sh
@@ -8,7 +8,7 @@
 #SBATCH --time=00:05:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./build/bin/cudaopenmpbuild_out.%j.out
 #SBATCH --error=./build/bin/cudaopenmpbuild_err.%j.out
 

--- a/scripts/bash/build_cleo_openmp.sh
+++ b/scripts/bash/build_cleo_openmp.sh
@@ -7,7 +7,7 @@
 #SBATCH --time=00:05:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./build/bin/openmpbuild_out.%j.out
 #SBATCH --error=./build/bin/openmpbuild_err.%j.out
 

--- a/scripts/bash/build_cleo_serial.sh
+++ b/scripts/bash/build_cleo_serial.sh
@@ -7,7 +7,7 @@
 #SBATCH --time=00:05:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./build/bin/serialbuild_out.%j.out
 #SBATCH --error=./build/bin/serialbuild_err.%j.out
 

--- a/scripts/bash/compile_cleo.sh
+++ b/scripts/bash/compile_cleo.sh
@@ -8,7 +8,7 @@
 #SBATCH --time=00:30:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./compile_cleo_out.%j.out
 #SBATCH --error=./compile_cleo_err.%j.out
 

--- a/scripts/bash/install_yac.sh
+++ b/scripts/bash/install_yac.sh
@@ -7,7 +7,7 @@
 #SBATCH --time=00:10:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./build/bin/install_yac_out.%j.out
 #SBATCH --error=./build/bin/install_yac_err.%j.out
 

--- a/scripts/bash/run_cleo.sh
+++ b/scripts/bash/run_cleo.sh
@@ -8,7 +8,7 @@
 #SBATCH --time=00:30:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./run_cleo_out.%j.out
 #SBATCH --error=./run_cleo_err.%j.out
 

--- a/scripts/build_compile_cleocoupledsdm.sh
+++ b/scripts/build_compile_cleocoupledsdm.sh
@@ -8,7 +8,7 @@
 #SBATCH --time=00:05:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./build/bin/build_cleocoupledsdm_out.%j.out
 #SBATCH --error=./build/bin/build_cleocoupledsdm_err.%j.out
 
@@ -17,13 +17,13 @@
 ### ----- (your environment and) directory paths ------- ###
 ### ---------- and executable(s) to compile ------------ ###
 spack load cmake@3.23.1%gcc
-cleoenv=/work/mh1126/m300950/cleoenv
+cleoenv=/work/bm1183/m300950/mambaenvs/cleoenv
 
 buildtype=$1
 enableyac=${2:-false}                     # "true" or otherwise
 path2CLEO=${3:-${HOME}/CLEO}
 path2build=${4:-${path2CLEO}/build}
-yacyaxtroot=/work/mh1126/m300950/yac      # used if enableyac == "true"
+yacyaxtroot=/work/bm1183/m300950/yac      # used if enableyac == "true"
 executables="cleocoupledsdm"
 ### ---------------------------------------------------- ###
 

--- a/scripts/compile_run_cleocoupledsdm.sh
+++ b/scripts/compile_run_cleocoupledsdm.sh
@@ -8,7 +8,7 @@
 #SBATCH --time=00:30:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./run_cleocoupledsdm_out.%j.out
 #SBATCH --error=./run_cleocoupledsdm_err.%j.out
 
@@ -21,7 +21,7 @@
 ### ----- (your environment and) directory paths ------- ###
 ### ------------ and executable to compile ------------- ###
 
-cleoenv=/work/mh1126/m300950/cleoenv
+cleoenv=/work/bm1183/m300950/mambaenvs/cleoenv
 buildtype=$1
 path2CLEO=${2:-${HOME}/CLEO}
 path2build=${3:-${path2CLEO}/build} # get from command line argument

--- a/scripts/create_gbxboundariesbinary_script.py
+++ b/scripts/create_gbxboundariesbinary_script.py
@@ -34,20 +34,20 @@ from pySD.gbxboundariesbinary_src.read_gbxboundaries import (
 
 ### ----------------------- INPUT PARAMETERS ----------------------- ###
 ### absolute or relative paths for build and CLEO directories
-path2CLEO = sys.argv[1]
-path2build = sys.argv[2]
-configfile = sys.argv[3]
+path2CLEO = Path(sys.argv[1])
+path2build = Path(sys.argv[2])
+configfile = Path(sys.argv[3])
 
 # booleans for [making, saving] initialisation figures
 isfigures = [True, True]
 
 ### essential paths and filenames
-constsfile = path2CLEO + "/libs/cleoconstants.hpp"
-binariespath = path2build + "/share/"
-savefigpath = path2build + "/bin/"
+constsfile = path2CLEO / "libs" / "cleoconstants.hpp"
+binariespath = path2build / "share"
+savefigpath = path2build / "bin"
 
 gridfile = (
-    binariespath + "/dimlessGBxboundaries.dat"
+    binariespath / "dimlessGBxboundaries.dat"
 )  # note this should match config.yaml
 
 ### input parameters for zcoords of gridbox boundaries
@@ -70,8 +70,8 @@ ygrid = np.asarray([0, 20])
 if path2CLEO == path2build:
     raise ValueError("build directory cannot be CLEO")
 else:
-    Path(path2build).mkdir(exist_ok=True)
-    Path(binariespath).mkdir(exist_ok=True)
+    path2build.mkdir(exist_ok=True)
+    binariespath.mkdir(exist_ok=True)
 
 ### write gridbox boundaries binary
 write_gridboxboundaries_binary(gridfile, zgrid, xgrid, ygrid, constsfile)
@@ -80,6 +80,6 @@ print_domain_info(constsfile, gridfile)
 ### plot gridbox boundaries binary
 if isfigures[0]:
     if isfigures[1]:
-        Path(savefigpath).mkdir(exist_ok=True)
+        savefigpath.mkdir(exist_ok=True)
     plot_gridboxboundaries(constsfile, gridfile, savefigpath, isfigures[1])
 ### ---------------------------------------------------------------- ###

--- a/scripts/create_initsuperdropsbinary_script.py
+++ b/scripts/create_initsuperdropsbinary_script.py
@@ -32,24 +32,24 @@ from pySD.initsuperdropsbinary_src import read_initsuperdrops as rsupers
 ### ----------------------- INPUT PARAMETERS ----------------------- ###
 ### --- absolute or relative paths for --- ###
 ### ---   build and CLEO directories --- ###
-path2CLEO = sys.argv[1]
-path2build = sys.argv[2]
-configfile = sys.argv[3]
+path2CLEO = Path(sys.argv[1])
+path2build = Path(sys.argv[2])
+configfile = Path(sys.argv[3])
 
 # booleans for [making, saving] initialisation figures
 isfigures = [True, True]
 gbxs2plt = "all"  # indexes of GBx index of SDs to plot (nb. "all" can be very slow)
 
 ### essential paths and filenames
-constsfile = path2CLEO + "/libs/cleoconstants.hpp"
-binariespath = path2build + "/share/"
-savefigpath = path2build + "/bin/"
+constsfile = path2CLEO / "libs" / "cleoconstants.hpp"
+binariespath = path2build / "share"
+savefigpath = path2build / "bin"
 
 gridfile = (
-    binariespath + "/dimlessGBxboundaries.dat"
+    binariespath / "dimlessGBxboundaries.dat"
 )  # note this should match config.yaml
 initsupersfile = (
-    binariespath + "/dimlessSDsinit.dat"
+    binariespath / "dimlessSDsinit.dat"
 )  # note this should match config.yaml
 
 ### --- Number of Superdroplets per Gridbox --- ###
@@ -147,8 +147,8 @@ coord2gen = None  # do not generate superdroplet coord2s
 if path2CLEO == path2build:
     raise ValueError("build directory cannot be CLEO")
 else:
-    Path(path2build).mkdir(exist_ok=True)
-    Path(binariespath).mkdir(exist_ok=True)
+    path2build.mkdir(exist_ok=True)
+    binariespath.mkdir(exist_ok=True)
 
 ### write initial superdrops binary
 attrsgen = attrsgen.AttrsGenerator(
@@ -161,7 +161,7 @@ csupers.write_initsuperdrops_binary(
 ### plot initial superdrops binary
 if isfigures[0]:
     if isfigures[1]:
-        Path(savefigpath).mkdir(exist_ok=True)
+        savefigpath.mkdir(exist_ok=True)
     rsupers.plot_initGBxs_distribs(
         configfile,
         constsfile,

--- a/scripts/create_thermobinaries_script.py
+++ b/scripts/create_thermobinaries_script.py
@@ -32,22 +32,22 @@ from pySD.thermobinary_src import read_thermodynamics as rthermo
 ### ----------------------- INPUT PARAMETERS ----------------------- ###
 ### --- absolute or relative paths for --- ###
 ### ---   build and CLEO directories --- ###
-path2CLEO = sys.argv[1]
-path2build = sys.argv[2]
-configfile = sys.argv[3]
+path2CLEO = Path(sys.argv[1])
+path2build = Path(sys.argv[2])
+configfile = Path(sys.argv[3])
 
 # booleans for [making, saving] initialisation figures
 isfigures = [True, True]
 
 ### essential paths and filenames
-constsfile = path2CLEO + "/libs/cleoconstants.hpp"
-binariespath = path2build + "/share/"
-savefigpath = path2build + "/bin/"
+constsfile = path2CLEO / "libs" / "cleoconstants.hpp"
+binariespath = path2build / "share"
+savefigpath = path2build / "bin"
 
 gridfile = (
-    binariespath + "/dimlessGBxboundaries.dat"
+    binariespath / "dimlessGBxboundaries.dat"
 )  # note this should match config.yaml
-thermofile = binariespath + "/dimlessthermo.dat"
+thermofiles = binariespath / "dimlessthermo.dat"
 
 ### --- Choose Initial Thermodynamic Conditions for Gridboxes  --- ###
 
@@ -125,13 +125,13 @@ thermodyngen = thermogen.ConstHydrostaticLapseRates(
 
 ### -------------------- BINARY FILE GENERATION--------------------- ###
 cthermo.write_thermodynamics_binary(
-    thermofile, thermodyngen, configfile, constsfile, gridfile
+    thermofiles, thermodyngen, configfile, constsfile, gridfile
 )
 
 if isfigures[0]:
     if isfigures[1]:
-        Path(savefigpath).mkdir(exist_ok=True)
+        savefigpath.mkdir(exist_ok=True)
     rthermo.plot_thermodynamics(
-        constsfile, configfile, gridfile, thermofile, savefigpath, isfigures[1]
+        constsfile, configfile, gridfile, thermofiles, savefigpath, isfigures[1]
     )
 ### ---------------------------------------------------------------- ###

--- a/scripts/inputfiles.sh
+++ b/scripts/inputfiles.sh
@@ -7,14 +7,14 @@
 #SBATCH --time=00:05:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./inputfiles_out.%j.out
 #SBATCH --error=./inputfiles_err.%j.out
 
 ### ----- You need to edit these lines to set your ----- ###
 ### ----- default compiler and python environment   ---- ###
 ### ----  and paths for CLEO and build directories  ---- ###
-condaenv=/work/mh1126/m300950/cleoenv
+condaenv=/work/bm1183/m300950/mambaenvs/cleoenv
 module load python3/2022.01-gcc-11.2.0
 source activate ${condaenv}
 

--- a/scripts/run_example.sh
+++ b/scripts/run_example.sh
@@ -7,7 +7,7 @@
 #SBATCH --time=00:30:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
 #SBATCH --mail-type=FAIL
-#SBATCH --account=mh1126
+#SBATCH --account=bm1183
 #SBATCH --output=./runexample_out.%j.out
 #SBATCH --error=./runexample_err.%j.out
 


### PR DESCRIPTION
- use Path from pathlib more correctly for filesystem paths in Python example scripts
- use subprocess and shutil instead of os.system where possible
- separate build and setup steps in build workflow of CI