### PR TITLE
major refactoring of superdroplets view handling (preparation for new sorting algorithm)

### DIFF
--- a/examples/boxmodelcollisions/lowlist/src/main_lowlistcolls.cpp
+++ b/examples/boxmodelcollisions/lowlist/src/main_lowlistcolls.cpp
@@ -58,9 +58,10 @@
 #include "superdrops/motion.hpp"
 #include "zarr/fsstore.hpp"
 
-inline InitialConditions auto create_initconds(const Config &config) {
+template <GridboxMaps GbxMaps>
+inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
   const auto initsupers = InitAllSupersFromBinary(config.get_initsupersfrombinary());
-  const auto initgbxs = InitGbxsNull(config.get_ngbxs());
+  const auto initgbxs = InitGbxsNull(gbxmaps.get_local_ngridboxes_hostcopy());
 
   return InitConds(initsupers, initgbxs);
 }
@@ -163,15 +164,15 @@ int main(int argc, char *argv[]) {
     auto store = FSStore(config.get_zarrbasedir());
     auto dataset = Dataset(store);
 
+    /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
+    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+
     /* Create coupldyn solver and coupling between coupldyn and SDM */
     const CoupledDynamics auto coupldyn = NullDynamics(tsteps.get_couplstep());
     const CouplingComms<CartesianMaps, NullDynamics> auto comms = NullDynComms{};
 
     /* Initial conditions for CLEO run */
-    const InitialConditions auto initconds = create_initconds(config);
-
-    /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
-    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+    const InitialConditions auto initconds = create_initconds(config, sdm.gbxmaps);
 
     /* Run CLEO (SDM coupled to dynamics solver) */
     const RunCLEO runcleo(sdm, coupldyn, comms);

--- a/examples/boxmodelcollisions/szakallurbich/src/main_szakallurbichcolls.cpp
+++ b/examples/boxmodelcollisions/szakallurbich/src/main_szakallurbichcolls.cpp
@@ -61,9 +61,10 @@
 #include "superdrops/motion.hpp"
 #include "zarr/fsstore.hpp"
 
-inline InitialConditions auto create_initconds(const Config &config) {
+template <GridboxMaps GbxMaps>
+inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
   const auto initsupers = InitAllSupersFromBinary(config.get_initsupersfrombinary());
-  const auto initgbxs = InitGbxsNull(config.get_ngbxs());
+  const auto initgbxs = InitGbxsNull(gbxmaps.get_local_ngridboxes_hostcopy());
 
   return InitConds(initsupers, initgbxs);
 }
@@ -164,15 +165,15 @@ int main(int argc, char *argv[]) {
     auto store = FSStore(config.get_zarrbasedir());
     auto dataset = Dataset(store);
 
+    /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
+    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+
     /* Create coupldyn solver and coupling between coupldyn and SDM */
     const CoupledDynamics auto coupldyn = NullDynamics(tsteps.get_couplstep());
     const CouplingComms<CartesianMaps, NullDynamics> auto comms = NullDynComms{};
 
     /* Initial conditions for CLEO run */
-    const InitialConditions auto initconds = create_initconds(config);
-
-    /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
-    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+    const InitialConditions auto initconds = create_initconds(config, sdm.gbxmaps);
 
     /* Run CLEO (SDM coupled to dynamics solver) */
     const RunCLEO runcleo(sdm, coupldyn, comms);

--- a/examples/boxmodelcollisions/testikstraub/src/main_testikstraubcolls.cpp
+++ b/examples/boxmodelcollisions/testikstraub/src/main_testikstraubcolls.cpp
@@ -62,9 +62,10 @@
 #include "superdrops/motion.hpp"
 #include "zarr/fsstore.hpp"
 
-inline InitialConditions auto create_initconds(const Config &config) {
+template <GridboxMaps GbxMaps>
+inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
   const auto initsupers = InitAllSupersFromBinary(config.get_initsupersfrombinary());
-  const auto initgbxs = InitGbxsNull(config.get_ngbxs());
+  const auto initgbxs = InitGbxsNull(gbxmaps.get_local_ngridboxes_hostcopy());
 
   return InitConds(initsupers, initgbxs);
 }
@@ -163,15 +164,15 @@ int main(int argc, char *argv[]) {
     auto store = FSStore(config.get_zarrbasedir());
     auto dataset = Dataset(store);
 
+    /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
+    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+
     /* Create coupldyn solver and coupling between coupldyn and SDM */
     const CoupledDynamics auto coupldyn = NullDynamics(tsteps.get_couplstep());
     const CouplingComms<CartesianMaps, NullDynamics> auto comms = NullDynComms{};
 
     /* Initial conditions for CLEO run */
-    const InitialConditions auto initconds = create_initconds(config);
-
-    /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
-    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+    const InitialConditions auto initconds = create_initconds(config, sdm.gbxmaps);
 
     /* Run CLEO (SDM coupled to dynamics solver) */
     const RunCLEO runcleo(sdm, coupldyn, comms);

--- a/examples/constthermo2d/src/main_const2d.cpp
+++ b/examples/constthermo2d/src/main_const2d.cpp
@@ -71,9 +71,10 @@ inline CoupledDynamics auto create_coupldyn(const Config &config, const Cartesia
   return FromFileDynamics(config.get_fromfiledynamics(), couplstep, ndims, nsteps);
 }
 
-inline InitialConditions auto create_initconds(const Config &config) {
+template <GridboxMaps GbxMaps>
+inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
   const auto initsupers = InitAllSupersFromBinary(config.get_initsupersfrombinary());
-  const auto initgbxs = InitGbxsNull(config.get_ngbxs());
+  const auto initgbxs = InitGbxsNull(gbxmaps.get_local_ngridboxes_hostcopy());
 
   return InitConds(initsupers, initgbxs);
 }
@@ -198,9 +199,6 @@ int main(int argc, char *argv[]) {
     auto store = FSStore(config.get_zarrbasedir());
     auto dataset = Dataset(store);
 
-    /* Initial conditions for CLEO run */
-    const InitialConditions auto initconds = create_initconds(config);
-
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));
 
@@ -210,6 +208,9 @@ int main(int argc, char *argv[]) {
 
     /* coupling between coupldyn and SDM */
     const CouplingComms<CartesianMaps, FromFileDynamics> auto comms = FromFileComms{};
+
+    /* Initial conditions for CLEO run */
+    const InitialConditions auto initconds = create_initconds(config, sdm.gbxmaps);
 
     /* Run CLEO (SDM coupled to dynamics solver) */
     const RunCLEO runcleo(sdm, coupldyn, comms);

--- a/examples/divfreemotion/src/main_divfree2d.cpp
+++ b/examples/divfreemotion/src/main_divfree2d.cpp
@@ -65,9 +65,10 @@ inline CoupledDynamics auto create_coupldyn(const Config &config, const Cartesia
   return FromFileDynamics(config.get_fromfiledynamics(), couplstep, ndims, nsteps);
 }
 
-inline InitialConditions auto create_initconds(const Config &config) {
+template <GridboxMaps GbxMaps>
+inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
   const auto initsupers = InitAllSupersFromBinary(config.get_initsupersfrombinary());
-  const auto initgbxs = InitGbxsNull(config.get_ngbxs());
+  const auto initgbxs = InitGbxsNull(gbxmaps.get_local_ngridboxes_hostcopy());
 
   return InitConds(initsupers, initgbxs);
 }
@@ -164,9 +165,6 @@ int main(int argc, char *argv[]) {
     auto store = FSStore(config.get_zarrbasedir());
     auto dataset = Dataset(store);
 
-    /* Initial conditions for CLEO run */
-    const InitialConditions auto initconds = create_initconds(config);
-
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));
 
@@ -176,6 +174,9 @@ int main(int argc, char *argv[]) {
 
     /* coupling between coupldyn and SDM */
     const CouplingComms<CartesianMaps, FromFileDynamics> auto comms = FromFileComms{};
+
+    /* Initial conditions for CLEO run */
+    const InitialConditions auto initconds = create_initconds(config, sdm.gbxmaps);
 
     /* Run CLEO (SDM coupled to dynamics solver) */
     const RunCLEO runcleo(sdm, coupldyn, comms);

--- a/examples/eurec4a1d/src/main_eurec4a1d.cpp
+++ b/examples/eurec4a1d/src/main_eurec4a1d.cpp
@@ -77,9 +77,10 @@ inline CoupledDynamics auto create_coupldyn(const Config &config, const Cartesia
   return FromFileDynamics(config.get_fromfiledynamics(), couplstep, ndims, nsteps);
 }
 
-inline InitialConditions auto create_initconds(const Config &config, const CartesianMaps &gbxmaps) {
-  const auto initgbxs = InitGbxsNull(gbxmaps.get_local_ngridboxes());
+template <GridboxMaps GbxMaps>
+inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
   const auto initsupers = InitSupersFromBinary(config.get_initsupersfrombinary(), gbxmaps);
+  const auto initgbxs = InitGbxsNull(gbxmaps.get_local_ngridboxes_hostcopy());
 
   return InitConds(initsupers, initgbxs);
 }
@@ -215,15 +216,15 @@ int main(int argc, char *argv[]) {
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));
 
-    /* Initial conditions for CLEO run */
-    const InitialConditions auto initconds = create_initconds(config, sdm.gbxmaps);
-
     /* Solver of dynamics coupled to CLEO SDM */
     CoupledDynamics auto coupldyn(
         create_coupldyn(config, sdm.gbxmaps, tsteps.get_couplstep(), tsteps.get_t_end()));
 
     /* coupling between coupldyn and SDM */
     const CouplingComms<CartesianMaps, FromFileDynamics> auto comms = FromFileComms{};
+
+    /* Initial conditions for CLEO run */
+    const InitialConditions auto initconds = create_initconds(config, sdm.gbxmaps);
 
     /* Run CLEO (SDM coupled to dynamics solver) */
     const RunCLEO runcleo(sdm, coupldyn, comms);

--- a/examples/fromfile_irreg/src/main_fromfile_irreg.cpp
+++ b/examples/fromfile_irreg/src/main_fromfile_irreg.cpp
@@ -66,9 +66,10 @@ inline CoupledDynamics auto create_coupldyn(const Config &config, const Cartesia
   return FromFileDynamics(config.get_fromfiledynamics(), couplstep, ndims, nsteps);
 }
 
-inline InitialConditions auto create_initconds(const Config &config) {
+template <GridboxMaps GbxMaps>
+inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
   const auto initsupers = InitAllSupersFromBinary(config.get_initsupersfrombinary());
-  const auto initgbxs = InitGbxsNull(config.get_ngbxs());
+  const auto initgbxs = InitGbxsNull(gbxmaps.get_local_ngridboxes_hostcopy());
 
   return InitConds(initsupers, initgbxs);
 }
@@ -170,9 +171,6 @@ int main(int argc, char *argv[]) {
     auto store = FSStore(config.get_zarrbasedir());
     auto dataset = Dataset(store);
 
-    /* Initial conditions for CLEO run */
-    const InitialConditions auto initconds = create_initconds(config);
-
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));
 
@@ -182,6 +180,9 @@ int main(int argc, char *argv[]) {
 
     /* coupling between coupldyn and SDM */
     const CouplingComms<CartesianMaps, FromFileDynamics> auto comms = FromFileComms{};
+
+    /* Initial conditions for CLEO run */
+    const InitialConditions auto initconds = create_initconds(config, sdm.gbxmaps);
 
     /* Run CLEO (SDM coupled to dynamics solver) */
     const RunCLEO runcleo(sdm, coupldyn, comms);

--- a/examples/rainshaft1d/src/main_rshaft1d.cpp
+++ b/examples/rainshaft1d/src/main_rshaft1d.cpp
@@ -71,9 +71,10 @@ inline CoupledDynamics auto create_coupldyn(const Config &config, const Cartesia
   return FromFileDynamics(config.get_fromfiledynamics(), couplstep, ndims, nsteps);
 }
 
-inline InitialConditions auto create_initconds(const Config &config) {
+template <GridboxMaps GbxMaps>
+inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
   const auto initsupers = InitAllSupersFromBinary(config.get_initsupersfrombinary());
-  const auto initgbxs = InitGbxsNull(config.get_ngbxs());
+  const auto initgbxs = InitGbxsNull(gbxmaps.get_local_ngridboxes_hostcopy());
 
   return InitConds(initsupers, initgbxs);
 }
@@ -186,9 +187,6 @@ int main(int argc, char *argv[]) {
     auto store = FSStore(config.get_zarrbasedir());
     auto dataset = Dataset(store);
 
-    /* Initial conditions for CLEO run */
-    const InitialConditions auto initconds = create_initconds(config);
-
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));
 
@@ -198,6 +196,9 @@ int main(int argc, char *argv[]) {
 
     /* coupling between coupldyn and SDM */
     const CouplingComms<CartesianMaps, FromFileDynamics> auto comms = FromFileComms{};
+
+    /* Initial conditions for CLEO run */
+    const InitialConditions auto initconds = create_initconds(config, sdm.gbxmaps);
 
     /* Run CLEO (SDM coupled to dynamics solver) */
     const RunCLEO runcleo(sdm, coupldyn, comms);

--- a/examples/speedtest/src/main_spdtest.cpp
+++ b/examples/speedtest/src/main_spdtest.cpp
@@ -73,9 +73,10 @@ inline CoupledDynamics auto create_coupldyn(const Config &config, const Cartesia
   return FromFileDynamics(config.get_fromfiledynamics(), couplstep, ndims, nsteps);
 }
 
-inline InitialConditions auto create_initconds(const Config &config) {
+template <GridboxMaps GbxMaps>
+inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
   const auto initsupers = InitAllSupersFromBinary(config.get_initsupersfrombinary());
-  const auto initgbxs = InitGbxsNull(config.get_ngbxs());
+  const auto initgbxs = InitGbxsNull(gbxmaps.get_local_ngridboxes_hostcopy());
 
   return InitConds(initsupers, initgbxs);
 }
@@ -225,9 +226,6 @@ int main(int argc, char *argv[]) {
     auto store = FSStore(config.get_zarrbasedir());
     auto dataset = Dataset(store);
 
-    /* Initial conditions for CLEO run */
-    const InitialConditions auto initconds = create_initconds(config);
-
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));
 
@@ -237,6 +235,9 @@ int main(int argc, char *argv[]) {
 
     /* coupling between coupldyn and SDM */
     const CouplingComms<CartesianMaps, FromFileDynamics> auto comms = FromFileComms{};
+
+    /* Initial conditions for CLEO run */
+    const InitialConditions auto initconds = create_initconds(config, sdm.gbxmaps);
 
     /* Run CLEO (SDM coupled to dynamics solver) */
     const RunCLEO runcleo(sdm, coupldyn, comms);

--- a/libs/cartesiandomain/add_supers_at_domain_top.cpp
+++ b/libs/cartesiandomain/add_supers_at_domain_top.cpp
@@ -149,7 +149,8 @@ viewd_supers create_newsupers_for_gridboxes(const CartesianMaps &gbxmaps,
                                             const CreateSuperdrop &create_superdrop,
                                             Kokkos::View<unsigned int *> gbxindexes,
                                             const size_t newnsupers_pergbx) {
-  viewd_supers newsupers("newsupers", total_newnsupers_to_create(gbxindexes, newnsupers_pergbx));
+  auto newsupers =
+      viewd_supers("newsupers", total_newnsupers_to_create(gbxindexes, newnsupers_pergbx));
   auto h_newsupers = Kokkos::create_mirror_view(newsupers);
 
   auto h_gbxindexes = Kokkos::create_mirror_view(gbxindexes);

--- a/libs/cartesiandomain/add_supers_at_domain_top.cpp
+++ b/libs/cartesiandomain/add_supers_at_domain_top.cpp
@@ -64,10 +64,7 @@ for (size_t ii(0); ii < d_gbxs.extent(0); ++ii){[...]}.
 */
 SupersInDomain move_supers_between_gridboxes_again(const viewd_gbx d_gbxs,
                                                    SupersInDomain &allsupers) {
-  auto totsupers = allsupers.get_totsupers();
-
-  totsupers = sort_supers(totsupers);
-  allsupers.set_totsupers(totsupers);
+  allsupers.sort_totsupers();
 
   const auto domainsupers = allsupers.domain_supers();
   const size_t ngbxs(d_gbxs.extent(0));
@@ -202,7 +199,7 @@ viewh_constgbx hostcopy_one_gridbox(const viewd_constgbx d_gbxs, const size_t ii
 /* throws error if the size of newnsupers + oldnsupers > total space in totsupers view */
 size_t check_space_in_totsupers(const SupersInDomain &allsupers,
                                 const viewd_constsupers newsupers) {
-  const auto totsupers = allsupers.get_totsupers();
+  const auto totsupers = allsupers.get_totsupers_readonly();
   const auto oldnsupers = allsupers.domain_nsupers();
   if (oldnsupers + newsupers.extent(0) > totsupers.extent(0)) {
     const auto err = std::string(
@@ -219,11 +216,11 @@ totsupers view */
 void add_superdrops_for_gridboxes(const SupersInDomain &allsupers,
                                   const viewd_constsupers newsupers) {
   const auto totsupers = allsupers.get_totsupers();
-  const auto og_totnsupers = check_space_in_totsupers(allsupers, newsupers);
+  const auto og_ntotsupers = check_space_in_totsupers(allsupers, newsupers);
 
   Kokkos::parallel_for(
       "add_superdrops", Kokkos::RangePolicy<ExecSpace>(0, newsupers.extent(0)),
-      KOKKOS_LAMBDA(const size_t kk) { totsupers(kk + og_totnsupers) = newsupers(kk); });
+      KOKKOS_LAMBDA(const size_t kk) { totsupers(kk + og_ntotsupers) = newsupers(kk); });
 }
 
 /* returns host copy of {lower, upper} coord3 boundaries from gbxmaps for 'gbxindex' on device */

--- a/libs/cartesiandomain/add_supers_at_domain_top.cpp
+++ b/libs/cartesiandomain/add_supers_at_domain_top.cpp
@@ -66,7 +66,7 @@ SupersInDomain move_supers_between_gridboxes_again(const viewd_gbx d_gbxs,
                                                    SupersInDomain &allsupers) {
   auto totsupers = allsupers.get_totsupers();
 
-  sort_supers(totsupers);
+  totsupers = sort_supers(totsupers);
   allsupers.set_totsupers(totsupers);
 
   const auto domainsupers = allsupers.domain_supers();

--- a/libs/cartesiandomain/add_supers_at_domain_top.hpp
+++ b/libs/cartesiandomain/add_supers_at_domain_top.hpp
@@ -126,7 +126,7 @@ struct AddSupersAtDomainTop {
   abouve coord3lim.
   */
   SupersInDomain operator()(const CartesianMaps &gbxmaps, viewd_gbx d_gbxs,
-                            SupersInDomain domainsupers) const;
+                            SupersInDomain allsupers) const;
 };
 
 #endif  // LIBS_CARTESIANDOMAIN_ADD_SUPERS_AT_DOMAIN_TOP_HPP_

--- a/libs/cartesiandomain/add_supers_at_domain_top.hpp
+++ b/libs/cartesiandomain/add_supers_at_domain_top.hpp
@@ -41,6 +41,7 @@
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/domainboundaries.hpp"
 #include "gridboxes/sortsupers.hpp"
+#include "gridboxes/supersindomain.hpp"
 #include "initialise/optional_config_params.hpp"
 #include "superdrops/superdrop.hpp"
 
@@ -123,11 +124,9 @@ struct AddSupersAtDomainTop {
   /*
   Call to apply boundary conditions to remove and then add superdroplets to the top of the domain
   abouve coord3lim.
-
-  _Note:_ totsupers is view of all superdrops (both in and out of bounds of domain).
   */
-  void operator()(const CartesianMaps &gbxmaps, viewd_gbx d_gbxs,
-                  const viewd_supers totsupers) const;
+  SupersInDomain operator()(const CartesianMaps &gbxmaps, viewd_gbx d_gbxs,
+                            SupersInDomain domainsupers) const;
 };
 
 #endif  // LIBS_CARTESIANDOMAIN_ADD_SUPERS_AT_DOMAIN_TOP_HPP_

--- a/libs/cartesiandomain/add_supers_at_domain_top.hpp
+++ b/libs/cartesiandomain/add_supers_at_domain_top.hpp
@@ -40,7 +40,6 @@
 #include "../kokkosaliases.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/domainboundaries.hpp"
-#include "gridboxes/sortsupers.hpp"
 #include "gridboxes/supersindomain.hpp"
 #include "initialise/optional_config_params.hpp"
 #include "superdrops/superdrop.hpp"

--- a/libs/cartesiandomain/add_supers_at_domain_top.hpp
+++ b/libs/cartesiandomain/add_supers_at_domain_top.hpp
@@ -126,7 +126,7 @@ struct AddSupersAtDomainTop {
   abouve coord3lim.
   */
   SupersInDomain operator()(const CartesianMaps &gbxmaps, viewd_gbx d_gbxs,
-                            SupersInDomain allsupers) const;
+                            SupersInDomain &allsupers) const;
 };
 
 #endif  // LIBS_CARTESIANDOMAIN_ADD_SUPERS_AT_DOMAIN_TOP_HPP_

--- a/libs/cartesiandomain/null_boundary_conditions.hpp
+++ b/libs/cartesiandomain/null_boundary_conditions.hpp
@@ -25,10 +25,13 @@
 
 #include "../kokkosaliases.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
+#include "gridboxes/supersindomain.hpp"
 
 struct NullBoundaryConditions {
-  void operator()(const CartesianMaps &gbxmaps, viewd_gbx d_gbxs,
-                  const viewd_supers totsupers) const {}
+  SupersInDomain operator()(const CartesianMaps &gbxmaps, viewd_gbx d_gbxs,
+                            const SupersInDomain domainsupers) const {
+    return domainsupers;
+  }
 };
 
 #endif  // LIBS_CARTESIANDOMAIN_NULL_BOUNDARY_CONDITIONS_HPP_

--- a/libs/cartesiandomain/null_boundary_conditions.hpp
+++ b/libs/cartesiandomain/null_boundary_conditions.hpp
@@ -29,8 +29,8 @@
 
 struct NullBoundaryConditions {
   SupersInDomain operator()(const CartesianMaps &gbxmaps, viewd_gbx d_gbxs,
-                            const SupersInDomain domainsupers) const {
-    return domainsupers;
+                            const SupersInDomain allsupers) const {
+    return allsupers;
   }
 };
 

--- a/libs/cartesiandomain/null_boundary_conditions.hpp
+++ b/libs/cartesiandomain/null_boundary_conditions.hpp
@@ -29,7 +29,7 @@
 
 struct NullBoundaryConditions {
   SupersInDomain operator()(const CartesianMaps &gbxmaps, viewd_gbx d_gbxs,
-                            const SupersInDomain allsupers) const {
+                            const SupersInDomain &allsupers) const {
     return allsupers;
   }
 };

--- a/libs/gridboxes/findrefs.hpp
+++ b/libs/gridboxes/findrefs.hpp
@@ -31,7 +31,7 @@
 /* namespace containing values of constants with dimensions */
 namespace SetRefPreds {
 
-/* struct for SupersInGbx::set_refs() predicate to find _first_ superdrop in
+/* struct for SupersInGbx::set_refs(...) predicate to find _first_ superdrop in
 view which has matching sdgbxindex to idx */
 struct Ref0 {
   unsigned int idx;
@@ -41,7 +41,7 @@ struct Ref0 {
   }
 };
 
-/* struct for SupersInGbx::set_refs() predicate to find _last_ superdrop in
+/* struct for SupersInGbx::set_refs(...) predicate to find _last_ superdrop in
 view which has matching sdgbxindex to idx */
 struct Ref1 {
   unsigned int idx;
@@ -134,13 +134,15 @@ KOKKOS_INLINE_FUNCTION size_t makeref(const Iter start, const Iter iter) {
   return static_cast<size_t>(ref);
 }
 
-/* returns position in view of {first, last} superdrop that is in domain,
-ie. that has sdgbxindex < oob_idx. Function is outermost level of parallelism. */
+/* returns position in view of {first, last} superdrop that is in domain, where first is assumed to
+be at 0th position. Last is position of last superdrop with sdgbxindex < idx_max. Function valid
+in outermost level (outside) of parallelism. */
 template <typename ViewSupers>
-inline kkpair_size_t find_domainrefs(const ViewSupers totsupers) {
+inline kkpair_size_t find_domainrefs(
+    const ViewSupers totsupers, const Kokkos::pair<unsigned int, unsigned int> gbxindex_range) {
   namespace SRP = SetRefPreds;
-  const auto ref0 = size_t{0};
-  const auto ref1 = size_t{find_ref(totsupers, SRP::Ref0{LIMITVALUES::oob_gbxindex})};
+  const auto ref0 = size_t{find_ref(totsupers, SRP::Ref0{gbxindex_range.first})};
+  const auto ref1 = size_t{find_ref(totsupers, SRP::Ref1{gbxindex_range.second})};
 
   return {ref0, ref1};
 }

--- a/libs/gridboxes/gridbox.hpp
+++ b/libs/gridboxes/gridbox.hpp
@@ -58,10 +58,6 @@ struct Gridbox {
   KOKKOS_INLINE_FUNCTION
   auto get_gbxindex() const { return gbxindex.value; }
 
-  viewd_constsupers domain_totsupers_readonly() const {
-    return supersingbx.domain_totsupers_readonly();
-  }
-
   size_t domain_totnsupers() const { return supersingbx.domain_totnsupers(); }
 };
 

--- a/libs/gridboxes/gridbox.hpp
+++ b/libs/gridboxes/gridbox.hpp
@@ -57,8 +57,6 @@ struct Gridbox {
 
   KOKKOS_INLINE_FUNCTION
   auto get_gbxindex() const { return gbxindex.value; }
-
-  size_t domain_totnsupers() const { return supersingbx.domain_totnsupers(); }
 };
 
 #endif  // LIBS_GRIDBOXES_GRIDBOX_HPP_

--- a/libs/gridboxes/gridbox.hpp
+++ b/libs/gridboxes/gridbox.hpp
@@ -46,14 +46,13 @@ struct Gridbox {
 
   /* assumes supers view (or subview) already sorted via sdgbxindex. Constructor works
   outside of parallelism */
-  Gridbox(const Gbxindex igbxindex, const State istate, const viewd_supers totsupers)
-      : gbxindex(igbxindex), state(istate), supersingbx(totsupers, gbxindex.value) {}
+  Gridbox(const Gbxindex igbxindex, const State istate, const subviewd_constsupers domainsupers)
+      : gbxindex(igbxindex), state(istate), supersingbx(gbxindex.value, domainsupers) {}
 
   /* assumes supers view (or subview) already sorted via sdgbxindex. Constructor works within
   parallel team policy on host given member 'team_member' */
-  Gridbox(const Gbxindex igbxindex, const State istate, const viewd_supers totsupers,
-          const kkpair_size_t irefs)
-      : gbxindex(igbxindex), state(istate), supersingbx(totsupers, gbxindex.value, irefs) {}
+  Gridbox(const Gbxindex igbxindex, const State istate, const kkpair_size_t irefs)
+      : gbxindex(igbxindex), state(istate), supersingbx(gbxindex.value, irefs) {}
 
   KOKKOS_INLINE_FUNCTION
   auto get_gbxindex() const { return gbxindex.value; }

--- a/libs/gridboxes/movesupersindomain.hpp
+++ b/libs/gridboxes/movesupersindomain.hpp
@@ -114,8 +114,8 @@ struct MoveSupersInDomain {
     _Note:_ totsupers is view of all superdrops (both in and out of bounds of domain).
     */
     SupersInDomain move_supers_between_gridboxes(const GbxMaps &gbxmaps, const viewd_gbx d_gbxs,
-                                                 SupersInDomain domainsupers) const {
-      auto totsupers = domainsupers.get_totsupers();
+                                                 SupersInDomain allsupers) const {
+      auto totsupers = allsupers.get_totsupers();
 
       sort_supers(totsupers);
 
@@ -133,7 +133,7 @@ struct MoveSupersInDomain {
             d_gbxs(ii).supersingbx.set_refs(team_member);
           });
 
-      domainsupers.set_totsupers(totsupers);
+      allsupers.set_totsupers(totsupers);
 
       // /* optional (expensive!) test to raise error if
       // superdrops' gbxindex doesn't match gridbox's gbxindex */
@@ -145,7 +145,7 @@ struct MoveSupersInDomain {
       //              "incorrect references to superdrops in gridbox during motion");
       //     });
 
-      return domainsupers;
+      return allsupers;
     }
   } enactmotion;
 
@@ -168,17 +168,17 @@ struct MoveSupersInDomain {
    * if current time, t_sdm, is time when superdrop motion should occur, enact movement of
    * superdroplets throughout domain.
    *
-   * @param domainsupers Struct to handle all superdrops (both in and out of bounds of domain).
+   * @param allsupers Struct to handle all superdrops (both in and out of bounds of domain).
    *
    */
   SupersInDomain run_step(const unsigned int t_sdm, const GbxMaps &gbxmaps, viewd_gbx d_gbxs,
-                          SupersInDomain domainsupers, const SDMMonitor auto mo) const {
+                          SupersInDomain allsupers, const SDMMonitor auto mo) const {
     if (enactmotion.motion.on_step(t_sdm)) {
-      domainsupers = move_superdrops_in_domain(t_sdm, gbxmaps, d_gbxs, domainsupers);
+      allsupers = move_superdrops_in_domain(t_sdm, gbxmaps, d_gbxs, allsupers);
       mo.monitor_motion(d_gbxs);
     }
 
-    return domainsupers;
+    return allsupers;
   }
 
  private:
@@ -193,7 +193,7 @@ struct MoveSupersInDomain {
   // loops from first two function calls into 1 loop?
   */
   SupersInDomain move_superdrops_in_domain(const unsigned int t_sdm, const GbxMaps &gbxmaps,
-                                           viewd_gbx d_gbxs, SupersInDomain domainsupers) const {
+                                           viewd_gbx d_gbxs, SupersInDomain allsupers) const {
     int my_rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
 
@@ -201,12 +201,12 @@ struct MoveSupersInDomain {
     enactmotion.move_supers_in_gridboxes(gbxmaps, d_gbxs);
 
     /* step (3) */
-    domainsupers = enactmotion.move_supers_between_gridboxes(gbxmaps, d_gbxs, domainsupers);
+    allsupers = enactmotion.move_supers_between_gridboxes(gbxmaps, d_gbxs, allsupers);
 
     /* step (4) */
-    domainsupers = apply_domain_boundary_conditions(gbxmaps, d_gbxs, domainsupers);
+    allsupers = apply_domain_boundary_conditions(gbxmaps, d_gbxs, allsupers);
 
-    return domainsupers;
+    return allsupers;
   }
 };
 

--- a/libs/gridboxes/movesupersindomain.hpp
+++ b/libs/gridboxes/movesupersindomain.hpp
@@ -46,7 +46,7 @@ which move to/from gridboxes on different nodes.
 */
 template <GridboxMaps GbxMaps>
 viewd_supers sendrecv_supers(const GbxMaps &gbxmaps, const viewd_gbx d_gbxs,
-                             const viewd_supers totsupers);
+                             viewd_supers totsupers);
 
 /*
 struct for functionality to move superdroplets throughtout
@@ -118,7 +118,7 @@ struct MoveSupersInDomain {
                                                  SupersInDomain &allsupers) const {
       auto totsupers = allsupers.get_totsupers();
 
-      sort_supers(totsupers);
+      totsupers = sort_supers(totsupers);
 
       int comm_size;
       MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
@@ -218,7 +218,7 @@ which move to/from gridboxes on different nodes.
 */
 template <GridboxMaps GbxMaps>
 viewd_supers sendrecv_supers(const GbxMaps &gbxmaps, const viewd_gbx d_gbxs,
-                             const viewd_supers totsupers) {
+                             viewd_supers totsupers) {
   int comm_size, my_rank;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
   MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
@@ -379,7 +379,7 @@ viewd_supers sendrecv_supers(const GbxMaps &gbxmaps, const viewd_gbx d_gbxs,
   for (unsigned int i = local_superdrops + total_superdrops_to_recv; i < totsupers.extent(0); i++)
     totsupers[i].set_sdgbxindex(LIMITVALUES::oob_gbxindex);
 
-  sort_supers(totsupers);
+  totsupers = sort_supers(totsupers);
 
   return totsupers;
 }

--- a/libs/gridboxes/sortsupers.hpp
+++ b/libs/gridboxes/sortsupers.hpp
@@ -21,8 +21,6 @@
 #ifndef LIBS_GRIDBOXES_SORTSUPERS_HPP_
 #define LIBS_GRIDBOXES_SORTSUPERS_HPP_
 
-#include <algorithm>
-
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Sort.hpp>
 #include <Kokkos_StdAlgorithms.hpp>
@@ -30,28 +28,44 @@
 #include "../kokkosaliases.hpp"
 #include "superdrops/superdrop.hpp"
 
-/* a precedes b if its sdgbxindex is smaller */
-struct SortComparator {
-  KOKKOS_INLINE_FUNCTION
-  bool operator()(const Superdrop &a, const Superdrop &b) const {
-    return (a.get_sdgbxindex()) < (b.get_sdgbxindex());
-  }
-};
-
-/* sort a view of superdroplets by their sdgbxindexes
-so that superdrops in the view are ordered from
-lowest to highest sdgbxindex. Note that sorting of
-superdrops with matching sdgbxindex can take any order */
-inline viewd_supers sort_supers(const viewd_supers supers) {
-  Kokkos::sort(ExecSpace(), supers, SortComparator{});
-
+/* sort the "supers" view of superdroplets by the Comparator. Note that sorting of superdrops
+is not guarenteed to be stable (not guarenteed to maintain previous order of equal values). */
+template <class Comparator>
+inline viewd_supers sort_supers(const viewd_supers supers, const Comparator &comp) {
+  Kokkos::sort(ExecSpace(), supers, comp);
   return supers;
 }
 
-/* returns true if superdrops in supers view are
-sorted by their sdgbxindexes in ascending order */
-inline bool is_sorted(const viewd_constsupers supers) {
-  return Kokkos::Experimental::is_sorted("IsSupersSorted", ExecSpace(), supers, SortComparator{});
+/* returns true if superdrops in "supers" view are already sorted by the Comparator */
+template <class Comparator>
+inline bool is_sorted_supers(const viewd_constsupers supers, const Comparator &comp) {
+  return Kokkos::Experimental::is_sorted("IsSupersSorted", ExecSpace(), supers, comp);
 }
+
+struct SortSupersBySdgbxindex {
+ private:
+  /* a precedes b if its sdgbxindex is smaller */
+  struct SortComparator {
+    KOKKOS_INLINE_FUNCTION
+    bool operator()(const Superdrop &a, const Superdrop &b) const {
+      return (a.get_sdgbxindex()) < (b.get_sdgbxindex());
+    }
+  };
+
+ public:
+  SortSupersBySdgbxindex() {}
+
+  /* sort the "supers" view of superdroplets by their sdgbxindexes so that superdrops in the
+  view are ordered from lowest to highest sdgbxindex. Note that sorting of superdrops with matching
+  sdgbxindex is not guarenteed to maintain their previous order (unstable sorting) */
+  viewd_supers operator()(const viewd_supers supers) {
+    return sort_supers(supers, SortComparator{});
+  }
+
+  /* returns true if superdrops in view are sorted by their sdgbxindexes in ascending order */
+  bool is_sorted(const viewd_constsupers supers) const {
+    return is_sorted_supers(supers, SortComparator{});
+  }
+};
 
 #endif  // LIBS_GRIDBOXES_SORTSUPERS_HPP_

--- a/libs/gridboxes/sortsupers.hpp
+++ b/libs/gridboxes/sortsupers.hpp
@@ -44,6 +44,9 @@ inline bool is_sorted_supers(const viewd_constsupers supers, const Comparator &c
 
 struct SortSupersBySdgbxindex {
  private:
+ public:
+  SortSupersBySdgbxindex() {}
+
   /* a precedes b if its sdgbxindex is smaller */
   struct SortComparator {
     KOKKOS_INLINE_FUNCTION
@@ -51,9 +54,6 @@ struct SortSupersBySdgbxindex {
       return (a.get_sdgbxindex()) < (b.get_sdgbxindex());
     }
   };
-
- public:
-  SortSupersBySdgbxindex() {}
 
   /* sort the "supers" view of superdroplets by their sdgbxindexes so that superdrops in the
   view are ordered from lowest to highest sdgbxindex. Note that sorting of superdrops with matching

--- a/libs/gridboxes/supersindomain.hpp
+++ b/libs/gridboxes/supersindomain.hpp
@@ -40,6 +40,8 @@ struct SupersInDomain {
 
   explicit SupersInDomain(const viewd_supers i_totsupers) : totsupers(i_totsupers) {}
 
+  void set_totsupers(const viewd_supers i_totsupers) { totsupers = i_totsupers; }
+
   viewd_supers get_totsupers() const { return totsupers; }
 
   /* returns the view of all the superdrops in the domain */
@@ -53,6 +55,12 @@ struct SupersInDomain {
   subviewd_constsupers domain_totsupers_readonly() const {
     const auto domainrefs = find_domainrefs(totsupers);
     return Kokkos::subview(totsupers, domainrefs);
+  }
+
+  /* returns the total number of all the superdrops in the domain (excluding out of bounds ones) */
+  size_t domain_nsupers() const {
+    const auto domainrefs = find_domainrefs(totsupers);
+    return domainrefs.second - domainrefs.first;
   }
 };
 

--- a/libs/gridboxes/supersindomain.hpp
+++ b/libs/gridboxes/supersindomain.hpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024 MPI-M, Clara Bayley
+ *
+ *
+ * ----- CLEO -----
+ * File: supersindomain.hpp
+ * Project: gridboxes
+ * Created Date: Tuesday 21st January 2025
+ * Author: Clara Bayley (CB)
+ * Additional Contributors:
+ * -----
+ * Last Modified: Tuesday 21st January 2025
+ * Modified By: CB
+ * -----
+ * License: BSD 3-Clause "New" or "Revised" License
+ * https://opensource.org/licenses/BSD-3-Clause
+ * -----
+ * File Description:
+ * Functions and structures related to handling superdroplets inside CLEO's domain (on one node)
+ */
+
+#ifndef LIBS_GRIDBOXES_SUPERSINDOMAIN_HPP_
+#define LIBS_GRIDBOXES_SUPERSINDOMAIN_HPP_
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_StdAlgorithms.hpp>
+
+#include "gridboxes/findrefs.hpp"
+#include "superdrops/kokkosaliases_sd.hpp"
+
+/* References to identify the chunk of memory containing super-droplets occupying domain
+(i.e. within any of the gridboxes on a single node), e.g. through std::span or Kokkos::subview) */
+struct SupersInDomain {
+ private:
+  viewd_supers totsupers; /**< view of all superdrops (both in and out of bounds of domain) */
+
+ public:
+  SupersInDomain() = default;   // Kokkos requirement for a (dual)View
+  ~SupersInDomain() = default;  // Kokkos requirement for a (dual)View
+
+  explicit SupersInDomain(const viewd_supers i_totsupers) : totsupers(i_totsupers) {}
+
+  viewd_supers get_totsupers() const { return totsupers; }
+
+  /* returns the view of all the superdrops in the domain */
+  subviewd_supers domain_supers() const {
+    const auto domainrefs = find_domainrefs(totsupers);
+    return Kokkos::subview(totsupers, domainrefs);
+  }
+
+  /* returns the view of all the superdrops in the domain. read-only means superdrops in
+  the view are const */
+  subviewd_constsupers domain_totsupers_readonly() const {
+    const auto domainrefs = find_domainrefs(totsupers);
+    return Kokkos::subview(totsupers, domainrefs);
+  }
+};
+
+#endif  // LIBS_GRIDBOXES_SUPERSINDOMAIN_HPP_

--- a/libs/gridboxes/supersindomain.hpp
+++ b/libs/gridboxes/supersindomain.hpp
@@ -27,6 +27,7 @@
 #include <Kokkos_StdAlgorithms.hpp>
 
 #include "gridboxes/findrefs.hpp"
+#include "gridboxes/sortsupers.hpp"
 #include "superdrops/kokkosaliases_sd.hpp"
 
 /* References to identify the chunk of memory containing super-droplets occupying domain
@@ -37,6 +38,12 @@ struct SupersInDomain {
   viewd_supers totsupers; /**< view of all superdrops (both in and out of bounds of domain) */
   kkpair_size_t
       domainrefs; /**< position in view of (first, last) superdrop that occupies gridbox */
+  SortSupersBySdgbxindex sort_by_sdgbxindex; /**< method to sort view of superdrops by sdgbxindex */
+
+  void set_totsupers_domainrefs(const viewd_supers totsupers_) {
+    totsupers = totsupers_;
+    domainrefs = find_domainrefs(totsupers, gbxindex_range);
+  }
 
  public:
   SupersInDomain() = default;   // Kokkos requirement for a (dual)View
@@ -45,16 +52,17 @@ struct SupersInDomain {
   explicit SupersInDomain(const viewd_supers totsupers_, const unsigned int gbxindex_max)
       : gbxindex_range({0, gbxindex_max}),
         totsupers(totsupers_),
-        domainrefs(find_domainrefs(totsupers, gbxindex_range)) {}
-
-  void set_domainrefs() { domainrefs = find_domainrefs(totsupers, gbxindex_range); }
-
-  void set_totsupers(const viewd_supers totsupers_) {
-    totsupers = totsupers_;
-    set_domainrefs();
+        domainrefs({0, 0}),
+        sort_by_sdgbxindex(SortSupersBySdgbxindex()) {
+    totsupers = sort_by_sdgbxindex(totsupers_);
+    set_totsupers_domainrefs(totsupers_);
   }
 
-  viewd_supers get_totsupers() const { return totsupers; }
+  viewd_supers get_totsupers() const {
+    return totsupers;
+  }  // TODO(CB): replace with appending SDs func which could resize(?)
+
+  viewd_constsupers get_totsupers_readonly() const { return totsupers; }
 
   /* returns the view of all the superdrops in the domain */
   subviewd_supers domain_supers() const { return Kokkos::subview(totsupers, domainrefs); }
@@ -67,6 +75,31 @@ struct SupersInDomain {
 
   /* returns the total number of all the superdrops in the domain (excluding out of bounds ones) */
   size_t domain_nsupers() const { return domainrefs.second - domainrefs.first; }
+
+  /* returns true if superdrops in view are sorted by their sdgbxindexes in ascending order */
+  bool is_sorted() const { return sort_by_sdgbxindex.is_sorted(totsupers); }
+
+  /* sort superdroplets by sdgbxindex and then (re-)set the totsupers view and the refs for the
+  superdroplets that are within the domain (sdgbxindex within gbxindex_range for a given node) */
+  viewd_supers sort_totsupers() {
+    auto totsupers_ = sort_by_sdgbxindex(totsupers);
+    set_totsupers_domainrefs(totsupers_);
+    return totsupers;
+  }
+
+  /* Only use if you know what you're doing(!) Return leaves SupersInDomain instance in an
+  intermediate state. Function sorts superdroplets by sdgbxindex but does not set the supers view
+  nor the refs for the superdroplets that are within the domain. This means 'totsupers' may change,
+  returned view may no longer be 'totsupers' and the domainrefs may be invalid. */
+  viewd_supers sort_totsupers_without_set() { return sort_by_sdgbxindex(totsupers); }
+
+  /* Only use if you know what you're doing(!) Assigns totsupers to given view and then sorts
+  superdroplets by sdgbxindex with possible (re-)setting of the totsupers view and the refs for the
+  superdroplets that are within the domain (sdgbxindex within gbxindex_range for a given node) */
+  viewd_supers sort_and_set_totsupers(const viewd_supers totsupers_) {
+    totsupers = totsupers_;
+    return sort_totsupers();
+  }
 };
 
 #endif  // LIBS_GRIDBOXES_SUPERSINDOMAIN_HPP_

--- a/libs/gridboxes/supersingbx.hpp
+++ b/libs/gridboxes/supersingbx.hpp
@@ -101,13 +101,6 @@ struct SupersInGbx {
   /* returns current number of superdrops referred to by gridbox */
   KOKKOS_INLINE_FUNCTION size_t nsupers() const { return refs.second - refs.first; }
 
-  /* returns the view of all the superdrops in the domain.
-  read-only means superdrops in the view are const */
-  viewd_constsupers domain_totsupers_readonly() const {
-    const auto domainrefs = find_domainrefs(totsupers);
-    return Kokkos::subview(totsupers, domainrefs);
-  }
-
   /* returns the total number of all the superdrops in the domain */
   size_t domain_totnsupers() const {
     const auto domainrefs = find_domainrefs(totsupers);

--- a/libs/gridboxes/supersingbx.hpp
+++ b/libs/gridboxes/supersingbx.hpp
@@ -100,12 +100,6 @@ struct SupersInGbx {
 
   /* returns current number of superdrops referred to by gridbox */
   KOKKOS_INLINE_FUNCTION size_t nsupers() const { return refs.second - refs.first; }
-
-  /* returns the total number of all the superdrops in the domain */
-  size_t domain_totnsupers() const {
-    const auto domainrefs = find_domainrefs(totsupers);
-    return domainrefs.second - domainrefs.first;
-  }
 };
 
 /* assumes totsupers is already sorted via sdgbxindex.

--- a/libs/gridboxes/supersingbx.hpp
+++ b/libs/gridboxes/supersingbx.hpp
@@ -29,23 +29,23 @@
 #include "gridboxes/findrefs.hpp"
 #include "superdrops/kokkosaliases_sd.hpp"
 
-/* References to identify the chunk of memory
-containing super-droplets occupying a given Gridbox
-(e.g. through std::span or Kokkos::subview) */
+/* References to identify the chunk of memory containing super-droplets occupying a given Gridbox.
+You must self ensure std::span/Kokkos::(sub)View used to find super-droplets is correct for
+current refs */
 struct SupersInGbx {
  private:
-  viewd_supers
-      totsupers; /**< reference to view of all superdrops (both in and out of bounds of domain) */
   unsigned int idx;   /**< value of gbxindex which sdgbxindex of superdrops must match */
   kkpair_size_t refs; /**< position in view of (first, last) superdrop that occupies gridbox */
 
   /* returns true if all superdrops in subview between refs satisfy the Predicate "pred" */
   template <typename Pred>
-  KOKKOS_FUNCTION bool is_pred(const TeamMember &team_member, const Pred pred) const;
+  KOKKOS_FUNCTION bool is_pred(const TeamMember &team_member, const Pred pred,
+                               const viewd_constsupers totsupers) const;
 
   /* returns true if all superdrops in subview between r0 and r1 do not satisfy pred */
   template <typename Pred>
   KOKKOS_FUNCTION bool is_prednot(const TeamMember &team_member, const Pred pred,
+                                  const viewd_constsupers totsupers,
                                   const kkpair_size_t refs4pred) const;
 
  public:
@@ -53,69 +53,73 @@ struct SupersInGbx {
   ~SupersInGbx() = default;  // Kokkos requirement for a (dual)View
 
   /* assumes supers view (or subview) already sorted via sdgbxindex. Constructor
-  works outside of parallelism */
-  SupersInGbx(const viewd_supers i_totsupers, const unsigned int i_idx)
-      : totsupers(i_totsupers), idx(i_idx), refs({0, 0}) {
-    set_refs();
+  works outside of parallelism to find refs given sorted superdrops in domain */
+  SupersInGbx(const unsigned int idx_, const subviewd_constsupers domainsupers)
+      : idx(idx_), refs({0, 0}) {
+    set_refs(domainsupers);
   }
 
-  /* assumes supers view (or subview) already sorted via sdgbxindex. Constructor
-  works within parallel team policy on host given member 'team_member' */
-  SupersInGbx(const viewd_supers i_totsupers, const unsigned int i_idx, const kkpair_size_t i_refs)
-      : totsupers(i_totsupers), idx(i_idx), refs(i_refs) {}
+  /* Constructor works within parallel team policy on host given member 'team_member' */
+  SupersInGbx(const unsigned int idx_, const kkpair_size_t refs_) : idx(idx_), refs(refs_) {}
 
-  /* assumes totsupers is already sorted via sdgbxindex. checks that all
+  /* assumes domainsupers is already sorted via sdgbxindex. checks that all
   superdrops in view which have matching sdgbxindex to idx are indeed
   included in (*this) subview (according to refs). Three criteria must
   be true for iscorrect to return true: (1) all superdrops in current
   subview have matching index. (2) all superdrops preceeding current
   subview do not have matching index. (3) all superdrops after current
   subview also do not have matching index. */
-  KOKKOS_FUNCTION bool iscorrect(const TeamMember &team_member) const;
+  KOKKOS_FUNCTION bool iscorrect(const TeamMember &team_member,
+                                 const viewd_constsupers totsupers) const;
 
-  /* assumes totsupers is already sorted via sdgbxindex.
+  /* assumes domainsupers is already sorted via sdgbxindex.
   sets 'refs' to pair with positions of first and last
   superdrops in view which have matching sdgbxindex to idx.
   Function is outside of parallelism (ie. in serial code). */
-  inline void set_refs();
+  inline void set_refs(const subviewd_constsupers domainsupers);
 
-  /* assumes totsupers is already sorted via sdgbxindex.
+  /* assumes domainsupers is already sorted via sdgbxindex.
   sets 'refs' to pair with positions of first and last
   superdrops in view which have matching sdgbxindex to idx.
   Function works within 1st layer of heirarchal parallelism
   for a team_member of a league */
-  KOKKOS_INLINE_FUNCTION void set_refs(const TeamMember &team_member);
+  KOKKOS_INLINE_FUNCTION void set_refs(const TeamMember &team_member,
+                                       const subviewd_constsupers domainsupers);
 
   /* returns subview from view of superdrops referencing superdrops
   which occupy given gridbox (according to refs) */
   KOKKOS_INLINE_FUNCTION
-  subviewd_supers operator()() const { return Kokkos::subview(totsupers, refs); }
+  subviewd_supers operator()(const subviewd_supers domainsupers) const {
+    return Kokkos::subview(domainsupers, refs);
+  }
 
-  /* returns read-only subview from view of superdrops
-  referencing superdrops which occupy given gridbox
-  (according to refs). read-only means superdrops
-  in the subview are const */
+  /* returns read-only subview from view of superdrops referencing superdrops which
+  occupy given gridbox (according to refs). read-only means superdrops in the subview are const */
   KOKKOS_INLINE_FUNCTION
-  subviewd_constsupers readonly() const { return Kokkos::subview(totsupers, refs); }
+  subviewd_constsupers readonly(const subviewd_constsupers domainsupers) const {
+    return Kokkos::subview(domainsupers, refs);
+  }
 
   /* returns current number of superdrops referred to by gridbox */
   KOKKOS_INLINE_FUNCTION size_t nsupers() const { return refs.second - refs.first; }
 };
 
-/* assumes totsupers is already sorted via sdgbxindex.
+/* assumes domainsupers is already sorted via sdgbxindex.
 sets 'refs' to pair with positions of first and last
 superdrops in view which have matching sdgbxindex to idx.
 Function is outside of parallelism (ie. in serial code). */
-inline void SupersInGbx::set_refs() { refs = find_refs(totsupers, idx); }
+inline void SupersInGbx::set_refs(const subviewd_constsupers domainsupers) {
+  refs = find_refs(domainsupers, idx);
+}
 
-/* assumes totsupers is already sorted via sdgbxindex.
+/* assumes domainsupers is already sorted via sdgbxindex.
 sets 'refs' to pair with positions of first and last
 superdrops in view which have matching sdgbxindex to idx.
 Function works within 1st layer of heirarchal
 parallelism for a team_member of a league */
-KOKKOS_INLINE_FUNCTION void SupersInGbx::set_refs(const TeamMember &team_member) {
-  const auto new_refs = find_refs(team_member, totsupers, idx);
-
+KOKKOS_INLINE_FUNCTION void SupersInGbx::set_refs(const TeamMember &team_member,
+                                                  const subviewd_constsupers domainsupers) {
+  const auto new_refs = find_refs(team_member, domainsupers, idx);
   Kokkos::single(
       Kokkos::PerTeam(team_member), [new_refs](kkpair_size_t &refs) { refs = new_refs; }, refs);
 }

--- a/libs/initialise/initialconditions.hpp
+++ b/libs/initialise/initialconditions.hpp
@@ -79,21 +79,20 @@ struct InitSupersData {
  * @tparam IC The type to check against the InitialConditions concept.
  */
 template <typename IC>
-concept InitialConditions =
-    requires(IC ic, unsigned int t, const viewh_constgbx h_gbxs, InitSupersData initdata) {
-      { ic.initsupers.get_maxnsupers() } -> std::convertible_to<size_t>;
-      { ic.initsupers.get_nspacedims() } -> std::convertible_to<unsigned int>;
-      { ic.initsupers.fetch_data() } -> std::same_as<InitSupersData>;
+concept InitialConditions = requires(IC ic) {
+  { ic.initsupers.get_maxnsupers() } -> std::convertible_to<size_t>;
+  { ic.initsupers.get_nspacedims() } -> std::convertible_to<unsigned int>;
+  { ic.initsupers.fetch_data() } -> std::same_as<InitSupersData>;
 
-      { ic.initgbxs.get_ngbxs() } -> std::convertible_to<size_t>;
-      { ic.initgbxs.press() } -> std::convertible_to<std::vector<double>>;
-      { ic.initgbxs.temp() } -> std::convertible_to<std::vector<double>>;
-      { ic.initgbxs.qvap() } -> std::convertible_to<std::vector<double>>;
-      { ic.initgbxs.qcond() } -> std::convertible_to<std::vector<double>>;
-      { ic.initgbxs.wvel() } -> std::convertible_to<std::vector<std::pair<double, double>>>;
-      { ic.initgbxs.uvel() } -> std::convertible_to<std::vector<std::pair<double, double>>>;
-      { ic.initgbxs.vvel() } -> std::convertible_to<std::vector<std::pair<double, double>>>;
-    };
+  { ic.initgbxs.get_ngbxs() } -> std::convertible_to<size_t>;
+  { ic.initgbxs.press() } -> std::convertible_to<std::vector<double>>;
+  { ic.initgbxs.temp() } -> std::convertible_to<std::vector<double>>;
+  { ic.initgbxs.qvap() } -> std::convertible_to<std::vector<double>>;
+  { ic.initgbxs.qcond() } -> std::convertible_to<std::vector<double>>;
+  { ic.initgbxs.wvel() } -> std::convertible_to<std::vector<std::pair<double, double>>>;
+  { ic.initgbxs.uvel() } -> std::convertible_to<std::vector<std::pair<double, double>>>;
+  { ic.initgbxs.vvel() } -> std::convertible_to<std::vector<std::pair<double, double>>>;
+};
 
 /* helpful struct satisyfing InitialConditions concept for functions to generate
 initial conditions for CLEO */

--- a/libs/observers/collect_data_for_dataset.hpp
+++ b/libs/observers/collect_data_for_dataset.hpp
@@ -41,8 +41,8 @@
 template <typename CDD, typename Store>
 concept CollectDataForDataset =
     requires(CDD cdd, const Dataset<Store> &ds, const viewd_constgbx d_gbxs,
-             const viewd_constsupers totsupers, const size_t sz) {
-      { cdd.get_functor(d_gbxs, totsupers) };
+             const subviewd_constsupers d_supers, const size_t sz) {
+      { cdd.get_functor(d_gbxs, d_supers) };
       { cdd.reallocate_views(sz) } -> std::same_as<void>;
       { cdd.write_to_arrays(ds) } -> std::same_as<void>;
       { cdd.write_to_ragged_arrays(ds) } -> std::same_as<void>;
@@ -71,9 +71,8 @@ struct CombinedCollectDataForDataset {
     CollectData2::Functor b_functor;
 
     explicit Functor(const CollectData1 a, const CollectData2 b, const viewd_constgbx d_gbxs,
-                     const viewd_constsupers totsupers)
-        : a_functor(a.get_functor(d_gbxs, totsupers)),
-          b_functor(b.get_functor(d_gbxs, totsupers)) {}
+                     const subviewd_constsupers d_supers)
+        : a_functor(a.get_functor(d_gbxs, d_supers)), b_functor(b.get_functor(d_gbxs, d_supers)) {}
 
     /* Functor operator to perform copy of each element in parallel in Kokkos Range Policy */
     KOKKOS_INLINE_FUNCTION
@@ -98,8 +97,8 @@ struct CombinedCollectDataForDataset {
    */
   CombinedCollectDataForDataset(const CollectData1 a, const CollectData2 b) : a(a), b(b) {}
 
-  Functor get_functor(const viewd_constgbx d_gbxs, const viewd_constsupers totsupers) const {
-    return Functor(a, b, d_gbxs, totsupers);
+  Functor get_functor(const viewd_constgbx d_gbxs, const subviewd_constsupers d_supers) const {
+    return Functor(a, b, d_gbxs, d_supers);
   }
 
   void write_to_arrays(const Dataset<Store> &dataset) const {
@@ -153,7 +152,7 @@ struct NullCollectDataForDataset {
     void operator()(const TeamMember &team_member) const {}
   };
 
-  Functor get_functor(const viewd_constgbx d_gbxs, const viewd_constsupers totsupers) const {
+  Functor get_functor(const viewd_constgbx d_gbxs, const subviewd_constsupers d_supers) const {
     return Functor{};
   }
 

--- a/libs/observers/consttstep_observer.hpp
+++ b/libs/observers/consttstep_observer.hpp
@@ -39,10 +39,10 @@
  */
 template <typename OFs>
 concept ObsFuncs = requires(OFs ofs, unsigned int t, const viewd_constgbx d_gbxs,
-                            const viewd_constsupers totsupers) {
+                            const subviewd_constsupers d_supers) {
   { ofs.before_timestepping(d_gbxs) } -> std::same_as<void>;
   { ofs.after_timestepping() } -> std::same_as<void>;
-  { ofs.at_start_step(t, d_gbxs, totsupers) } -> std::same_as<void>;
+  { ofs.at_start_step(t, d_gbxs, d_supers) } -> std::same_as<void>;
   { ofs.get_sdmmonitor() };
 };
 
@@ -119,12 +119,12 @@ struct ConstTstepObserver {
    *
    * @param t_mdl The unsigned int parameter representing the current model time.
    * @param d_gbxs The view of gridboxes in device memory.
-   * @param totsupers View of superdrops on device.
+   * @param d_supers View of superdrops on device.
    */
   void at_start_step(const unsigned int t_mdl, const viewd_constgbx d_gbxs,
-                     const viewd_constsupers totsupers) const {
+                     const subviewd_constsupers d_supers) const {
     if (on_step(t_mdl)) {
-      do_obs.at_start_step(t_mdl, d_gbxs, totsupers);
+      do_obs.at_start_step(t_mdl, d_gbxs, d_supers);
     }
   }
 

--- a/libs/observers/gbxindex_observer.hpp
+++ b/libs/observers/gbxindex_observer.hpp
@@ -133,10 +133,10 @@ class GbxindexObserver {
    * observer concept.
    * @param t_mdl Current model timestep.
    * @param d_gbxs View of gridboxes on device.
-   * @param totsupers View of superdrops on device.
+   * @param d_supers View of superdrops on device.
    */
   void at_start_step(const unsigned int t_mdl, const viewd_constgbx d_gbxs,
-                     const viewd_constsupers totsupers) const {}
+                     const subviewd_constsupers d_supers) const {}
 
   /**
    * @brief Get null monitor for SDM processes from observer.

--- a/libs/observers/generic_collect_data.hpp
+++ b/libs/observers/generic_collect_data.hpp
@@ -92,14 +92,14 @@ class GenericCollectData {
    */
   struct Functor {
     using mirrorviewd_data = XarrayAndViews<Store, T>::mirrorviewd_data;
-    FunctorFunc ffunc;           /**< functor to collect data into d_data during parallel loop */
-    viewd_constgbx d_gbxs;       /**< view of gridboxes on device */
-    viewd_constsupers totsupers; /**< view of superdroplets on device */
-    mirrorviewd_data d_data;     /**< mirror view on device for data to collect */
+    FunctorFunc ffunc;             /**< functor to collect data into d_data during parallel loop */
+    viewd_constgbx d_gbxs;         /**< view of gridboxes on device */
+    subviewd_constsupers d_supers; /**< view of superdroplets on device */
+    mirrorviewd_data d_data;       /**< mirror view on device for data to collect */
 
-    Functor(FunctorFunc ffunc, const viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+    Functor(FunctorFunc ffunc, const viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
             mirrorviewd_data d_data)
-        : ffunc(ffunc), d_gbxs(d_gbxs), totsupers(totsupers), d_data(d_data) {}
+        : ffunc(ffunc), d_gbxs(d_gbxs), d_supers(d_supers), d_data(d_data) {}
 
     /**
      * @brief Adapter from signature of Kokkos::parallel_for with a range policy to call to
@@ -108,7 +108,7 @@ class GenericCollectData {
      * @param nn The index of the data element.
      */
     KOKKOS_INLINE_FUNCTION
-    void operator()(const size_t nn) const { ffunc(nn, d_gbxs, totsupers, d_data); }
+    void operator()(const size_t nn) const { ffunc(nn, d_gbxs, d_supers, d_data); }
   };
 
   /* Constructor to initialize GenericCollectData given functor function-like object,
@@ -131,14 +131,14 @@ class GenericCollectData {
    * @brief Returns the functor for collecting data.
    *
    * @param d_gbxs The view of gridboxes on device.
-   * @param totsupers The view of superdroplets on device.
+   * @param d_supers The view of superdroplets on device.
    * @return The functor object to use during a Kokkos:parallel_for range policy loop.
    */
-  Functor get_functor(const viewd_constgbx d_gbxs, const viewd_constsupers totsupers) const {
+  Functor get_functor(const viewd_constgbx d_gbxs, const subviewd_constsupers d_supers) const {
     // assert(((ptr->d_data.extent(0) == d_gbxs.extent(0)) ||
-    //         (ptr->d_data.extent(0) == totsupers.extent(0))) &&
+    //         (ptr->d_data.extent(0) == d_supers.extent(0))) &&
     //        "d_data view should be size of the number of gridboxes or superdroplets");
-    return Functor(ffunc, d_gbxs, totsupers, ptr->d_data);
+    return Functor(ffunc, d_gbxs, d_supers, ptr->d_data);
   }
 
   /**

--- a/libs/observers/massmoments_observer.hpp
+++ b/libs/observers/massmoments_observer.hpp
@@ -287,10 +287,10 @@ struct CollectMassMoments {
    * within a Kokkos::parallel_for loop over gridboxes with a team policy.
    *
    * @param d_gbxs View of gridboxes on device.
-   * @param totsupers View of superdroplets on device.
+   * @param d_supers View of superdroplets on device.
    * @return Functor for collecting mass moments.
    */
-  Functor get_functor(const viewd_constgbx d_gbxs, const viewd_constsupers totsupers) const {
+  Functor get_functor(const viewd_constgbx d_gbxs, const subviewd_constsupers d_supers) const {
     assert(((mom0_ptr->d_data.extent(0) == d_gbxs.extent(0)) &&
             (mom1_ptr->d_data.extent(0) == d_gbxs.extent(0)) &&
             (mom2_ptr->d_data.extent(0) == d_gbxs.extent(0))) &&

--- a/libs/observers/nsupers_observer.hpp
+++ b/libs/observers/nsupers_observer.hpp
@@ -50,12 +50,12 @@
  *
  * @param ii The index of the gridbox.
  * @param d_gbxs The view of gridboxes on device.
- * @param totsupers The view of superdroplets on device.
+ * @param d_supers The view of superdroplets on device.
  * @param d_data The mirror view buffer for the number of superdroplets.
  */
 struct NsupersFunc {
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t ii, viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+  void operator()(const size_t ii, viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
                   Buffer<uint32_t>::mirrorviewd_buffer d_data) const {
     auto nsupers = static_cast<uint32_t>(d_gbxs(ii).supersingbx.nsupers());
     d_data(ii) = nsupers;

--- a/libs/observers/observers.hpp
+++ b/libs/observers/observers.hpp
@@ -39,12 +39,12 @@
  */
 template <typename Obs>
 concept Observer = requires(Obs obs, unsigned int t, const viewd_constgbx d_gbxs,
-                            const viewd_constsupers totsupers) {
+                            const subviewd_constsupers d_supers) {
   { obs.next_obs(t) } -> std::convertible_to<unsigned int>;
   { obs.on_step(t) } -> std::same_as<bool>;
   { obs.before_timestepping(d_gbxs) } -> std::same_as<void>;
   { obs.after_timestepping() } -> std::same_as<void>;
-  { obs.at_start_step(t, d_gbxs, totsupers) } -> std::same_as<void>;
+  { obs.at_start_step(t, d_gbxs, d_supers) } -> std::same_as<void>;
   { obs.get_sdmmonitor() };
 };
 
@@ -129,12 +129,12 @@ struct CombinedObserver {
    *
    * @param t_mdl The unsigned int parameter.
    * @param d_gbxs The view of gridboxes in device memory.
-   * @param totsupers View of superdrops on device.
+   * @param d_supers View of superdrops on device.
    */
   void at_start_step(const unsigned int t_mdl, const viewd_constgbx d_gbxs,
-                     const viewd_constsupers totsupers) const {
-    a.at_start_step(t_mdl, d_gbxs, totsupers);
-    b.at_start_step(t_mdl, d_gbxs, totsupers);
+                     const subviewd_constsupers d_supers) const {
+    a.at_start_step(t_mdl, d_gbxs, d_supers);
+    b.at_start_step(t_mdl, d_gbxs, d_supers);
   }
 
   /**
@@ -209,10 +209,10 @@ struct NullObserver {
    *
    * @param t_mdl The unsigned int for the current timestep.
    * @param d_gbxs The view of gridboxes in device memory.
-   * @param totsupers View of superdrops on device.
+   * @param d_supers View of superdrops on device.
    */
   void at_start_step(const unsigned int t_mdl, const viewd_constgbx d_gbxs,
-                     const viewd_constsupers totsupers) const {}
+                     const subviewd_constsupers d_supers) const {}
 
   /**
    * @brief Get null monitor for SDM processes from observer.

--- a/libs/observers/sdmmonitor/do_sdmmonitor_obs.hpp
+++ b/libs/observers/sdmmonitor/do_sdmmonitor_obs.hpp
@@ -95,10 +95,10 @@ class DoSDMMonitorObs {
    *
    * @param t_mdl Current model timestep.
    * @param d_gbxs View of gridboxes on device.
-   * @param totsupers View of superdrops on device.
+   * @param d_supers View of superdrops on device.
    */
   void at_start_step(const unsigned int t_mdl, const viewd_constgbx d_gbxs,
-                     const viewd_constsupers totsupers) const {
+                     const subviewd_constsupers d_supers) const {
     at_start_step();
   }
 

--- a/libs/observers/sdmmonitor/monitor_condensation_observer.hpp
+++ b/libs/observers/sdmmonitor/monitor_condensation_observer.hpp
@@ -70,7 +70,7 @@ struct MonitorCondensation {
    *
    * @param d_gbxs The view of gridboxes in device memory.
    */
-  void monitor_motion(const viewd_constgbx d_gbxs) const {}
+  void monitor_motion(const viewd_constgbx d_gbxs, const subviewd_constsupers domainsupers) const {}
 
   /**
    * @brief Constructor for MonitorCondensation

--- a/libs/observers/sdmmonitor/monitor_massmoments.hpp
+++ b/libs/observers/sdmmonitor/monitor_massmoments.hpp
@@ -166,14 +166,15 @@ struct MonitorMassMoments {
    * distribution during SDM motion.
    *
    * @param d_gbxs The view of gridboxes in device memory.
+   * @param domainsupers The view of all super-droplets (in bounds of domain).
    */
-  void monitor_motion(const viewd_constgbx d_gbxs) const {
+  void monitor_motion(const viewd_constgbx d_gbxs, const subviewd_constsupers domainsupers) const {
     const size_t ngbxs(d_gbxs.extent(0));
     Kokkos::parallel_for(
         "monitor_motion", TeamPolicy(ngbxs, Kokkos::AUTO()),
         KOKKOS_CLASS_LAMBDA(const TeamMember& team_member) {
           const auto ii = team_member.league_rank();
-          const auto supers(d_gbxs(ii).supersingbx.readonly());
+          const auto supers = d_gbxs(ii).supersingbx.readonly(domainsupers);
           motion_moms.fetch_massmoments(team_member, supers);
         });
   }

--- a/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
+++ b/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
@@ -167,10 +167,10 @@ class DoMonitorMassMomentsObs {
    *
    * @param t_mdl Current model timestep.
    * @param d_gbxs View of gridboxes on device.
-   * @param totsupers View of superdrops on device.
+   * @param d_supers View of superdrops on device.
    */
   void at_start_step(const unsigned int t_mdl, const viewd_constgbx d_gbxs,
-                     const viewd_constsupers totsupers) const {
+                     const subviewd_constsupers d_supers) const {
     at_start_step();
   }
 

--- a/libs/observers/streamout_observer.cpp
+++ b/libs/observers/streamout_observer.cpp
@@ -36,14 +36,14 @@
  * @param d_gbxs View of the gridboxes on the device.
  */
 void StreamOutObserver::streamout_statement(const unsigned int t_mdl, const viewd_constgbx d_gbxs,
-                                            const viewd_constsupers totsupers) const {
+                                            const subviewd_constsupers d_supers) const {
   /* copy first gridbox into mirror view in case Gridboxes view is in device memory */
   auto d_gbx = Kokkos::subview(d_gbxs, kkpair_size_t({0, 1}));
   auto h_gbx = Kokkos::create_mirror_view_and_copy(HostSpace(), d_gbx);
   const auto &gbx = h_gbx(0);
 
   std::cout << "t=" << std::fixed << std::setprecision(2) << step2realtime(t_mdl)
-            << "s, totnsupers=" << totsupers.extent(0) << ", ngbxs=" << d_gbxs.extent(0) << ", (Gbx"
+            << "s, totnsupers=" << d_supers.extent(0) << ", ngbxs=" << d_gbxs.extent(0) << ", (Gbx"
             << gbx.get_gbxindex() << ": [T, p, qv, qc] = [" << gbx.state.temp * dlc::TEMP0 << "K, "
             << gbx.state.press * dlc::P0 << "Pa, " << std::scientific << std::setprecision(4)
             << gbx.state.qvap << ", " << gbx.state.qcond

--- a/libs/observers/streamout_observer.cpp
+++ b/libs/observers/streamout_observer.cpp
@@ -35,17 +35,17 @@
  * @param t_mdl Current model time.
  * @param d_gbxs View of the gridboxes on the device.
  */
-void StreamOutObserver::streamout_statement(const unsigned int t_mdl,
-                                            const viewd_constgbx d_gbxs) const {
+void StreamOutObserver::streamout_statement(const unsigned int t_mdl, const viewd_constgbx d_gbxs,
+                                            const viewd_constsupers totsupers) const {
   /* copy first gridbox into mirror view in case Gridboxes view is in device memory */
   auto d_gbx = Kokkos::subview(d_gbxs, kkpair_size_t({0, 1}));
   auto h_gbx = Kokkos::create_mirror_view_and_copy(HostSpace(), d_gbx);
   const auto &gbx = h_gbx(0);
 
   std::cout << "t=" << std::fixed << std::setprecision(2) << step2realtime(t_mdl)
-            << "s, totnsupers=" << gbx.domain_totnsupers() << ", ngbxs=" << d_gbxs.extent(0)
-            << ", (Gbx" << gbx.get_gbxindex() << ": [T, p, qv, qc] = ["
-            << gbx.state.temp * dlc::TEMP0 << "K, " << gbx.state.press * dlc::P0 << "Pa, "
-            << std::scientific << std::setprecision(4) << gbx.state.qvap << ", " << gbx.state.qcond
+            << "s, totnsupers=" << totsupers.extent(0) << ", ngbxs=" << d_gbxs.extent(0) << ", (Gbx"
+            << gbx.get_gbxindex() << ": [T, p, qv, qc] = [" << gbx.state.temp * dlc::TEMP0 << "K, "
+            << gbx.state.press * dlc::P0 << "Pa, " << std::scientific << std::setprecision(4)
+            << gbx.state.qvap << ", " << gbx.state.qcond
             << "], nsupers = " << gbx.supersingbx.nsupers() << ")" << std::endl;
 }

--- a/libs/observers/streamout_observer.hpp
+++ b/libs/observers/streamout_observer.hpp
@@ -61,7 +61,8 @@ struct StreamOutObserver {
    * @param t_mdl Current model time.
    * @param d_gbxs View of the gridboxes on the device.
    */
-  void streamout_statement(const unsigned int t_mdl, const viewd_constgbx d_gbxs) const;
+  void streamout_statement(const unsigned int t_mdl, const viewd_constgbx d_gbxs,
+                           const viewd_constsupers totsupers) const;
 
  public:
   /**
@@ -122,7 +123,7 @@ struct StreamOutObserver {
   void at_start_step(const unsigned int t_mdl, const viewd_constgbx d_gbxs,
                      const viewd_constsupers totsupers) const {
     if (on_step(t_mdl)) {
-      streamout_statement(t_mdl, d_gbxs);
+      streamout_statement(t_mdl, d_gbxs, totsupers);
     }
   }
 

--- a/libs/observers/streamout_observer.hpp
+++ b/libs/observers/streamout_observer.hpp
@@ -62,7 +62,7 @@ struct StreamOutObserver {
    * @param d_gbxs View of the gridboxes on the device.
    */
   void streamout_statement(const unsigned int t_mdl, const viewd_constgbx d_gbxs,
-                           const viewd_constsupers totsupers) const;
+                           const subviewd_constsupers d_supers) const;
 
  public:
   /**
@@ -118,12 +118,12 @@ struct StreamOutObserver {
    *
    * @param t_mdl Current model time.
    * @param d_gbxs View of grid boxes.
-   * @param totsupers View of super grids.
+   * @param d_supers View of super grids.
    */
   void at_start_step(const unsigned int t_mdl, const viewd_constgbx d_gbxs,
-                     const viewd_constsupers totsupers) const {
+                     const subviewd_constsupers d_supers) const {
     if (on_step(t_mdl)) {
-      streamout_statement(t_mdl, d_gbxs, totsupers);
+      streamout_statement(t_mdl, d_gbxs, d_supers);
     }
   }
 

--- a/libs/observers/superdrops_observer.hpp
+++ b/libs/observers/superdrops_observer.hpp
@@ -74,10 +74,10 @@ struct RaggedCount {
    * = uint64_t), to 8 byte unsigned integer (uint32_t).
    *
    * @param dataset The dataset to write data to.
-   * @param totsupers The view of total super-droplets.
+   * @param d_supers The view of total super-droplets.
    */
-  void write_to_array(const Dataset<Store> &dataset, const viewd_constsupers totsupers) const {
-    const auto totnsupers = static_cast<uint32_t>(totsupers.extent(0));
+  void write_to_array(const Dataset<Store> &dataset, const subviewd_constsupers d_supers) const {
+    const auto totnsupers = static_cast<uint32_t>(d_supers.extent(0));
     dataset.write_to_array(xzarr_ptr, totnsupers);
   }
 
@@ -138,14 +138,14 @@ CollectDataForDataset<Store> auto CollectSuperdropVariable(
  *
  * @param kk The index of the superdrop.
  * @param d_gbxs The view of gridboxes on device.
- * @param totsupers The view of superdroplets on device.
+ * @param d_supers The view of superdroplets on device.
  * @param d_data The mirror view buffer for the superdroplets' sdgbxindex.
  */
 struct SdgbxindexFunc {
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t kk, viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+  void operator()(const size_t kk, viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
                   Buffer<uint32_t>::mirrorviewd_buffer d_data) const {
-    auto sdgbxindex = static_cast<uint32_t>(totsupers(kk).get_sdgbxindex());
+    auto sdgbxindex = static_cast<uint32_t>(d_supers(kk).get_sdgbxindex());
     d_data(kk) = sdgbxindex;
   }
 };
@@ -182,14 +182,14 @@ CollectDataForDataset<Store> auto CollectSdgbxindex(const Dataset<Store> &datase
  *
  * @param kk The index of the superdrop.
  * @param d_gbxs The view of gridboxes on device.
- * @param totsupers The view of superdroplets on device.
+ * @param d_supers The view of superdroplets on device.
  * @param d_data The mirror view buffer for the superdroplets' identity.
  */
 struct SdIdFunc {
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t kk, viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+  void operator()(const size_t kk, viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
                   Buffer<uint32_t>::mirrorviewd_buffer d_data) const {
-    auto sdid = static_cast<uint32_t>(totsupers(kk).sdId.get_value());
+    auto sdid = static_cast<uint32_t>(d_supers(kk).sdId.get_value());
     d_data(kk) = sdid;
   }
 };
@@ -226,16 +226,16 @@ CollectDataForDataset<Store> auto CollectSdId(const Dataset<Store> &dataset,
  *
  * @param kk The index of the superdrop.
  * @param d_gbxs The view of gridboxes on device.
- * @param totsupers The view of superdroplets on device.
+ * @param d_supers The view of superdroplets on device.
  * @param d_data The mirror view buffer for the superdroplets' multiplicity.
  */
 struct XiFunc {
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t kk, viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+  void operator()(const size_t kk, viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
                   Buffer<uint64_t>::mirrorviewd_buffer d_data) const {
-    assert((totsupers(kk).get_xi() < LIMITVALUES::uint64_t_max) &&
+    assert((d_supers(kk).get_xi() < LIMITVALUES::uint64_t_max) &&
            "superdroplet mulitiplicy too large to represent with 4 byte unsigned integer");
-    auto xi = static_cast<uint64_t>(totsupers(kk).get_xi());
+    auto xi = static_cast<uint64_t>(d_supers(kk).get_xi());
     d_data(kk) = xi;
   }
 };
@@ -269,14 +269,14 @@ CollectDataForDataset<Store> auto CollectXi(const Dataset<Store> &dataset, const
  *
  * @param kk The index of the superdrop.
  * @param d_gbxs The view of gridboxes on device.
- * @param totsupers The view of superdroplets on device.
+ * @param d_supers The view of superdroplets on device.
  * @param d_data The mirror view buffer for the superdroplets' radius.
  */
 struct RadiusFunc {
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t kk, viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+  void operator()(const size_t kk, viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
                   Buffer<float>::mirrorviewd_buffer d_data) const {
-    auto radius = static_cast<float>(totsupers(kk).get_radius());
+    auto radius = static_cast<float>(d_supers(kk).get_radius());
     d_data(kk) = radius;
   }
 };
@@ -311,14 +311,14 @@ CollectDataForDataset<Store> auto CollectRadius(const Dataset<Store> &dataset,
  *
  * @param kk The index of the superdrop.
  * @param d_gbxs The view of gridboxes on device.
- * @param totsupers The view of superdroplets on device.
+ * @param d_supers The view of superdroplets on device.
  * @param d_data The mirror view buffer for the superdroplets' msol.
  */
 struct MsolFunc {
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t kk, viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+  void operator()(const size_t kk, viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
                   Buffer<float>::mirrorviewd_buffer d_data) const {
-    auto msol = static_cast<float>(totsupers(kk).get_msol());
+    auto msol = static_cast<float>(d_supers(kk).get_msol());
     d_data(kk) = msol;
   }
 };
@@ -353,14 +353,14 @@ CollectDataForDataset<Store> auto CollectMsol(const Dataset<Store> &dataset,
  *
  * @param kk The index of the superdrop.
  * @param d_gbxs The view of gridboxes on device.
- * @param totsupers The view of superdroplets on device.
+ * @param d_supers The view of superdroplets on device.
  * @param d_data The mirror view buffer for the superdroplets' coord3.
  */
 struct Coord3Func {
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t kk, viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+  void operator()(const size_t kk, viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
                   Buffer<float>::mirrorviewd_buffer d_data) const {
-    auto coord3 = static_cast<float>(totsupers(kk).get_coord3());
+    auto coord3 = static_cast<float>(d_supers(kk).get_coord3());
     d_data(kk) = coord3;
   }
 };
@@ -395,14 +395,14 @@ CollectDataForDataset<Store> auto CollectCoord3(const Dataset<Store> &dataset,
  *
  * @param kk The index of the superdrop.
  * @param d_gbxs The view of gridboxes on device.
- * @param totsupers The view of superdroplets on device.
+ * @param d_supers The view of superdroplets on device.
  * @param d_data The mirror view buffer for the superdroplets' coord1.
  */
 struct Coord1Func {
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t kk, viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+  void operator()(const size_t kk, viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
                   Buffer<float>::mirrorviewd_buffer d_data) const {
-    auto coord1 = static_cast<float>(totsupers(kk).get_coord1());
+    auto coord1 = static_cast<float>(d_supers(kk).get_coord1());
     d_data(kk) = coord1;
   }
 };
@@ -437,14 +437,14 @@ CollectDataForDataset<Store> auto CollectCoord1(const Dataset<Store> &dataset,
  *
  * @param kk The index of the superdrop.
  * @param d_gbxs The view of gridboxes on device.
- * @param totsupers The view of superdroplets on device.
+ * @param d_supers The view of superdroplets on device.
  * @param d_data The mirror view buffer for the superdroplets' coord2.
  */
 struct Coord2Func {
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t kk, viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+  void operator()(const size_t kk, viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
                   Buffer<float>::mirrorviewd_buffer d_data) const {
-    auto coord2 = static_cast<float>(totsupers(kk).get_coord2());
+    auto coord2 = static_cast<float>(d_supers(kk).get_coord2());
     d_data(kk) = coord2;
   }
 };

--- a/libs/observers/thermo_observer.hpp
+++ b/libs/observers/thermo_observer.hpp
@@ -82,12 +82,12 @@ CollectDataForDataset<Store> auto CollectThermoVariable(const Dataset<Store> &da
  *
  * @param ii The index of the gridbox.
  * @param d_gbxs The view of gridboxes on device.
- * @param totsupers The view of superdroplets on device.
+ * @param d_supers The view of superdroplets on device.
  * @param d_data The mirror view buffer for the pressure in each gridbox.
  */
 struct PressFunc {
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t ii, viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+  void operator()(const size_t ii, viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
                   Buffer<float>::mirrorviewd_buffer d_data) const {
     auto press = static_cast<float>(d_gbxs(ii).state.press);
     d_data(ii) = press;
@@ -104,12 +104,12 @@ struct PressFunc {
  *
  * @param ii The index of the gridbox.
  * @param d_gbxs The view of gridboxes on device.
- * @param totsupers The view of superdroplets on device.
+ * @param d_supers The view of superdroplets on device.
  * @param d_data The mirror view buffer for the temperature in each gridbox.
  */
 struct TempFunc {
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t ii, viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+  void operator()(const size_t ii, viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
                   Buffer<float>::mirrorviewd_buffer d_data) const {
     auto temp = static_cast<float>(d_gbxs(ii).state.temp);
     d_data(ii) = temp;
@@ -126,12 +126,12 @@ struct TempFunc {
  *
  * @param ii The index of the gridbox.
  * @param d_gbxs The view of gridboxes on device.
- * @param totsupers The view of superdroplets on device.
+ * @param d_supers The view of superdroplets on device.
  * @param d_data The mirror view buffer for qvap from each gridbox.
  */
 struct QvapFunc {
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t ii, viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+  void operator()(const size_t ii, viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
                   Buffer<float>::mirrorviewd_buffer d_data) const {
     auto qvap = static_cast<float>(d_gbxs(ii).state.qvap);
     d_data(ii) = qvap;
@@ -148,12 +148,12 @@ struct QvapFunc {
  *
  * @param ii The index of the gridbox.
  * @param d_gbxs The view of gridboxes on device.
- * @param totsupers The view of superdroplets on device.
+ * @param d_supers The view of superdroplets on device.
  * @param d_data The mirror view buffer for qcond from each gridbox.
  */
 struct QcondFunc {
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t ii, viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+  void operator()(const size_t ii, viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
                   Buffer<float>::mirrorviewd_buffer d_data) const {
     auto qcond = static_cast<float>(d_gbxs(ii).state.qcond);
     d_data(ii) = qcond;

--- a/libs/observers/time_observer.hpp
+++ b/libs/observers/time_observer.hpp
@@ -111,10 +111,10 @@ class DoTimeObs {
    *
    * @param t_mdl Current model timestep.
    * @param d_gbxs View of gridboxes on device.
-   * @param totsupers View of superdrops on device.
+   * @param d_supers View of superdrops on device.
    */
   void at_start_step(const unsigned int t_mdl, const viewd_constgbx d_gbxs,
-                     const viewd_constsupers totsupers) const {
+                     const subviewd_constsupers d_supers) const {
     at_start_step(t_mdl);
   }
 

--- a/libs/observers/totnsupers_observer.hpp
+++ b/libs/observers/totnsupers_observer.hpp
@@ -51,17 +51,17 @@ class DoTotNsupersObs {
   std::shared_ptr<XarrayZarrArray<Store, uint32_t>> xzarr_ptr; /**< pointer to totnsupers array */
 
   /**
-   * @brief Write out the total number of superdroplets in totsupers view at the start of a timestep
+   * @brief Write out the total number of superdroplets in d_supers view at the start of a timestep
    * to an array in the dataset.
    *
    * _Note:_ conversion of totnsupers from size_t (arch dependent usually 8 bytes) to shorter 4
    * byte, unsigned int (unit32_t).
    *
-   * @param totsupers View of all the superdroplets to count (on device memory but metadata for
+   * @param d_supers View of all the superdroplets to count (on device memory but metadata for
    * extent of view is available on host).
    */
-  void at_start_step(const viewd_constsupers totsupers) const {
-    const auto data = static_cast<uint32_t>(totsupers.extent(0));
+  void at_start_step(const subviewd_constsupers d_supers) const {
+    const auto data = static_cast<uint32_t>(d_supers.extent(0));
     dataset.write_to_array(xzarr_ptr, data);
   }
 
@@ -97,15 +97,15 @@ class DoTotNsupersObs {
 
   /**
    * @brief Adapter to call at start step function which writes the total number of superdroplets in
-   * totsupers view to the array in the dataset.
+   * d_supers view to the array in the dataset.
    *
    * @param t_mdl Current model timestep.
    * @param d_gbxs View of gridboxes on device.
-   * @param totsupers View of superdrops on device.
+   * @param d_supers View of superdrops on device.
    */
   void at_start_step(const unsigned int t_mdl, const viewd_constgbx d_gbxs,
-                     const viewd_constsupers totsupers) const {
-    at_start_step(totsupers);
+                     const subviewd_constsupers d_supers) const {
+    at_start_step(d_supers);
   }
 
   /**

--- a/libs/observers/windvel_observer.hpp
+++ b/libs/observers/windvel_observer.hpp
@@ -80,12 +80,12 @@ CollectDataForDataset<Store> auto CollectWindVariable(const Dataset<Store> &data
  *
  * @param ii The index of the gridbox.
  * @param d_gbxs The view of gridboxes on device.
- * @param totsupers The view of superdroplets on device.
+ * @param d_supers The view of superdroplets on device.
  * @param d_data The mirror view buffer for wvel form each gridbox.
  */
 struct WvelFunc {
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t ii, viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+  void operator()(const size_t ii, viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
                   Buffer<float>::mirrorviewd_buffer d_data) const {
     auto wvel = static_cast<float>(d_gbxs(ii).state.wvelcentre());
     d_data(ii) = wvel;
@@ -102,12 +102,12 @@ struct WvelFunc {
  *
  * @param ii The index of the gridbox.
  * @param d_gbxs The view of gridboxes on device.
- * @param totsupers The view of superdroplets on device.
+ * @param d_supers The view of superdroplets on device.
  * @param d_data The mirror view buffer for uvel form each gridbox.
  */
 struct UvelFunc {
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t ii, viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+  void operator()(const size_t ii, viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
                   Buffer<float>::mirrorviewd_buffer d_data) const {
     auto uvel = static_cast<float>(d_gbxs(ii).state.uvelcentre());
     d_data(ii) = uvel;
@@ -124,12 +124,12 @@ struct UvelFunc {
  *
  * @param ii The index of the gridbox.
  * @param d_gbxs The view of gridboxes on device.
- * @param totsupers The view of superdroplets on device.
+ * @param d_supers The view of superdroplets on device.
  * @param d_data The mirror view buffer for vvel form each gridbox.
  */
 struct VvelFunc {
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t ii, viewd_constgbx d_gbxs, const viewd_constsupers totsupers,
+  void operator()(const size_t ii, viewd_constgbx d_gbxs, const subviewd_constsupers d_supers,
                   Buffer<float>::mirrorviewd_buffer d_data) const {
     auto vvel = static_cast<float>(d_gbxs(ii).state.vvelcentre());
     d_data(ii) = vvel;

--- a/libs/observers/write_to_dataset_observer.hpp
+++ b/libs/observers/write_to_dataset_observer.hpp
@@ -72,11 +72,11 @@ class DoWriteToDataset {
    * @brief Calls the parallel_write function during at_start_step.
    * @param t_mdl Current model time.
    * @param d_gbxs View of gridboxes.
-   * @param totsupers View of superdroplets.
+   * @param d_supers View of superdroplets.
    */
   void at_start_step(const unsigned int t_mdl, const viewd_constgbx d_gbxs,
-                     const viewd_constsupers totsupers) const {
-    parallel_write(d_gbxs, totsupers);
+                     const subviewd_constsupers d_supers) const {
+    parallel_write(d_gbxs, d_supers);
   }
 
   /**

--- a/libs/runcleo/creategbxs.cpp
+++ b/libs/runcleo/creategbxs.cpp
@@ -34,7 +34,8 @@
  * @param ngbxs_from_maps The number of gridboxes from gridbox maps.
  * @param gbxs The dualview containing gridboxes.
  */
-void is_gbxinit_complete(const size_t ngbxs_from_maps, dualview_gbx gbxs) {
+void is_gbxinit_complete(const size_t ngbxs_from_maps, dualview_gbx gbxs,
+                         const viewd_constsupers totsupers) {
   const auto ngbxs = size_t{gbxs.extent(0)};
   if (ngbxs != ngbxs_from_maps) {
     const std::string err(
@@ -49,7 +50,7 @@ void is_gbxinit_complete(const size_t ngbxs_from_maps, dualview_gbx gbxs) {
       "is_gbxinit_complete", TeamPolicy(ngbxs, Kokkos::AUTO()),
       KOKKOS_LAMBDA(const TeamMember &team_member) {
         const auto ii = team_member.league_rank();
-        assert(d_gbxs(ii).supersingbx.iscorrect(team_member) &&
+        assert(d_gbxs(ii).supersingbx.iscorrect(team_member, totsupers) &&
                "incorrect references to superdrops in gridbox");
       });
 }

--- a/libs/runcleo/creategbxs.hpp
+++ b/libs/runcleo/creategbxs.hpp
@@ -266,7 +266,8 @@ dualview_gbx create_gbxs(const GbxMaps &gbxmaps, const GbxInitConds &gbxic,
   const auto gbxs = initialise_gbxs(gbxmaps, gbxic, domainsupers);
 
   std::cout << "checking initialisation\n";
-  is_gbxinit_complete(gbxmaps.get_local_ngridboxes_hostcopy(), gbxs, allsupers.get_totsupers());
+  is_gbxinit_complete(gbxmaps.get_local_ngridboxes_hostcopy(), gbxs,
+                      allsupers.get_totsupers_readonly());
 
   // // Print information about the created superdrops
   // print_gbxs(gbxs.view_host());

--- a/libs/runcleo/createsupers.cpp
+++ b/libs/runcleo/createsupers.cpp
@@ -28,13 +28,13 @@
  * superdroplets are sorted by ascending gridbox indexes. If the initialisation is incomplete
  * (the superdroplets are not sorted), it throws an exception with an appropriate error message.
  *
- * @param supers The view of super-droplets in device memory.
+ * @param allsupers Struct to handle all the super-droplets in device memory.
  *
  * @throws std::invalid_argument If the initialisation is incomplete i.e. the super-droplets
  * are not ordered correctly.
  */
-void is_sdsinit_complete(const viewd_constsupers supers) {
-  if (is_sorted(supers) == 0) {
+void is_sdsinit_complete(const SupersInDomain allsupers) {
+  if (allsupers.is_sorted() == 0) {
     const std::string err(
         "supers ordered incorrectly "
         "(ie. not sorted by asceding sdgbxindex");
@@ -48,18 +48,18 @@ void is_sdsinit_complete(const viewd_constsupers supers) {
  * This function prints information about each superdroplet, including its ID, Gridbox index,
  * spatial coordinates, and attributes.
  *
- * @param supers The view of super-droplets in device memory.
+ * @param totsupers The view of super-droplets in device memory.
  */
-void print_supers(const viewd_constsupers supers) {
-  auto h_supers =
-      Kokkos::create_mirror_view(supers);  // mirror of supers in case view is on device memory
-  Kokkos::deep_copy(h_supers, supers);
+void print_supers(const viewd_constsupers totsupers) {
+  auto h_totsupers =
+      Kokkos::create_mirror_view(totsupers);  // mirror of supers in case view is on device memory
+  Kokkos::deep_copy(h_totsupers, totsupers);
 
-  for (size_t kk(0); kk < h_supers.extent(0); ++kk) {
-    std::cout << "SD: " << h_supers(kk).sdId << " [gbx, (coords), (attrs)]: [ "
-              << h_supers(kk).get_sdgbxindex() << ", (" << h_supers(kk).get_coord3() << ", "
-              << h_supers(kk).get_coord1() << ", " << h_supers(kk).get_coord2() << "), ("
-              << h_supers(kk).is_solute() << ", " << h_supers(kk).get_radius() << ", "
-              << h_supers(kk).get_msol() << ", " << h_supers(kk).get_xi() << ") ] \n";
+  for (size_t kk(0); kk < h_totsupers.extent(0); ++kk) {
+    std::cout << "SD: " << h_totsupers(kk).sdId << " [gbx, (coords), (attrs)]: [ "
+              << h_totsupers(kk).get_sdgbxindex() << ", (" << h_totsupers(kk).get_coord3() << ", "
+              << h_totsupers(kk).get_coord1() << ", " << h_totsupers(kk).get_coord2() << "), ("
+              << h_totsupers(kk).is_solute() << ", " << h_totsupers(kk).get_radius() << ", "
+              << h_totsupers(kk).get_msol() << ", " << h_totsupers(kk).get_xi() << ") ] \n";
   }
 }

--- a/libs/runcleo/createsupers.hpp
+++ b/libs/runcleo/createsupers.hpp
@@ -29,7 +29,7 @@
 #include <string>
 
 #include "../kokkosaliases.hpp"
-#include "gridboxes/sortsupers.hpp"
+#include "gridboxes/supersindomain.hpp"
 #include "runcleo/gensuperdrop.hpp"
 
 /**
@@ -57,19 +57,19 @@ viewd_supers initialise_supers(const SuperdropInitConds &sdic);
  *
  * The equivalent serial version of the Kokkos::parallel_for([...]) is:
  * @code
- * for (size_t kk(0); kk < totnsupers; ++kk)
+ * for (size_t kk(0); kk < ntotsupers; ++kk)
  * {
- *  h_supers(kk) = gen(kk);
+ *  h_totsupers(kk) = gen(kk);
  * }
  * @endcode
  *
  * @param sdic The instance of the super-droplets' initial conditions data.
- * @param supers The view of superdrops on device memory.
+ * @param totsupers The view of superdrops on device memory.
  * @return A mirror view of superdrops on host memory.
  */
 template <typename SuperdropInitConds>
 viewd_supers::HostMirror initialise_supers_on_host(const SuperdropInitConds &sdic,
-                                                   const viewd_supers supers);
+                                                   const viewd_supers totsupers);
 
 /**
  * @brief Check if superdroplets initialisation is complete.
@@ -78,12 +78,12 @@ viewd_supers::HostMirror initialise_supers_on_host(const SuperdropInitConds &sdi
  * superdroplets are sorted by ascending gridbox indexes. If the initialisation is incomplete
  * (the superdroplets are not sorted), it throws an exception with an appropriate error message.
  *
- * @param supers The view of super-droplets in device memory.
+ * @param allsupers Struct to handle all the super-droplets in device memory.
  *
  * @throws std::invalid_argument If the initialisation is incomplete i.e. the super-droplets
  * are not ordered correctly.
  */
-void is_sdsinit_complete(const viewd_constsupers supers);
+void is_sdsinit_complete(const SupersInDomain allsupers);
 
 /**
  * @brief Print statement about initialised super-droplets.
@@ -91,15 +91,15 @@ void is_sdsinit_complete(const viewd_constsupers supers);
  * This function prints information about each superdroplet, including its ID, Gridbox index,
  * spatial coordinates, and attributes.
  *
- * @param supers The view of super-droplets in device memory.
+ * @param totsupers The view of super-droplets in device memory.
  */
-void print_supers(const viewd_constsupers supers);
+void print_supers(const viewd_constsupers totsupers);
 
 /**
  * @brief Create a view of super-droplets in (device) memory.
  *
  * This function creates an ordered view of superdrops in device memory, where the number
- * of superdrops is specified by the parameter `totnsupers`. The superdrops are
+ * of superdrops is specified by the parameter `ntotsupers`. The superdrops are
  * ordered by the gridbox indexes and generated using a generator which uses
  * the initial conditions provided by the `SuperdropInitConds` type.
  *
@@ -108,31 +108,31 @@ void print_supers(const viewd_constsupers supers);
  *
  * @tparam SuperdropInitConds The type of the super-droplets' initial conditions data.
  * @param sdic The instance of the super-droplets' initial conditions data.
- * @return A view of super-droplets in device memory.
+ * @return Struct for handling super-droplets in device memory.
  */
 template <typename SuperdropInitConds>
-viewd_supers create_supers(const SuperdropInitConds &sdic) {
+SupersInDomain create_supers(const SuperdropInitConds &sdic, const unsigned int gbxindex_max) {
   Kokkos::Profiling::ScopedRegion region("init_supers");
 
   // Log message and create superdrops using the initial conditions
   std::cout << "\n--- create superdrops ---\ninitialising\n";
-  viewd_supers supers(initialise_supers(sdic));
+  auto totsupers = initialise_supers(sdic);
 
   // Log message and sort the view of superdrops
-  std::cout << "sorting\n";
-  supers = sort_supers(supers);
+  std::cout << "sorting and finding superdrops in domain\n";
+  auto allsupers = SupersInDomain(totsupers, gbxindex_max);
 
   // Log message and perform checks on the initialisation of superdrops
   std::cout << "checking initialisation\n";
-  is_sdsinit_complete(supers);
+  is_sdsinit_complete(allsupers);
 
   // // Print information about the created superdrops
-  // print_supers(supers);
+  // print_supers(totsupers);
 
   // Log message indicating the successful creation of superdrops
   std::cout << "--- create superdrops: success ---\n";
 
-  return supers;
+  return allsupers;
 }
 
 /**
@@ -151,15 +151,15 @@ viewd_supers initialise_supers(const SuperdropInitConds &sdic) {
   GenSuperdrop gen(sdic);
 
   // create superdrops view on device
-  viewd_supers supers("supers", gen.get_maxnsupers());
+  auto totsupers = viewd_supers("totsupers", gen.get_maxnsupers());
 
   // initialise a mirror of superdrops view on host
-  auto h_supers = initialise_supers_on_host(sdic, supers);
+  auto h_totsupers = initialise_supers_on_host(sdic, totsupers);
 
-  // Copy host view to device (h_supers to supers)
-  Kokkos::deep_copy(supers, h_supers);
+  // Copy host view to device (h_totsupers to totsupers)
+  Kokkos::deep_copy(totsupers, h_totsupers);
 
-  return supers;
+  return totsupers;
 }
 
 /**
@@ -173,29 +173,29 @@ viewd_supers initialise_supers(const SuperdropInitConds &sdic) {
  *
  * The equivalent serial version of the Kokkos::parallel_for([...]) is:
  * @code
- * for (size_t kk(0); kk < totnsupers; ++kk)
+ * for (size_t kk(0); kk < ntotsupers; ++kk)
  * {
- *  h_supers(kk) = gen(kk);
+ *  h_totsupers(kk) = gen(kk);
  * }
  * @endcode
  *
  * @param sdic The instance of the super-droplets' initial conditions data.
- * @param supers The view of superdrops on device memory.
+ * @param totsupers The view of superdrops on device memory.
  * @return A mirror view of superdrops on host memory.
  */
 template <typename SuperdropInitConds>
 viewd_supers::HostMirror initialise_supers_on_host(const SuperdropInitConds &sdic,
-                                                   const viewd_supers supers) {
+                                                   const viewd_supers totsupers) {
   // Create a mirror view of supers in case the original view is on device memory
-  auto h_supers = Kokkos::create_mirror_view(supers);
+  auto h_totsupers = Kokkos::create_mirror_view(totsupers);
 
   // Parallel initialisation of the mirror view
-  const size_t totnsupers(supers.extent(0));
+  const auto ntotsupers = size_t{totsupers.extent(0)};
   const GenSuperdrop gen(sdic);
-  Kokkos::parallel_for("initialise_supers_on_host", Kokkos::RangePolicy<HostSpace>(0, totnsupers),
-                       [=](const size_t kk) { h_supers(kk) = gen(kk); });
+  Kokkos::parallel_for("initialise_supers_on_host", Kokkos::RangePolicy<HostSpace>(0, ntotsupers),
+                       [=](const size_t kk) { h_totsupers(kk) = gen(kk); });
 
-  return h_supers;
+  return h_totsupers;
 }
 
 #endif  // LIBS_RUNCLEO_CREATESUPERS_HPP_

--- a/libs/runcleo/createsupers.hpp
+++ b/libs/runcleo/createsupers.hpp
@@ -151,7 +151,7 @@ viewd_supers initialise_supers(const SuperdropInitConds &sdic) {
   GenSuperdrop gen(sdic);
 
   // create superdrops view on device
-  viewd_supers supers("supers", gen.get_local_nsupers());
+  viewd_supers supers("supers", gen.get_maxnsupers());
 
   // initialise a mirror of superdrops view on host
   auto h_supers = initialise_supers_on_host(sdic, supers);

--- a/libs/runcleo/gensuperdrop.hpp
+++ b/libs/runcleo/gensuperdrop.hpp
@@ -38,6 +38,7 @@
  */
 class GenSuperdrop {
  private:
+  size_t maxnsupers; /**< Maximum allowed superdroplets in the domain (total extent of view). */
   unsigned int nspacedims; /**< Number of spatial dimensions. */
   InitSupersData initdata; /**< instance of InitSupersData for initialising superdrops. */
 
@@ -82,9 +83,11 @@ class GenSuperdrop {
    */
   template <typename SuperdropInitConds>
   explicit GenSuperdrop(const SuperdropInitConds &sdic)
-      : nspacedims(sdic.get_nspacedims()), initdata(sdic.fetch_data()) {}
+      : maxnsupers(sdic.get_maxnsupers()),
+        nspacedims(sdic.get_nspacedims()),
+        initdata(sdic.fetch_data()) {}
 
-  unsigned int get_local_nsupers() { return initdata.sdgbxindexes.size(); }
+  auto get_maxnsupers() { return maxnsupers; }
 
   /**
    * @brief Generate a super-droplet using initial data for the kk'th superdrop.

--- a/libs/runcleo/runcleo.hpp
+++ b/libs/runcleo/runcleo.hpp
@@ -121,7 +121,7 @@ class RunCLEO {
    * @return 0 on success.
    */
   int timestep_cleo(const unsigned int t_end, const dualview_gbx gbxs,
-                    const SupersInDomain domainsupers) const {
+                    SupersInDomain domainsupers) const {
     std::cout << "\n--- timestepping ---\n";
 
     unsigned int t_mdl(0);
@@ -222,11 +222,11 @@ class RunCLEO {
    * @param domainsupers Struct to handle all superdrops (both in and out of bounds of domain).
    */
   void sdm_step(const unsigned int t_mdl, unsigned int t_next, dualview_gbx gbxs,
-                const SupersInDomain domainsupers) const {
+                SupersInDomain domainsupers) const {
     Kokkos::Profiling::ScopedRegion region("timestep_sdm");
 
     gbxs.sync_device();  // get device up to date with host
-    sdm.run_step(t_mdl, t_next, gbxs.view_device(), domainsupers.get_totsupers());
+    sdm.run_step(t_mdl, t_next, gbxs.view_device(), domainsupers);
     gbxs.modify_device();  // mark device view of gbxs as modified
   }
 

--- a/libs/runcleo/runcleo.hpp
+++ b/libs/runcleo/runcleo.hpp
@@ -121,7 +121,7 @@ class RunCLEO {
    * @return 0 on success.
    */
   int timestep_cleo(const unsigned int t_end, const dualview_gbx gbxs,
-                    SupersInDomain allsupers) const {
+                    SupersInDomain &allsupers) const {
     std::cout << "\n--- timestepping ---\n";
 
     unsigned int t_mdl(0);
@@ -157,7 +157,7 @@ class RunCLEO {
    * @return Size of the next timestep.
    */
   unsigned int start_step(const unsigned int t_mdl, dualview_gbx gbxs,
-                          const SupersInDomain allsupers) const {
+                          const SupersInDomain &allsupers) const {
     if (t_mdl % sdm.get_couplstep() == 0) {
       gbxs.sync_host();
       comms.receive_dynamics(sdm.gbxmaps, coupldyn, gbxs.view_host());
@@ -222,7 +222,7 @@ class RunCLEO {
    * @param allsupers Struct to handle all superdrops (both in and out of bounds of domain).
    */
   void sdm_step(const unsigned int t_mdl, unsigned int t_next, dualview_gbx gbxs,
-                SupersInDomain allsupers) const {
+                SupersInDomain &allsupers) const {
     Kokkos::Profiling::ScopedRegion region("timestep_sdm");
 
     gbxs.sync_device();  // get device up to date with host
@@ -310,9 +310,9 @@ class RunCLEO {
 
     // create runtime objects and prepare CLEO for timestepping
     Kokkos::Profiling::pushRegion("init");
-    auto totsupers = create_supers(initconds.initsupers);
-    auto allsupers = SupersInDomain(totsupers);
-    auto gbxs = create_gbxs(sdm.gbxmaps, initconds.initgbxs, allsupers.get_totsupers());
+    auto allsupers = SupersInDomain(create_supers(initconds.initsupers),
+                                    sdm.gbxmaps.get_local_ngridboxes_hostcopy());
+    auto gbxs = create_gbxs(sdm.gbxmaps, initconds.initgbxs, allsupers);
     prepare_to_timestep(gbxs);
     Kokkos::Profiling::popRegion();
 

--- a/libs/runcleo/runcleo.hpp
+++ b/libs/runcleo/runcleo.hpp
@@ -310,8 +310,8 @@ class RunCLEO {
 
     // create runtime objects and prepare CLEO for timestepping
     Kokkos::Profiling::pushRegion("init");
-    auto allsupers = SupersInDomain(create_supers(initconds.initsupers),
-                                    sdm.gbxmaps.get_local_ngridboxes_hostcopy());
+    auto allsupers =
+        create_supers(initconds.initsupers, sdm.gbxmaps.get_local_ngridboxes_hostcopy());
     auto gbxs = create_gbxs(sdm.gbxmaps, initconds.initgbxs, allsupers);
     prepare_to_timestep(gbxs);
     Kokkos::Profiling::popRegion();

--- a/libs/runcleo/runcleo.hpp
+++ b/libs/runcleo/runcleo.hpp
@@ -35,6 +35,7 @@
 #include "gridboxes/gridbox.hpp"
 #include "gridboxes/gridboxmaps.hpp"
 #include "gridboxes/movesupersindomain.hpp"
+#include "gridboxes/supersindomain.hpp"
 #include "initialise/initialconditions.hpp"
 #include "observers/observers.hpp"
 #include "runcleo/coupleddynamics.hpp"
@@ -116,23 +117,23 @@ class RunCLEO {
    *
    * @param t_end End time for timestepping.
    * @param gbxs DualView of gridboxes.
-   * @param totsupers View of all superdroplets (both in and out of bounds of domain).
+   * @param domainsupers Struct to handle all superdroplets (both in and out of bounds of domain).
    * @return 0 on success.
    */
   int timestep_cleo(const unsigned int t_end, const dualview_gbx gbxs,
-                    const viewd_supers totsupers) const {
+                    const SupersInDomain domainsupers) const {
     std::cout << "\n--- timestepping ---\n";
 
     unsigned int t_mdl(0);
     while (t_mdl <= t_end) {
       /* start step (in general involves coupling) */
-      const auto t_next = (unsigned int)start_step(t_mdl, gbxs);
+      const auto t_next = (unsigned int)start_step(t_mdl, gbxs, domainsupers);
 
       /* advance dynamics solver (optionally concurrent to SDM) */
       coupldyn_step(t_mdl, t_next);
 
       /* advance SDM (optionally concurrent to dynamics solver) */
-      sdm_step(t_mdl, t_next, gbxs, totsupers);
+      sdm_step(t_mdl, t_next, gbxs, domainsupers);
 
       /* proceed to next step (in general involves coupling) */
       t_mdl = proceed_to_next_step(t_next, gbxs);
@@ -155,7 +156,8 @@ class RunCLEO {
    * @param gbxs DualView of gridboxes.
    * @return Size of the next timestep.
    */
-  unsigned int start_step(const unsigned int t_mdl, dualview_gbx gbxs) const {
+  unsigned int start_step(const unsigned int t_mdl, dualview_gbx gbxs,
+                          const SupersInDomain domainsupers) const {
     if (t_mdl % sdm.get_couplstep() == 0) {
       gbxs.sync_host();
       comms.receive_dynamics(sdm.gbxmaps, coupldyn, gbxs.view_host());
@@ -163,7 +165,7 @@ class RunCLEO {
     }
 
     gbxs.sync_device();
-    sdm.at_start_step(t_mdl, gbxs);
+    sdm.at_start_step(t_mdl, gbxs, domainsupers);
 
     return get_next_step(t_mdl);
   }
@@ -217,14 +219,14 @@ class RunCLEO {
    * @param t_mdl Current timestep of the coupled model.
    * @param t_next Next timestep of the coupled model.
    * @param gbxs DualView of gridboxes.
-   * @param totsupers View of all superdrops (both in and out of bounds of domain).
+   * @param domainsupers Struct to handle all superdrops (both in and out of bounds of domain).
    */
   void sdm_step(const unsigned int t_mdl, unsigned int t_next, dualview_gbx gbxs,
-                const viewd_supers totsupers) const {
+                const SupersInDomain domainsupers) const {
     Kokkos::Profiling::ScopedRegion region("timestep_sdm");
 
     gbxs.sync_device();  // get device up to date with host
-    sdm.run_step(t_mdl, t_next, gbxs.view_device(), totsupers);
+    sdm.run_step(t_mdl, t_next, gbxs.view_device(), domainsupers.get_totsupers());
     gbxs.modify_device();  // mark device view of gbxs as modified
   }
 
@@ -309,13 +311,14 @@ class RunCLEO {
     // create runtime objects and prepare CLEO for timestepping
     Kokkos::Profiling::pushRegion("init");
     auto totsupers = create_supers(initconds.initsupers);
-    auto gbxs = create_gbxs(sdm.gbxmaps, initconds.initgbxs, totsupers);
+    auto domainsupers = SupersInDomain(totsupers);
+    auto gbxs = create_gbxs(sdm.gbxmaps, initconds.initgbxs, domainsupers.get_totsupers());
     prepare_to_timestep(gbxs);
     Kokkos::Profiling::popRegion();
 
     // do timestepping from t=0 to t=t_end
     Kokkos::Profiling::pushRegion("timestep");
-    timestep_cleo(t_end, gbxs, totsupers);
+    timestep_cleo(t_end, gbxs, domainsupers);
     Kokkos::Profiling::popRegion();
 
     Kokkos::Profiling::popRegion();

--- a/libs/runcleo/sdmmethods.hpp
+++ b/libs/runcleo/sdmmethods.hpp
@@ -32,6 +32,7 @@
 #include "gridboxes/gridbox.hpp"
 #include "gridboxes/gridboxmaps.hpp"
 #include "gridboxes/movesupersindomain.hpp"
+#include "gridboxes/supersindomain.hpp"
 #include "observers/observers.hpp"
 #include "superdrops/microphysicalprocess.hpp"
 #include "superdrops/motion.hpp"
@@ -212,9 +213,10 @@ class SDMMethods {
    * @param t_mdl Current timestep of the coupled model.
    * @param gbxs Dualview of gridboxes (on host and on device).
    */
-  void at_start_step(const unsigned int t_mdl, const dualview_gbx gbxs) const {
+  void at_start_step(const unsigned int t_mdl, const dualview_gbx gbxs,
+                     const SupersInDomain domainsupers) const {
     const auto d_gbxs = gbxs.view_device();
-    const auto domain_totsupers = gbxs.view_host()(0).domain_totsupers_readonly();
+    const auto domain_totsupers = domainsupers.domain_totsupers_readonly();
     obs.at_start_step(t_mdl, d_gbxs, domain_totsupers);
   }
 

--- a/libs/superdrops/sdmmonitor.hpp
+++ b/libs/superdrops/sdmmonitor.hpp
@@ -29,8 +29,8 @@
 /**
  * @brief Concept of SDMmonitor to monitor various SDM processes.
  *
- * _Note:_ Constraints missing `{ mo.monitor_motion(d_gbxs) } -> std::same_as<void>;` to avoid
- * adding constraint over templated type "d_gbxs".
+ * _Note:_ Constraints missing `{ mo.monitor_motion(d_gbxs, domainsupers) } -> std::same_as<void>;`
+ * to avoid adding constraint over templated argument types.
  *
  * @tparam SDMMo Type that satisfies the SDMMonitor concept.
  */
@@ -101,9 +101,9 @@ struct CombinedSDMMonitor {
    *
    * Each monitor is run sequentially.
    */
-  void monitor_motion(const auto d_gbxs) const {
-    a.monitor_motion(d_gbxs);
-    b.monitor_motion(d_gbxs);
+  void monitor_motion(const auto d_gbxs, const auto domainsupers) const {
+    a.monitor_motion(d_gbxs, domainsupers);
+    b.monitor_motion(d_gbxs, domainsupers);
   }
 };
 
@@ -121,7 +121,7 @@ struct NullSDMMonitor {
   KOKKOS_FUNCTION
   void monitor_microphysics(const TeamMember &team_member, const viewd_constsupers supers) const {}
 
-  void monitor_motion(const auto d_gbxs) const {}
+  void monitor_motion(const auto d_gbxs, const auto domainsupers) const {}
 };
 
 #endif  //  LIBS_SUPERDROPS_SDMMONITOR_HPP_

--- a/roughpaper/scratch/main.cpp
+++ b/roughpaper/scratch/main.cpp
@@ -140,9 +140,10 @@ inline auto create_movement(const CartesianMaps &gbxmaps) {
   return MoveSupersInDomain(gbxmaps, motion, boundary_conditions);
 }
 
-inline InitialConditions auto create_initconds(const Config &config) {
+template <GridboxMaps GbxMaps>
+inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
   const auto initsupers = InitAllSupersFromBinary(config.get_initsupersfrombinary());
-  const auto initgbxs = InitGbxsNull(config.get_ngbxs());
+  const auto initgbxs = InitGbxsNull(gbxmaps.get_local_ngridboxes_hostcopy());
 
   return InitConds(initsupers, initgbxs);
 }
@@ -198,9 +199,6 @@ int main(int argc, char *argv[]) {
     auto store = FSStore(config.get_zarrbasedir());
     auto dataset = Dataset(store);
 
-    /* Initial conditions for CLEO run */
-    const InitialConditions auto initconds = create_initconds(config);
-
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));
 
@@ -210,6 +208,9 @@ int main(int argc, char *argv[]) {
 
     /* coupling between coupldyn and SDM */
     const CouplingComms<CartesianMaps, FromFileDynamics> auto comms = FromFileComms{};
+
+    /* Initial conditions for CLEO run */
+    const InitialConditions auto initconds = create_initconds(config, sdm.gbxmaps);
 
     /* Run CLEO (SDM coupled to dynamics solver) */
     const RunCLEO runcleo(sdm, coupldyn, comms);

--- a/roughpaper/src/main.cpp
+++ b/roughpaper/src/main.cpp
@@ -59,15 +59,15 @@ int main(int argc, char *argv[]) {
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));
 
-    /* Initial conditions for CLEO run */
-    const InitialConditions auto initconds = create_initconds(config, sdm.gbxmaps);
-
     /* Solver of dynamics coupled to CLEO SDM */
     CoupledDynamics auto coupldyn(
         create_coupldyn(config, sdm.gbxmaps, tsteps.get_couplstep(), tsteps.get_t_end()));
 
     /* coupling between coupldyn and SDM */
     const CouplingComms<CartesianMaps, FromFileDynamics> auto comms = FromFileComms{};
+
+    /* Initial conditions for CLEO run */
+    const InitialConditions auto initconds = create_initconds(config, sdm.gbxmaps);
 
     /* Run CLEO (SDM coupled to dynamics solver) */
     const RunCLEO runcleo(sdm, coupldyn, comms);

--- a/roughpaper/src/main_impl.hpp
+++ b/roughpaper/src/main_impl.hpp
@@ -87,10 +87,11 @@ inline CoupledDynamics auto create_coupldyn(const Config &config, const Cartesia
   return FromFileDynamics(config.get_fromfiledynamics(), couplstep, ndims, nsteps);
 }
 
-inline InitialConditions auto create_initconds(const Config &config, const CartesianMaps &gbxmaps) {
+template <GridboxMaps GbxMaps>
+inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
   // const auto initsupers = InitAllSupersFromBinary(config.get_initsupersfrombinary());
   const auto initsupers = InitSupersFromBinary(config.get_initsupersfrombinary(), gbxmaps);
-  const auto initgbxs = InitGbxsNull(config.get_ngbxs());
+  const auto initgbxs = InitGbxsNull(gbxmaps.get_local_ngridboxes_hostcopy());
 
   return InitConds(initsupers, initgbxs);
 }

--- a/scripts/compile_run_cleocoupledsdm.sh
+++ b/scripts/compile_run_cleocoupledsdm.sh
@@ -26,8 +26,8 @@ compilername=${2:-intel}                                        # "intel" or "gc
 path2CLEO=${3:-${HOME}/CLEO}                                    # must be absolute path
 path2build=${4:-${path2CLEO}/build}                             # should be absolute path
 enableyac=${5:-false}                                           # == "true" or otherwise false
-executables=${6:-"cleocoupledsdm testing"}                      # executable(s) to compile
-executable2run=${7:-${path2build}/roughpaper/src/${executable}} # path to executable to run
+executables=${6:-"cleocoupledsdm"}                              # executable(s) to compile
+executable2run=${7:-${path2build}/roughpaper/src/${executables}} # path to executable to run
 configfile=${8:-${path2CLEO}/roughpaper/src/config/config.yaml} # configuration to run
 stacksize_limit=${9:-204800}                                    # ulimit -s [stacksize_limit] (kB)
 ### ---------------------------------------------------- ###
@@ -75,8 +75,8 @@ echo "### ------------------------------------------- ###"
 
 ### ---------------- compile executables --------------- ###
 make_clean=false
-rm ${run_executable}
-compilecmd="${CLEO_PATH2BUILD}/scripts/bash/compile_cleo.sh ${executables} ${make_clean}"
+rm -f ${executable2run}
+compilecmd="${CLEO_PATH2CLEO}/scripts/bash/compile_cleo.sh ${executables} ${make_clean}"
 echo ${compilecmd}
 eval ${compilecmd}
 ### ---------------------------------------------------- ###
@@ -90,7 +90,7 @@ echo "### ------------------------------------------- ###"
 
 ### ------------------- run executable ----------------- ###
 cd ${CLEO_PATH2BUILD} && pwd
-runcmd="${CLEO_PATH2BUILD}/scripts/bash/run_cleo.sh ${executable2run} ${configfile} ${stacksize_limit}"
+runcmd="${CLEO_PATH2CLEO}/scripts/bash/run_cleo.sh ${executable2run} ${configfile} ${stacksize_limit}"
 echo ${runcmd}
 eval ${runcmd}
 ### -------------------------------------------------- ###


### PR DESCRIPTION
Motivation:
- superdroplet movement is very slow, partly due to use of unoptimised std::sort by kokkos. Better sorting algorithm could utilise property that superdroplets view is at least partially (mostly) sorted before sorting is called.
- adding superdroplets to the domain (e.g. by boundary conditions or movement via MPI) may require a resizing of the superdroplet view, but changing the superdroplet view address is currently very difficult because it is embedded in every gridbox.

Changes:
- New struct "SupersInDomain" handles entire superdroplets view on one node, e.g. returning location of superdroplets in domain (0<=sdgbxindex<number gridboxes on a node) and leaving buffer space for addition of new superdroplets. Struct also handles the sorting of the superdroplets via member functions. Future developments which resize view and/or change it's address are now easy.
- Minor changes e.g. better use of auto and kokkos element access via () not [] operator.