### PR TITLE
optimisations to improve performance of SD movement

### DIFF
--- a/libs/cartesiandomain/add_supers_at_domain_top.cpp
+++ b/libs/cartesiandomain/add_supers_at_domain_top.cpp
@@ -65,9 +65,7 @@ void move_supers_between_gridboxes_again(const viewd_gbx d_gbxs, const viewd_sup
       "move_supers_between_gridboxes_again", TeamPolicy(ngbxs, Kokkos::AUTO()),
       KOKKOS_LAMBDA(const TeamMember &team_member) {
         const auto ii = team_member.league_rank();
-
-        auto &gbx(d_gbxs(ii));
-        gbx.supersingbx.set_refs(team_member);
+        d_gbxs(ii).supersingbx.set_refs(team_member);
       });
 }
 

--- a/libs/gridboxes/movesupersindomain.hpp
+++ b/libs/gridboxes/movesupersindomain.hpp
@@ -98,7 +98,7 @@ struct MoveSupersInDomain {
           KOKKOS_CLASS_LAMBDA(const TeamMember &team_member) {
             const auto ii = team_member.league_rank();
 
-            auto &gbx(d_gbxs(ii));
+            auto &gbx = d_gbxs(ii);
             move_supers_in_gbx(team_member, gbx.get_gbxindex(), gbxmaps, gbx.state,
                                gbx.supersingbx());
           });
@@ -126,9 +126,7 @@ struct MoveSupersInDomain {
           "move_supers_between_gridboxes", TeamPolicy(ngbxs, Kokkos::AUTO()),
           KOKKOS_LAMBDA(const TeamMember &team_member) {
             const auto ii = team_member.league_rank();
-
-            auto &gbx(d_gbxs(ii));
-            gbx.supersingbx.set_refs(team_member);
+            d_gbxs(ii).supersingbx.set_refs(team_member);
           });
 
       // /* optional (expensive!) test to raise error if

--- a/libs/gridboxes/predcorr.hpp
+++ b/libs/gridboxes/predcorr.hpp
@@ -54,9 +54,8 @@ equations in Grabowski et al. 2018 */
 template <GridboxMaps GbxMaps, VelocityFormula TV>
 struct PredCorr {
  private:
-  const double delt;          // equivalent of motionstep as dimensionless time
-  const TV terminalv;         // returns terminal velocity given a superdroplet
-  const viewd_coords deltas;  // view on device required for operator return;
+  const double delt;   // equivalent of motionstep as dimensionless time
+  const TV terminalv;  // returns terminal velocity given a superdroplet
 
   /* method to interpolate coord3 wind velocity component (w)
   defined on coord3 faces of a gridbox to a superdroplet's
@@ -152,15 +151,15 @@ struct PredCorr {
  public:
   PredCorr(const unsigned int motionstep, const std::function<double(unsigned int)> int2time,
            const TV i_terminalv)
-      : delt(int2time(motionstep)), terminalv(i_terminalv), deltas("deltas") {}
+      : delt(int2time(motionstep)), terminalv(i_terminalv) {}
 
   /* operator for use in the "superdrop_coords" function of the PredCorrMotion struct.
   Operator uses predictor-corrector method to return the change in
   a superdroplet's coordinates from a forward timestep of motion using the
   interpolated wind velocity from a gridbox's state */
   KOKKOS_FUNCTION
-  viewd_constcoords operator()(const unsigned int gbxindex, const GbxMaps &gbxmaps,
-                               const State &state, const Superdrop &drop) const {
+  Superdrop operator()(const unsigned int gbxindex, const GbxMaps &gbxmaps, const State &state,
+                       Superdrop &drop) const {
     /* Use predictor-corrector method to get change in SD coords */
     const auto delta3 = delta_coord3(gbxindex, gbxmaps, state, drop);
     const auto delta1 = delta_coord1(gbxindex, gbxmaps, state, drop);
@@ -169,11 +168,10 @@ struct PredCorr {
     /* CFL check on predicted change to SD coords */
     cfl_criteria(gbxmaps, gbxindex, delta3, delta1, delta2);
 
-    /* return change in coordinates in order: (coord3, coord1, coord2) */
-    deltas(0) = delta3;
-    deltas(1) = delta1;
-    deltas(2) = delta2;
-    return deltas;
+    /* update SD coords */
+    drop.increment_coords(delta3, delta1, delta2);
+
+    return drop;
   }
 };
 

--- a/libs/gridboxes/predcorrmotion.hpp
+++ b/libs/gridboxes/predcorrmotion.hpp
@@ -65,10 +65,7 @@ struct PredCorrMotion {
   void superdrop_coords(const unsigned int gbxindex, const GbxMaps &gbxmaps, const State &state,
                         Superdrop &drop) const {
     /* change in SD coords: (coord3, coord1, coord2) */
-    const auto deltas = predcorr(gbxindex, gbxmaps, state, drop);
-
-    /* update SD coords */
-    drop.increment_coords(deltas(0), deltas(1), deltas(2));
+    drop = predcorr(gbxindex, gbxmaps, state, drop);
   }
 
   /* function satisfies requirements of "superdrop_gbx" in the motion

--- a/libs/observers/streamout_observer.cpp
+++ b/libs/observers/streamout_observer.cpp
@@ -40,7 +40,7 @@ void StreamOutObserver::streamout_statement(const unsigned int t_mdl,
   /* copy first gridbox into mirror view in case Gridboxes view is in device memory */
   auto d_gbx = Kokkos::subview(d_gbxs, kkpair_size_t({0, 1}));
   auto h_gbx = Kokkos::create_mirror_view_and_copy(HostSpace(), d_gbx);
-  const auto &gbx(h_gbx(0));
+  const auto &gbx = h_gbx(0);
 
   std::cout << "t=" << std::fixed << std::setprecision(2) << step2realtime(t_mdl)
             << "s, totnsupers=" << gbx.domain_totnsupers() << ", ngbxs=" << d_gbxs.extent(0)


### PR DESCRIPTION
- don't use view to hold deltas in predcorr motion