### PR TITLE
new sorting algorithm

### DIFF
--- a/libs/gridboxes/findrefs.hpp
+++ b/libs/gridboxes/findrefs.hpp
@@ -134,9 +134,9 @@ KOKKOS_INLINE_FUNCTION size_t makeref(const Iter start, const Iter iter) {
   return static_cast<size_t>(ref);
 }
 
-/* returns position in view of {first, last} superdrop that is in domain, where first is assumed to
-be at 0th position. Last is position of last superdrop with sdgbxindex < idx_max. Function valid
-in outermost level (outside) of parallelism. */
+/* returns position in view of {first, last} superdrop that is in domain. First is position of
+first superdrop with sdgbxindex >= gbxindex_range.first. Last is position of last superdrop with
+sdgbxindex <= gbxindex_range.second. Function valid in outermost level (outside) of parallelism. */
 template <typename ViewSupers>
 inline kkpair_size_t find_domainrefs(
     const ViewSupers totsupers, const Kokkos::pair<unsigned int, unsigned int> gbxindex_range) {
@@ -145,6 +145,17 @@ inline kkpair_size_t find_domainrefs(
   const auto ref1 = size_t{find_ref(totsupers, SRP::Ref1{gbxindex_range.second})};
 
   return {ref0, ref1};
+}
+
+/* returns position in view of {first, last} superdrop that is in domain, where first is assumed to
+be at 0th position. Last is position of last superdrop with sdgbxindex < gbxindex_max.
+Function valid in outermost level (outside) of parallelism. */
+template <typename ViewSupers>
+inline kkpair_size_t find_domainrefs(const ViewSupers totsupers, const unsigned int gbxindex_max) {
+  namespace SRP = SetRefPreds;
+  const auto ref1 = size_t{find_ref(totsupers, SRP::Ref1{gbxindex_max})};
+
+  return {0, ref1};
 }
 
 #endif  // LIBS_GRIDBOXES_FINDREFS_HPP_

--- a/libs/gridboxes/sortsupers.hpp
+++ b/libs/gridboxes/sortsupers.hpp
@@ -24,17 +24,10 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Sort.hpp>
 #include <Kokkos_StdAlgorithms.hpp>
+#include <cassert>
 
 #include "../kokkosaliases.hpp"
 #include "superdrops/superdrop.hpp"
-
-/* sort the "supers" view of superdroplets by the Comparator. Note that sorting of superdrops
-is not guarenteed to be stable (not guarenteed to maintain previous order of equal values). */
-template <class Comparator>
-inline viewd_supers sort_supers(const viewd_supers supers, const Comparator &comp) {
-  Kokkos::sort(ExecSpace(), supers, comp);
-  return supers;
-}
 
 /* returns true if superdrops in "supers" view are already sorted by the Comparator */
 template <class Comparator>
@@ -42,10 +35,37 @@ inline bool is_sorted_supers(const viewd_constsupers supers, const Comparator &c
   return Kokkos::Experimental::is_sorted("IsSupersSorted", ExecSpace(), supers, comp);
 }
 
+/* sort each gridbox's "supers" view by the Comparator. No sorting between the gridboxes,
+nor for out of bounds superdroplets. */
+template <class Comparator>
+inline void sort_supers_within_gbxs(const subviewd_supers domainsupers, const viewd_constgbx gbxs,
+                                    const Comparator &comp) {
+  const auto ngbxs = gbxs.extent(0);
+  Kokkos::parallel_for(
+      "sort_supers_in_gbxs", TeamPolicy(ngbxs, Kokkos::AUTO()),
+      KOKKOS_LAMBDA(const TeamMember &team_member) {
+        const auto ii = team_member.league_rank();
+        auto supers = gbxs(ii).supersingbx(domainsupers);
+        Kokkos::Experimental::sort_team(team_member, supers, comp);
+      });
+}
+
+/* Counting sort algorithm to (stable) sort superdroplets inside the domain by sdgbxindex.
+Gridbox indexes are assumed to run from 0 to gbxindex_max so that Superdroplets inside the
+domain have 0 <= sdgbxindex <= gbxindex_max. Superdroplets outside of the domain
+(i.e. sdgbxindex > gbxindex_max) are not guarenteed to be sorted. */
 struct SortSupersBySdgbxindex {
- private:
  public:
-  SortSupersBySdgbxindex() {}
+  size_t gbxindex_max;        /**< maximum gbxindex of in-domain superdroplets */
+  viewd_counts counts;        /**< number of superdroplets in each gridbox + outside of domain */
+  viewd_counts cumlcounts;    /**< cumulative version of counts */
+  viewd_supers totsupers_tmp; /**< temporary view of superdroplets used by sorting algorithm */
+
+  SortSupersBySdgbxindex(const size_t gbxindex_max_, const size_t ntotsupers)
+      : gbxindex_max(gbxindex_max_),
+        counts("counts", gbxindex_max + 1),
+        cumlcounts("cumlcounts", gbxindex_max + 1),
+        totsupers_tmp("totsupers_tmp", ntotsupers) {}
 
   /* a precedes b if its sdgbxindex is smaller */
   struct SortComparator {
@@ -55,16 +75,82 @@ struct SortSupersBySdgbxindex {
     }
   };
 
-  /* sort the "supers" view of superdroplets by their sdgbxindexes so that superdrops in the
-  view are ordered from lowest to highest sdgbxindex. Note that sorting of superdrops with matching
-  sdgbxindex is not guarenteed to maintain their previous order (unstable sorting) */
-  viewd_supers operator()(const viewd_supers supers) {
-    return sort_supers(supers, SortComparator{});
-  }
-
   /* returns true if superdrops in view are sorted by their sdgbxindexes in ascending order */
   bool is_sorted(const viewd_constsupers supers) const {
     return is_sorted_supers(supers, SortComparator{});
+  }
+
+  /* Returns position of superdroplet count in counts/cumlcounts views given its
+  sdgbxindex. For in-domain superdroplets (0 <=sdgbxindex <= gbxindex_max),
+  position in counts/cumlcounts views is at the value of sdgbxindex, e.g.
+  if sdgbxindex=4, then position=4. If superdroplet has sdgbxindex > gbxindex_max
+  its position is last position of counts/cumlcounts array, i.e. all superdroplets with
+  sdgbxindex > gbxindex_max are found at last=(counts.extent(0) - 1) position of
+  counts/cumlcounts array. */
+  KOKKOS_INLINE_FUNCTION
+  size_t get_count_position(const size_t sdgbxindex) const {
+    return !(sdgbxindex <= gbxindex_max) ? (counts.extent(0) - 1) : sdgbxindex;
+  }
+
+  /* counts number of superdroplets in each gbx with sdgbxindex <= gbxindex_max and all
+  superdroplets with sdgbxindex > gbxindex_max. E.g. if totsupers contains 5 supersdroplets
+  with sdgbxindex=0, then counts array at position 0 will be 5, meanwhile all counts of
+  superdroplets with sdgbxindex > gbxindex_max go into last position of counts array.
+  Returns cumulative sum from position 0 to last position.  */
+  viewd_counts create_cumlcounts(const viewd_constsupers totsupers) {
+    const auto ntotsupers = size_t{totsupers.extent(0)};
+    Kokkos::parallel_for(
+        "increment_counts", Kokkos::RangePolicy<ExecSpace>(0, ntotsupers),
+        KOKKOS_CLASS_LAMBDA(const size_t kk) {
+          auto pos = get_count_position(totsupers(kk).get_sdgbxindex());
+          Kokkos::atomic_inc(&counts(pos));  // counts(sdgbxindex)++ or counts([last])++;
+        });
+
+    Kokkos::Experimental::exclusive_scan("cumulative_sum", ExecSpace(), counts, cumlcounts, 0);
+    Kokkos::Experimental::fill(ExecSpace(), counts, 0);  // reset in preparation for next call
+
+    return cumlcounts;
+  }
+
+  viewd_supers counting_sort(const viewd_supers totsupers) {
+    const auto ntotsupers = size_t{totsupers.extent(0)};
+    Kokkos::parallel_for(
+        "counting_sort", Kokkos::RangePolicy<ExecSpace>(0, ntotsupers),
+        KOKKOS_CLASS_LAMBDA(const size_t kk) {
+          const auto pos = get_count_position(totsupers(kk).get_sdgbxindex());
+          auto new_kk = Kokkos::atomic_fetch_add(&cumlcounts(pos), 1);
+          totsupers_tmp(new_kk) = totsupers(kk);
+          totsupers(kk).set_sdgbxindex(LIMITVALUES::oob_gbxindex);  // fail-safe reset totsupers
+        });
+
+    /* assertion for debugging only works for hostspace cumlcounts */
+    // assert((cumlcounts(counts.extent(0) - 1) == totsupers_tmp.extent(0)) &&
+    //        "last cumulative sum of totsupers count should equal expected number of totsupers");
+
+    return totsupers_tmp;
+  }
+
+  /* Counting sort algorithm to (stable) sort superdroplets inside the domain by sdgbxindex.
+  Note that sorting of superdrops with matching sdgbxindex is not guarenteed to maintain their
+  previous order (possibly unstable sorting). */
+  viewd_supers operator()(const viewd_supers totsupers, const subviewd_supers domainsupers,
+                          const viewd_constgbx gbxs) {
+    sort_supers_within_gbxs(domainsupers, gbxs, SortComparator{});  // (optional)
+    const auto sorted_supers = (*this)(totsupers);
+    return sorted_supers;
+  }
+
+  /* Counting sort algorithm to (stable) sort superdroplets inside the domain by sdgbxindex.
+  Superdrops in totsupers may change (e.g. sdgbxindex may be set to LIMITVALUES::oob_gbxindex) and
+  returned view may not be the same totsupers view given as argument. Superdroplets outside of the
+  domain (i.e. sdgbxindex > gbxindex_max) are not guarenteed to be sorted. */
+  viewd_supers operator()(const viewd_supers totsupers) {
+    cumlcounts = create_cumlcounts(totsupers);
+    // TODO(CB): (optional) insert here the creation of a length of counts array and then use more
+    // efficient moving in counting_sort
+    const auto sorted_supers = counting_sort(totsupers);
+    totsupers_tmp = totsupers;  // fail-safe reset totsupers_tmp
+    return sorted_supers;
   }
 };
 

--- a/libs/gridboxes/supersindomain.hpp
+++ b/libs/gridboxes/supersindomain.hpp
@@ -52,9 +52,6 @@ struct SupersInDomain {
   }
 
  public:
-  SupersInDomain() = default;   // Kokkos requirement for a (dual)View
-  ~SupersInDomain() = default;  // Kokkos requirement for a (dual)View
-
   /* Assigns and sorts view for superdroplets, then identifies in-domain superdroplets.
   Gridbox indexes are assumed to start at 0, meaning superdroplets inside the domain are
   those with 0 <= sdgbxindex <= gbxindex_range.second (= gbxindex_max). */
@@ -62,9 +59,9 @@ struct SupersInDomain {
       : gbxindex_range({0, gbxindex_max}),
         totsupers(totsupers_),
         domainrefs({0, 0}),
-        sort_by_sdgbxindex(SortSupersBySdgbxindex()) {
-    totsupers = sort_by_sdgbxindex(totsupers_);
-    set_totsupers_domainrefs(totsupers_);
+        sort_by_sdgbxindex(SortSupersBySdgbxindex(gbxindex_range.second, totsupers.extent(0))) {
+    auto sorted_supers = sort_by_sdgbxindex(totsupers_);
+    set_totsupers_domainrefs(sorted_supers);
   }
 
   viewd_supers get_totsupers() const {
@@ -92,8 +89,8 @@ struct SupersInDomain {
   /* sort superdroplets by sdgbxindex and then (re-)set the totsupers view and the refs for the
   superdroplets that are within the domain (sdgbxindex within gbxindex_range for a given node) */
   viewd_supers sort_totsupers() {
-    auto totsupers_ = sort_by_sdgbxindex(totsupers);
-    set_totsupers_domainrefs(totsupers_);
+    auto sorted_supers = sort_by_sdgbxindex(totsupers);
+    set_totsupers_domainrefs(sorted_supers);
     return totsupers;
   }
 

--- a/libs/gridboxes/supersindomain.hpp
+++ b/libs/gridboxes/supersindomain.hpp
@@ -30,25 +30,34 @@
 #include "gridboxes/sortsupers.hpp"
 #include "superdrops/kokkosaliases_sd.hpp"
 
-/* References to identify the chunk of memory containing super-droplets occupying domain
-(i.e. within any of the gridboxes on a single node), e.g. through std::span or Kokkos::subview) */
+/* Struct which handles the references to identify the chunk of memory containing super-droplets
+occupying domain (i.e. within any of the gridboxes on a single node), e.g. through std::span or
+Kokkos::subview). Gridbox indexes are assumed to run from 0 to gbxindex_max so that Superdroplets
+inside the domain have 0 <= sdgbxindex <= gbxindex_max. Struct also contains menthods to sort
+and reassign the superdroplet view used to store superdroplets in the domain. */
 struct SupersInDomain {
  private:
   Kokkos::pair<unsigned int, unsigned int> gbxindex_range; /**< {min, max} gbxindex of domain */
-  viewd_supers totsupers; /**< view of all superdrops (both in and out of bounds of domain) */
-  kkpair_size_t
-      domainrefs; /**< position in view of (first, last) superdrop that occupies gridbox */
+  viewd_supers totsupers;   /**< view of all superdrops (both in and out of bounds of domain) */
+  kkpair_size_t domainrefs; /**< position in view of (first, last) superdrop that occupies domain */
   SortSupersBySdgbxindex sort_by_sdgbxindex; /**< method to sort view of superdrops by sdgbxindex */
 
+  /* Assign superdroplets view used to store superdroplets in the domain and update the domainrefs
+  for identifying the subview which contains in-domain superdroplets. Gridbox indexes are assumed
+  to start at 0, meaning superdroplets inside the domain are those with
+  0 <= sdgbxindex <= gbxindex_range.second (= gbxindex_max). */
   void set_totsupers_domainrefs(const viewd_supers totsupers_) {
     totsupers = totsupers_;
-    domainrefs = find_domainrefs(totsupers, gbxindex_range);
+    domainrefs = find_domainrefs(totsupers, gbxindex_range.second);
   }
 
  public:
   SupersInDomain() = default;   // Kokkos requirement for a (dual)View
   ~SupersInDomain() = default;  // Kokkos requirement for a (dual)View
 
+  /* Assigns and sorts view for superdroplets, then identifies in-domain superdroplets.
+  Gridbox indexes are assumed to start at 0, meaning superdroplets inside the domain are
+  those with 0 <= sdgbxindex <= gbxindex_range.second (= gbxindex_max). */
   explicit SupersInDomain(const viewd_supers totsupers_, const unsigned int gbxindex_max)
       : gbxindex_range({0, gbxindex_max}),
         totsupers(totsupers_),
@@ -62,13 +71,14 @@ struct SupersInDomain {
     return totsupers;
   }  // TODO(CB): replace with appending SDs func which could resize(?)
 
+  /* read-only means superdrops in the totsupers view are const */
   viewd_constsupers get_totsupers_readonly() const { return totsupers; }
 
-  /* returns the view of all the superdrops in the domain */
+  /* returns the view of all the superdrops in the domain (excluding out of bounds ones) */
   subviewd_supers domain_supers() const { return Kokkos::subview(totsupers, domainrefs); }
 
   /* returns the view of all the superdrops in the domain. read-only means superdrops in
-  the view are const */
+  the subview are const */
   subviewd_constsupers domain_supers_readonly() const {
     return Kokkos::subview(totsupers, domainrefs);
   }

--- a/libs/kokkosaliases.hpp
+++ b/libs/kokkosaliases.hpp
@@ -53,4 +53,7 @@ using kokkos_dblmaph = Kokkos::UnorderedMap<unsigned int, double, HostSpace>;
 using viewd_ndims = Kokkos::View<size_t[3]>;
 /**< View in device memory for number of gridboxes in CartesianMaps. */
 
+/* Sorting Superdrops */
+using viewd_counts = Kokkos::View<size_t *>; /**< View in device memory for sorting superdroplets */
+
 #endif  // LIBS_KOKKOSALIASES_HPP_


### PR DESCRIPTION
kokkos::sort (default std::sort) is too slow for sorting superdroplets. since superdroplets have known sorting range and are partially (mostly) sorted, preliminary results show counting sort has better performance for large numbers of superdroplets. This PR therefore replaces Kokkos::sort with a couting sort algorithm

Further performance optimisations could involve pre-sorting gridboxes and/or using kokkos::move to move contiguous lengths of superdroplet view (with match sggbxindexes) during sorting rather than individual superdroplets.