### PR TITLE
bugfix yac bubble test case

### DIFF
--- a/examples/bubble3d/bubble3d_inputfiles.py
+++ b/examples/bubble3d/bubble3d_inputfiles.py
@@ -75,13 +75,13 @@ def main(
     zgrid = get_zgrid(icon_grid_file, num_vertical_levels)  # [m]
     xgrid = [
         0,
-        100000,
+        30000,
         2500,
     ]  # evenly spaced xhalf coords [m] # distance must match longitude in config file
     ygrid = [
         0,
-        20000,
-        4000,
+        6250,
+        1250,
     ]  # evenly spaced xhalf coords [m] # distance must match latitudes in config file
 
     ### --- settings for initial superdroplets --- ###

--- a/examples/bubble3d/bubble3d_inputfiles.py
+++ b/examples/bubble3d/bubble3d_inputfiles.py
@@ -75,13 +75,13 @@ def main(
     zgrid = get_zgrid(icon_grid_file, num_vertical_levels)  # [m]
     xgrid = [
         0,
-        30000,
+        100000,
         2500,
     ]  # evenly spaced xhalf coords [m] # distance must match longitude in config file
     ygrid = [
         0,
-        12000,
-        6000,
+        20000,
+        4000,
     ]  # evenly spaced xhalf coords [m] # distance must match latitudes in config file
 
     ### --- settings for initial superdroplets --- ###

--- a/examples/bubble3d/bubble3d_inputfiles.py
+++ b/examples/bubble3d/bubble3d_inputfiles.py
@@ -21,6 +21,7 @@ thermodynamics read from ICON output of bubble test case by YAC
 """
 
 import sys
+from pathlib import Path
 
 
 def get_zgrid(icon_grid_file, num_vertical_levels):
@@ -62,12 +63,12 @@ def main(
     ### ---------------------------------------------------------------- ###
     ### --- essential paths and filenames --- ###
     # path and filenames for creating initial SD conditions
-    constants_filename = path2CLEO / "libs" / "cleoconstants.hpp"
+    constants_filename = path2CLEO / Path("libs/cleoconstants.hpp")
 
     ### --- plotting initialisation figures --- ###
     # booleans for [making, saving] initialisation figures
     isfigures = [True, True]  # TODO(CB): move into args
-    savefigpath = path2build / "bin"  # binpath # TODO(CB): move into args
+    savefigpath = path2build / Path("bin")  # binpath # TODO(CB): move into args
 
     ### --- settings for 3-D gridbox boundaries --- ###
     num_vertical_levels = 24  # TODO(CB): move to config file (?)

--- a/examples/bubble3d/run_bubble_tmp.sh
+++ b/examples/bubble3d/run_bubble_tmp.sh
@@ -65,7 +65,11 @@ then
   module purge
   # note version of python must match the YAC python bindings (e.g. module load python3/2022.01-gcc-11.2.0)
   module load openmpi/4.1.2-gcc-11.2.0 # same mpi as loaded for the build
-  spack load py-netcdf4
+  ### ----------------- load Python ------------------------ ###
+  spack load python@3.9.9%gcc@=11.2.0/fwv
+  spack load py-cython@0.29.33%gcc@=11.2.0/j7b4fa
+  spack load py-mpi4py@3.1.2%gcc@=11.2.0/hdi5yl6
+  ### ------------------------------------------------------ ###
 
   export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/sw/spack-levante/libfyaml-0.7.12-fvbhgo/lib
   export PYTHONPATH=${PYTHONPATH}:${path2yac}/yac/python # path to python bindings

--- a/examples/bubble3d/run_bubble_tmp.sh
+++ b/examples/bubble3d/run_bubble_tmp.sh
@@ -13,7 +13,7 @@
 
 action=$1
 path2CLEO=${2:-${HOME}/CLEO}
-path2yac=${3:-/work/bm1183/m300950/yac}
+path2yac=${3:-/work/bm1183/m300950/yacyaxt}
 path2build=${4:-${HOME}/CLEO/build_bubble3d}
 
 icon_grid_file=/work/bm1183/m300950/icon/build/experiments/aes_bubble/aes_bubble_atm_cgrid_ml.nc

--- a/examples/bubble3d/run_bubble_tmp.sh
+++ b/examples/bubble3d/run_bubble_tmp.sh
@@ -48,8 +48,8 @@ then
   cp ${icon_grid_file} ${icon_grid_file_copy}
   cp ${icon_data_file} ${icon_data_file_copy}
 
-  source activate /work/bm1183/m300950/mambaenvs/cleoenv
-  /work/bm1183/m300950/mambaenvs/cleoenv/bin/python ${path2CLEO}/examples/bubble3d/bubble3d_inputfiles.py \
+  source activate /work/bm1183/m300950/bin/envs/cleoenv
+  /work/bm1183/m300950/bin/envs/cleoenv/bin/python ${path2CLEO}/examples/bubble3d/bubble3d_inputfiles.py \
    ${path2CLEO} \
    ${path2build} \
    ${path2CLEO}/examples/bubble3d/src/config/bubble3d_config.yaml \

--- a/examples/bubble3d/src/config/bubble3d_config.yaml
+++ b/examples/bubble3d/src/config/bubble3d_config.yaml
@@ -25,8 +25,8 @@
 ### SDM Runtime Parameters ###
 domain:
   nspacedims : 3                                          # no. of spatial dimensions to model
-  ngbxs : 576                                            # total number of Gbxs
-  maxnsupers: 576                                        # maximum number of SDs
+  ngbxs : 4800                                            # total number of Gbxs
+  maxnsupers: 4800                                        # maximum number of SDs
 
 timesteps:
   CONDTSTEP : 2                                           # time between SD condensation [s]
@@ -50,11 +50,11 @@ outputdata:
   setup_filename : ./bin/bubble3d_setup.txt                   # .txt filename to copy configuration to
   stats_filename : ./bin/bubble3d_stats.txt                   # .txt file to output runtime statistics to
   zarrbasedir : ./bin/bubble3d_sol.zarr                       # zarr store base directory
-  maxchunk : 2500000                                      # maximum no. of elements in chunks of zarr store array
+  maxchunk : 2500000                                          # maximum no. of elements in chunks of zarr store array
 
 coupled_dynamics:
   type: yac
-  lower_longitude: -0.9424777965
-  upper_longitude: 0.9424777965
-  lower_latitude: -0.392699082
-  upper_latitude: 0.392699082
+  lower_longitude: -3.29867229                                # must match xgrid domain delta_x
+  upper_longitude: 2.98451302
+  lower_latitude: -1.25665                                    # must match ygrid domain delta_y
+  upper_latitude: 1.25665

--- a/examples/bubble3d/src/config/bubble3d_config.yaml
+++ b/examples/bubble3d/src/config/bubble3d_config.yaml
@@ -25,8 +25,8 @@
 ### SDM Runtime Parameters ###
 domain:
   nspacedims : 3                                          # no. of spatial dimensions to model
-  ngbxs : 4800                                            # total number of Gbxs
-  maxnsupers: 4800                                        # maximum number of SDs
+  ngbxs : 1440                                            # total number of Gbxs
+  maxnsupers: 1440                                        # maximum number of SDs
 
 timesteps:
   CONDTSTEP : 2                                           # time between SD condensation [s]
@@ -54,7 +54,7 @@ outputdata:
 
 coupled_dynamics:
   type: yac
-  lower_longitude: -3.29867229                                # must match xgrid domain delta_x
-  upper_longitude: 2.98451302
-  lower_latitude: -1.25665                                    # must match ygrid domain delta_y
-  upper_latitude: 1.25665
+  lower_longitude: -0.989601687                               # must match xgrid domain delta_x
+  upper_longitude: 0.895353906
+  lower_latitude: -0.392699082                                # must match ygrid domain delta_y
+  upper_latitude: 0.392699082

--- a/examples/run_example.sh
+++ b/examples/run_example.sh
@@ -32,7 +32,7 @@ script_args="$7"
 
 cleoenv=/work/bm1183/m300950/mambaenvs/cleoenv
 python=${cleoenv}/bin/python3
-yacyaxtroot=/work/bm1183/m300950/yac
+yacyaxtroot=/work/bm1183/m300950/yacyaxt
 spack load cmake@3.23.1%gcc
 module load python3/2022.01-gcc-11.2.0
 source activate ${cleoenv}

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
@@ -205,7 +205,7 @@ CartesianDynamics::CartesianDynamics(const Config &config, const std::array<size
   // --- Interpolation stack ---
   int interp_stack_id;
   yac_cget_interp_stack_config(&interp_stack_id);
-  yac_cadd_interp_stack_config_nnn(interp_stack_id, YAC_NNN_AVG, 1, 1.0);
+  yac_cadd_interp_stack_config_nnn(interp_stack_id, YAC_NNN_AVG, 1, 0.0, 1.0);
 
   // --- Field definitions ---
   int num_point_sets = 1;

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
@@ -112,13 +112,13 @@ void create_grid_and_points_definitions(const Config &config, const std::array<s
   // these arrays will have a size equal to the number of edges.
   for (size_t lat_index = 0; lat_index < vertex_latitudes.size() * 2 - 1; lat_index++) {
     if (lat_index % 2 == 0) {
-      edge_centers_longitudes.insert(edge_centers_longitudes.end(), cell_center_longitudes.begin(),
-                                     cell_center_longitudes.end());
+      edge_centers_longitudes.insert(edge_centers_longitudes.end(), cell_center_longitudes.rbegin(),
+                                     cell_center_longitudes.rend());
       edge_centers_latitudes.insert(edge_centers_latitudes.end(), cell_center_longitudes.size(),
                                     vertex_latitudes[lat_index / 2]);
     } else {
-      edge_centers_longitudes.insert(edge_centers_longitudes.end(), vertex_longitudes.begin(),
-                                     vertex_longitudes.end());
+      edge_centers_longitudes.insert(edge_centers_longitudes.end(), vertex_longitudes.rbegin(),
+                                     vertex_longitudes.rend());
       edge_centers_latitudes.insert(edge_centers_latitudes.end(), vertex_longitudes.size(),
                                     cell_center_latitudes[(lat_index - 1) / 2]);
     }

--- a/scripts/bash/build_cleo_cuda_openmp.sh
+++ b/scripts/bash/build_cleo_cuda_openmp.sh
@@ -26,7 +26,7 @@ gcc="/sw/spack-levante/gcc-11.2.0-bcn7mb/bin/gcc"
 path2CLEO=$1    # required
 path2build=$2   # required
 enableyac=$3    # required
-yacyaxtroot=$4      # required if enableyac=true
+yacyaxtroot=$4  # required if enableyac=true
 
 yac_openmpi=openmpi/4.1.2-gcc-11.2.0 # required if enableyac=true (must match gcc)
 yac_netcdf=netcdf-c/4.8.1-openmpi-4.1.2-gcc-11.2.0 # required if enableyac=true (must match gcc & openmp)

--- a/scripts/bash/build_cleo_serial.sh
+++ b/scripts/bash/build_cleo_serial.sh
@@ -24,7 +24,7 @@ gcc="/sw/spack-levante/gcc-11.2.0-bcn7mb/bin/gcc"
 path2CLEO=$1    # required
 path2build=$2   # required
 enableyac=$3    # required
-yacyaxtroot=$4      # required if enableyac=true
+yacyaxtroot=$4  # required if enableyac=true
 
 yac_openmpi=openmpi/4.1.2-gcc-11.2.0 # required if enableyac=true (must match gcc)
 yac_netcdf=netcdf-c/4.8.1-openmpi-4.1.2-gcc-11.2.0 # required if enableyac=true (must match gcc & openmp)

--- a/scripts/bash/install_yac.sh
+++ b/scripts/bash/install_yac.sh
@@ -16,20 +16,27 @@
 ### gcc 11.2.0 compiler with openmpi 4.1.2 on Levante
 ### ------------------------------------------------------- ###
 
+set -ex
+
 root4YAC=$1 # absolute path for YAC and YAXT installations
 
-yaxt_source=https://swprojects.dkrz.de/redmine/attachments/download/534/yaxt-0.11.1.tar.gz
-yaxt_version=yaxt-0.11.1 # must match yaxt_source
+yaxt_tag=0.11.1
+yaxt_version=yaxt-${yaxt_tag}
+yaxt_release_tag=release-${yaxt_tag}
+yaxt_source=https://gitlab.dkrz.de/dkrz-sw/yaxt/-/archive/$yaxt_release_tag/$yaxt_version.tar.gz
 
-yac_source=https://gitlab.dkrz.de/dkrz-sw/yac/-/archive/v3.2.0/yac-v3.2.0.tar.gz
-yac_version=yac-v3.2.0 # must match yac_source
+yac_tag=v3.5.2
+yac_version=yac_$yac_tag
+yac_source=https://gitlab.dkrz.de/dkrz-sw/yac/-/archive/$yac_tag/$yac_version.tar.gz
 
 gcc=gcc/11.2.0-gcc-11.2.0
 openmpi=openmpi/4.1.2-gcc-11.2.0
 netcdf=netcdf-c/4.8.1-openmpi-4.1.2-gcc-11.2.0 # must match gcc and openmpi
 netcdf_root=/sw/spack-levante/netcdf-c-4.8.1-6qheqr # must match with `module show ${netcdf}`
 fyaml_root=/sw/spack-levante/libfyaml-0.7.12-fvbhgo # must match with `spack location -i libfyaml``
+python=python@3.9.9%gcc@=11.2.0/fwv
 pycython=py-cython@0.29.33%gcc@=11.2.0/j7b4fa
+pympi4py=py-mpi4py@3.1.2%gcc@=11.2.0/hdi5yl6
 
 CC=/sw/spack-levante/openmpi-4.1.2-mnmady/bin/mpicc # must match gcc
 FC=/sw/spack-levante/openmpi-4.1.2-mnmady/bin/mpif90 # must match gcc
@@ -38,16 +45,22 @@ if [ "${root4YAC}" == "" ]
 then
   echo "Bad input, please specify absolute path for where you want to install YAC"
 else
+  mkdir ${root4YAC}
   module load ${gcc} ${openmpi} ${netcdf}
+  ### ----------------- load Python ------------------------ ###
+  spack load ${python}
   spack load ${pycython}
+  spack load ${pympi4py}
+  ### ------------------------------------------------------ ###
 
   ### --------------------- install YAXT ------------------- ###
-  cd ${root4YAC} && pwd
-  curl -s -L ${yaxt_source} | tar xvz
-  cd ${yaxt_version}
-  ./configure \
+  mkdir ${root4YAC}/${yaxt_version}
+  cd ${root4YAC}/${yaxt_version} &&  pwd
+  curl -s -L ${yaxt_source} | tar xvz --strip-components=1
+  mkdir build && cd build
+  ../configure \
     CC=${CC} FC=${FC} \
-    CFLAGS="-O0 -g -Wall -fPIC" \
+    CFLAGS="-O0 -g -Wall" \
     FCFLAGS="-O0 -g -Wall -cpp -fimplicit-none" \
     --without-regard-for-quality \
     --without-example-programs \
@@ -61,25 +74,27 @@ else
 
   ## --------------------- install YAC -------------------- ###
   # python bindings made in yac_version directory (note this is not yac directory!)
-  cd ${root4YAC} && pwd
-  curl -s -L ${yac_source} | tar xvz
-  cd ${yac_version}
-  ./configure \
+  mkdir ${root4YAC}/${yac_version}
+  cd ${root4YAC}/${yac_version} && pwd
+  curl -s -L ${yac_source} | tar xvz --strip-components=1
+  mkdir build && cd build
+  ../configure \
     CC=${CC} FC=${FC} \
-    CFLAGS="-O0 -g -Wall -fPIC" \
+    CFLAGS="-O0 -g -Wall" \
     FCFLAGS="-O0 -g -Wall -cpp -fimplicit-none" \
     LDFLAGS="-lm" \
     --disable-mpi-checks \
     --with-yaxt-root=${root4YAC}/yaxt \
     --with-netcdf-root=${netcdf_root} \
     --with-fyaml-root=${fyaml_root} \
-    --enable-rpaths \
     --enable-python-bindings \
+    --enable-rpaths \
+    --with-pic \
     --prefix=${root4YAC}/yac
   make -j 8
-  make install || true
+  make install
 
-  mv ${root4YAC}/${yac_version}/python ${root4YAC}/yac/python
+  mv ${root4YAC}/${yac_version}/build/python ${root4YAC}/yac/
   cd ${root4YAC} && rm -rf ${yac_version}
   ### ------------------------------------------------------ ###
 fi

--- a/scripts/build_compile_cleocoupledsdm.sh
+++ b/scripts/build_compile_cleocoupledsdm.sh
@@ -23,7 +23,7 @@ buildtype=$1
 enableyac=${2:-false}                     # "true" or otherwise
 path2CLEO=${3:-${HOME}/CLEO}
 path2build=${4:-${path2CLEO}/build}
-yacyaxtroot=/work/bm1183/m300950/yac      # used if enableyac == "true"
+yacyaxtroot=/work/bm1183/m300950/yacyaxt  # used if enableyac == "true"
 executables="cleocoupledsdm"
 ### ---------------------------------------------------- ###
 


### PR DESCRIPTION
- update YAC version and install script to fix python bindings installation
- inverted order of edge longitudes to fix incorrect windfields compared to ICON

also:
- correctly configure domain sizes and lat/lon boundaries for entire domain and cropped domain testcases

note:
-bubble3d example currently not compatible with MPI therefore cannot run from main branch