### PR TITLE
further optimiations of new sorting algorithm

### DIFF
--- a/libs/cartesiandomain/add_supers_at_domain_top.cpp
+++ b/libs/cartesiandomain/add_supers_at_domain_top.cpp
@@ -64,7 +64,7 @@ for (size_t ii(0); ii < d_gbxs.extent(0); ++ii){[...]}.
 */
 SupersInDomain move_supers_between_gridboxes_again(const viewd_gbx d_gbxs,
                                                    SupersInDomain &allsupers) {
-  allsupers.sort_totsupers();
+  allsupers.sort_totsupers(d_gbxs);
 
   const auto domainsupers = allsupers.domain_supers();
   const size_t ngbxs(d_gbxs.extent(0));

--- a/libs/gridboxes/findrefs.hpp
+++ b/libs/gridboxes/findrefs.hpp
@@ -158,8 +158,6 @@ Function valid in outermost level (outside) of parallelism default implementatio
 template <typename ViewSupers>
 inline kkpair_size_t find_domainrefs(const Kokkos::HostSpace &ex, const ViewSupers totsupers,
                                      const unsigned int gbxindex_max) {
-  Kokkos::Profiling::ScopedRegion region("find_domainrefs_default_func");
-
   namespace SRP = SetRefPreds;
   const auto ref1 = size_t{find_ref(totsupers, SRP::Ref1{gbxindex_max})};
 
@@ -172,16 +170,12 @@ Function valid in outermost level (outside) of parallelism valid for CUDA device
 template <class ExecutionSpace, typename ViewSupers>
 inline kkpair_size_t find_domainrefs(const ExecutionSpace &ex, const ViewSupers totsupers,
                                      const unsigned int gbxindex_max) {
-  Kokkos::Profiling::ScopedRegion region("find_domainrefs_cuda_func");
-
   namespace SRP = SetRefPreds;
-
   auto ref1 = Kokkos::View<size_t[1]>("domainref1");
   Kokkos::parallel_for(
       "find_domainrefs_cuda", 1, KOKKOS_LAMBDA(const int i) {
         ref1(0) = size_t{find_ref(totsupers, SRP::Ref1{gbxindex_max})};
       });
-
   auto h_ref1 = Kokkos::create_mirror_view_and_copy(HostSpace(), ref1);
 
   return {0, h_ref1(0)};

--- a/libs/gridboxes/findrefs.hpp
+++ b/libs/gridboxes/findrefs.hpp
@@ -77,20 +77,23 @@ KOKKOS_INLINE_FUNCTION kkpair_size_t find_refs(const TeamMemberType &team_member
 }
 
 /* returns distance from begining of totsupers view to the superdroplet that is first to fail
-to satisfy given Predicate "pred". Function is outermost level of parallelism. */
+to satisfy given Predicate "pred". Function is outermost level of parallelism. Parallel equivalent
+is experimental and appears to be slower (!):
+```
+namespace KE = Kokkos::Experimental;
+const auto iter = KE::partition_point("find_ref", ExecSpace(), totsupers, pred);
+return makeref(KE::begin(totsupers), iter);
+```
+*/
 template <typename Pred, typename ViewSupers>
 inline size_t find_ref(const ViewSupers totsupers, const Pred pred) {
-  namespace KE = Kokkos::Experimental;
-
-  /* iterator to first superdrop in totsupers that fails to satisfy pred */
-  const auto iter = KE::partition_point("find_ref", ExecSpace(), totsupers, pred);
-  return makeref(KE::begin(totsupers), iter);
+  return find_partition_point(totsupers, pred, 0, totsupers.extent(0));
 }
 
 /* returns element access index from begining of totsupers view to the superdroplet that
 is first to fail to satisfy given Predicate "pred". Function is 2nd level of nested parallelism,
 i.e. is thread parallelism within a league for a given team_member. Parallel equivalent
-is experimental (!):
+is experimental and appears to be slower (!):
 ```
 namespace KE = Kokkos::Experimental;
 const auto start = KE::begin(totsupers);

--- a/libs/gridboxes/movesupersindomain.hpp
+++ b/libs/gridboxes/movesupersindomain.hpp
@@ -195,7 +195,7 @@ struct MoveSupersInDomain {
 
     set_gridboxes_refs(d_gbxs, allsupers.domain_supers());
 
-    // /* optional (expensive!) test if superdrops' gbxindex doesn't match gridbox's gbxindex */
+    /* optional (expensive!) test if superdrops' gbxindex doesn't match gridbox's gbxindex */
     // check_sdgbxindex_during_motion(d_gbxs, allsupers.get_totsupers_readonly());
 
     return allsupers;

--- a/libs/gridboxes/movesupersindomain.hpp
+++ b/libs/gridboxes/movesupersindomain.hpp
@@ -24,6 +24,7 @@
 #define LIBS_GRIDBOXES_MOVESUPERSINDOMAIN_HPP_
 
 #include <Kokkos_Core.hpp>
+#include <Kokkos_Profiling_ScopedRegion.hpp>
 #include <cassert>
 #include <concepts>
 #include <cstdint>
@@ -94,8 +95,9 @@ struct MoveSupersInDomain {
     when in serial */
     void move_supers_in_gridboxes(const GbxMaps &gbxmaps, const viewd_gbx d_gbxs,
                                   const subviewd_supers domainsupers) const {
-      const size_t ngbxs(d_gbxs.extent(0));
+      Kokkos::Profiling::ScopedRegion region("sdm_movement_move_in_gridboxes");
 
+      const size_t ngbxs(d_gbxs.extent(0));
       Kokkos::parallel_for(
           "move_supers_in_gridboxes", TeamPolicy(ngbxs, Kokkos::AUTO()),
           KOKKOS_CLASS_LAMBDA(const TeamMember &team_member) {
@@ -118,7 +120,7 @@ struct MoveSupersInDomain {
   void set_gridboxes_refs(const viewd_gbx d_gbxs, const subviewd_constsupers domainsupers) const {
     const auto ngbxs = d_gbxs.extent(0);
     Kokkos::parallel_for(
-        "move_supers_between_gridboxes", TeamPolicy(ngbxs, Kokkos::AUTO()),
+        "set_gridboxes_refs", TeamPolicy(ngbxs, Kokkos::AUTO()),
         KOKKOS_LAMBDA(const TeamMember &team_member) {
           const auto ii = team_member.league_rank();
           d_gbxs(ii).supersingbx.set_refs(team_member, domainsupers);
@@ -180,6 +182,8 @@ struct MoveSupersInDomain {
   */
   SupersInDomain move_supers_between_gridboxes(const GbxMaps &gbxmaps, const viewd_gbx d_gbxs,
                                                SupersInDomain &allsupers) const {
+    Kokkos::Profiling::ScopedRegion region("sdm_movement_between_gridboxes");
+
     int comm_size;
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
 
@@ -221,7 +225,9 @@ struct MoveSupersInDomain {
     allsupers = move_supers_between_gridboxes(gbxmaps, d_gbxs, allsupers);
 
     /* step (4) */
+    Kokkos::Profiling::pushRegion("sdm_movement_boundary_conditions");
     allsupers = apply_domain_boundary_conditions(gbxmaps, d_gbxs, allsupers);
+    Kokkos::Profiling::popRegion();
 
     return allsupers;
   }

--- a/libs/gridboxes/movesupersindomain.hpp
+++ b/libs/gridboxes/movesupersindomain.hpp
@@ -186,11 +186,11 @@ struct MoveSupersInDomain {
     // TODO(ALL): remove guard once domain decomposition is GPU compatible
     if (comm_size > 1) {
       // TODO(ALL): combine two sorts into one(?)
-      auto totsupers = allsupers.sort_totsupers_without_set();
+      auto totsupers = allsupers.sort_totsupers_without_set(d_gbxs);
       totsupers = sendrecv_supers(gbxmaps, d_gbxs, totsupers);
-      allsupers.sort_and_set_totsupers(totsupers);
+      allsupers.sort_and_set_totsupers(totsupers, d_gbxs);
     } else {
-      allsupers.sort_totsupers();
+      allsupers.sort_totsupers(d_gbxs);
     }
 
     set_gridboxes_refs(d_gbxs, allsupers.domain_supers());

--- a/libs/gridboxes/supersindomain.hpp
+++ b/libs/gridboxes/supersindomain.hpp
@@ -48,7 +48,7 @@ struct SupersInDomain {
   0 <= sdgbxindex <= gbxindex_range.second (= gbxindex_max). */
   void set_totsupers_domainrefs(const viewd_supers totsupers_) {
     totsupers = totsupers_;
-    domainrefs = find_domainrefs(totsupers, gbxindex_range.second);
+    domainrefs = find_domainrefs(ExecSpace(), totsupers, gbxindex_range.second);
   }
 
  public:

--- a/libs/gridboxes/supersindomain.hpp
+++ b/libs/gridboxes/supersindomain.hpp
@@ -89,8 +89,6 @@ struct SupersInDomain {
   /* sort superdroplets by sdgbxindex and then (re-)set the totsupers view and the refs for the
   superdroplets that are within the domain (sdgbxindex within gbxindex_range for a given node) */
   viewd_supers sort_totsupers(const viewd_constgbx d_gbxs) {
-    Kokkos::Profiling::ScopedRegion region("supers_in_domain_sort_totsupers");
-
     auto sorted_supers = sort_by_sdgbxindex(totsupers, d_gbxs, domainrefs);
     set_totsupers_domainrefs(sorted_supers);
     return totsupers;
@@ -101,8 +99,6 @@ struct SupersInDomain {
   nor the refs for the superdroplets that are within the domain. This means 'totsupers' may change,
   returned view may no longer be 'totsupers' and the domainrefs may be invalid. */
   viewd_supers sort_totsupers_without_set(const viewd_constgbx d_gbxs) {
-    Kokkos::Profiling::ScopedRegion region("supers_in_domain_sort_without_set");
-
     return sort_by_sdgbxindex(totsupers, d_gbxs, domainrefs);
   }
 
@@ -110,8 +106,6 @@ struct SupersInDomain {
   superdroplets by sdgbxindex with possible (re-)setting of the totsupers view and the refs for the
   superdroplets that are within the domain (sdgbxindex within gbxindex_range for a given node) */
   viewd_supers sort_and_set_totsupers(const viewd_supers totsupers_, const viewd_constgbx d_gbxs) {
-    Kokkos::Profiling::ScopedRegion region("supers_in_domain_sort_and_set");
-
     totsupers = totsupers_;
     return sort_totsupers(d_gbxs);
   }

--- a/libs/gridboxes/supersindomain.hpp
+++ b/libs/gridboxes/supersindomain.hpp
@@ -88,8 +88,10 @@ struct SupersInDomain {
 
   /* sort superdroplets by sdgbxindex and then (re-)set the totsupers view and the refs for the
   superdroplets that are within the domain (sdgbxindex within gbxindex_range for a given node) */
-  viewd_supers sort_totsupers() {
-    auto sorted_supers = sort_by_sdgbxindex(totsupers);
+  viewd_supers sort_totsupers(const viewd_constgbx d_gbxs) {
+    Kokkos::Profiling::ScopedRegion region("supers_in_domain_sort_totsupers");
+
+    auto sorted_supers = sort_by_sdgbxindex(totsupers, d_gbxs, domainrefs);
     set_totsupers_domainrefs(sorted_supers);
     return totsupers;
   }
@@ -98,14 +100,20 @@ struct SupersInDomain {
   intermediate state. Function sorts superdroplets by sdgbxindex but does not set the supers view
   nor the refs for the superdroplets that are within the domain. This means 'totsupers' may change,
   returned view may no longer be 'totsupers' and the domainrefs may be invalid. */
-  viewd_supers sort_totsupers_without_set() { return sort_by_sdgbxindex(totsupers); }
+  viewd_supers sort_totsupers_without_set(const viewd_constgbx d_gbxs) {
+    Kokkos::Profiling::ScopedRegion region("supers_in_domain_sort_without_set");
+
+    return sort_by_sdgbxindex(totsupers, d_gbxs, domainrefs);
+  }
 
   /* Only use if you know what you're doing(!) Assigns totsupers to given view and then sorts
   superdroplets by sdgbxindex with possible (re-)setting of the totsupers view and the refs for the
   superdroplets that are within the domain (sdgbxindex within gbxindex_range for a given node) */
-  viewd_supers sort_and_set_totsupers(const viewd_supers totsupers_) {
+  viewd_supers sort_and_set_totsupers(const viewd_supers totsupers_, const viewd_constgbx d_gbxs) {
+    Kokkos::Profiling::ScopedRegion region("supers_in_domain_sort_and_set");
+
     totsupers = totsupers_;
-    return sort_totsupers();
+    return sort_totsupers(d_gbxs);
   }
 };
 

--- a/libs/kokkosaliases.hpp
+++ b/libs/kokkosaliases.hpp
@@ -26,6 +26,7 @@
 #include <Kokkos_DualView.hpp>
 #include <Kokkos_Pair.hpp>
 #include <Kokkos_Random.hpp>
+#include <Kokkos_ScatterView.hpp>
 #include <Kokkos_UnorderedMap.hpp>
 #include <memory>
 
@@ -55,5 +56,7 @@ using viewd_ndims = Kokkos::View<size_t[3]>;
 
 /* Sorting Superdrops */
 using viewd_counts = Kokkos::View<size_t *>; /**< View in device memory for sorting superdroplets */
+/**< Scatter view for abstracted use of atomics/duplicates when computing sums for viewd_counts */
+using scatterviewd_counts = Kokkos::Experimental::ScatterView<size_t *>;
 
 #endif  // LIBS_KOKKOSALIASES_HPP_


### PR DESCRIPTION
- use faster partition point algorithm in finding domain refs
- use scatterview instead of only atomics in cumulative counts parallelisation
- parallelise over gxbs to reduce number of atomic conflicts in superdroplet copying

+ attempt to parallelise over gxbs using counts for cumlcounts calculation failed in GPU compatiblity and so is redacted.