### PR TITLE
refactor fromfile example and kokkos team size

### DIFF
--- a/examples/fromfile/fromfile.sh
+++ b/examples/fromfile/fromfile.sh
@@ -2,8 +2,8 @@
 #SBATCH --job-name=fromfile
 #SBATCH --partition=compute
 #SBATCH --nodes=1
-#SBATCH --ntasks-per-node=32
-#SBATCH --cpus-per-task=8
+#SBATCH --ntasks-per-node=4
+#SBATCH --cpus-per-task=16
 #SBATCH --mem=10G
 #SBATCH --time=00:05:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
@@ -26,7 +26,7 @@ executables="fromfile"
 
 pythonscript=${path2CLEO}/examples/fromfile/fromfile.py
 configfile=${path2CLEO}/examples/fromfile/src/config/fromfile_config.yaml
-script_args="${configfile} --do_inputfiles=TRUE --do_run_executable=TRUE --do_plot_results=TRUE"
+script_args="${configfile} --do_inputfiles=TRUE --do_run_executable=TRUE --do_plot_results=TRUE --ntasks=4"
 ### ---------------------------------------------------- ###
 ### ---------------------------------------------------- ###
 ### ---------------------------------------------------- ###

--- a/examples/fromfile/fromfile_inputfiles.py
+++ b/examples/fromfile/fromfile_inputfiles.py
@@ -26,10 +26,12 @@ import sys
 def main(
     path2CLEO,
     path2build,
+    savefigpath,
     config_filename,
     grid_filename,
     initsupers_filename,
     thermofiles,
+    isfigures=[True, True],  # booleans for [making, saving] initialisation figures
 ):
     import numpy as np
 
@@ -51,11 +53,6 @@ def main(
     ### --- essential paths and filenames --- ###
     # path and filenames for creating initial SD conditions
     constants_filename = path2CLEO / "libs" / "cleoconstants.hpp"
-
-    ### --- plotting initialisation figures --- ###
-    # booleans for [making, saving] initialisation figures
-    isfigures = [True, True]  # TODO(CB): move into args
-    savefigpath = path2build / "bin"  # binpath # TODO(CB): move into args
 
     ### --- settings for 3-D gridbox boundaries --- ###
     zgrid = [0, 1500, 60]  # evenly spaced zhalf coords [zmin, zmax, zdelta] [m]
@@ -145,5 +142,6 @@ def main(
 
 
 if __name__ == "__main__":
-    ### args = path2CLEO, path2build, config_filename, grid_filename, initsupers_filename, thermofiles
+    ### args = path2CLEO, path2build, savefigpath, config_filename,
+    #               grid_filename, initsupers_filename, thermofiles, isfigures
     main(*sys.argv[1:])

--- a/examples/fromfile/src/config/fromfile_config.yaml
+++ b/examples/fromfile/src/config/fromfile_config.yaml
@@ -47,8 +47,8 @@ initsupers:
 
 ### Output Parameters ###
 outputdata:
-  setup_filename : ./bin/fromfile_setup.txt                   # .txt filename to copy configuration to
-  zarrbasedir : ./bin/fromfile_sol.zarr                       # zarr store base directory
+  setup_filename : ./bin/ntasks4/fromfile_setup.txt                   # .txt filename to copy configuration to
+  zarrbasedir : ./bin/ntasks4/fromfile_sol.zarr                       # zarr store base directory
   maxchunk : 2500000                                      # maximum no. of elements in chunks of zarr store array
 
 ### Coupled Dynamics Parameters ###

--- a/examples/fromfile/src/config/fromfile_config.yaml
+++ b/examples/fromfile/src/config/fromfile_config.yaml
@@ -22,6 +22,10 @@
 # and so can the thermodynamics files when using coupled thermodynamics "fromfile".
 #
 
+### Kokkos Initialization Parameters ###
+kokkos_settings:
+  num_threads: 16                                          # number of threads for host parallel backend
+
 ### SDM Runtime Parameters ###
 domain:
   nspacedims : 3                                          # no. of spatial dimensions to model

--- a/libs/cartesiandomain/add_supers_at_domain_top.cpp
+++ b/libs/cartesiandomain/add_supers_at_domain_top.cpp
@@ -69,7 +69,7 @@ SupersInDomain move_supers_between_gridboxes_again(const viewd_gbx d_gbxs,
   const auto domainsupers = allsupers.domain_supers();
   const size_t ngbxs(d_gbxs.extent(0));
   Kokkos::parallel_for(
-      "move_supers_between_gridboxes_again", TeamPolicy(ngbxs, Kokkos::AUTO()),
+      "move_supers_between_gridboxes_again", TeamPolicy(ngbxs, KCS::team_size),
       KOKKOS_LAMBDA(const TeamMember &team_member) {
         const auto ii = team_member.league_rank();
         d_gbxs(ii).supersingbx.set_refs(team_member, domainsupers);

--- a/libs/cartesiandomain/add_supers_at_domain_top.hpp
+++ b/libs/cartesiandomain/add_supers_at_domain_top.hpp
@@ -44,6 +44,8 @@
 #include "initialise/optional_config_params.hpp"
 #include "superdrops/superdrop.hpp"
 
+namespace KCS = KokkosCleoSettings;
+
 struct LognormalDistribution {
   double numconc; /**< number concentration of new droplets */
   double geomean; /**< geometric mean of lognormal distribution */

--- a/libs/gridboxes/movesupersindomain.hpp
+++ b/libs/gridboxes/movesupersindomain.hpp
@@ -41,6 +41,8 @@
 #include "superdrops/sdmmonitor.hpp"
 #include "superdrops/superdrop.hpp"
 
+namespace KCS = KokkosCleoSettings;
+
 /*
 function to move super-droplets between MPI processes, e.g. for superdroplets
 which move to/from gridboxes on different nodes.
@@ -99,7 +101,7 @@ struct MoveSupersInDomain {
 
       const size_t ngbxs(d_gbxs.extent(0));
       Kokkos::parallel_for(
-          "move_supers_in_gridboxes", TeamPolicy(ngbxs, Kokkos::AUTO()),
+          "move_supers_in_gridboxes", TeamPolicy(ngbxs,  KCS::team_size),
           KOKKOS_CLASS_LAMBDA(const TeamMember &team_member) {
             const auto ii = team_member.league_rank();
 

--- a/libs/gridboxes/sortsupers.hpp
+++ b/libs/gridboxes/sortsupers.hpp
@@ -29,6 +29,8 @@
 #include "../kokkosaliases.hpp"
 #include "superdrops/superdrop.hpp"
 
+namespace KCS = KokkosCleoSettings;
+
 /* returns true if superdrops in "supers" view are already sorted by the Comparator */
 template <class Comparator>
 inline bool is_sorted_supers(const viewd_constsupers supers, const Comparator &comp) {
@@ -165,7 +167,7 @@ struct SortSupersBySdgbxindex {
                              const subviewd_supers oob_supers) {
     const auto ngbxs = size_t{d_gbxs.extent(0)};
     Kokkos::parallel_for(
-        "counting_sort_gbxs", TeamPolicy(ngbxs, Kokkos::AUTO()),
+        "counting_sort_gbxs", TeamPolicy(ngbxs, KCS::team_size),
         KOKKOS_CLASS_LAMBDA(const TeamMember &team_member) {
           const auto ii = team_member.league_rank();
           auto supers = d_gbxs(ii).supersingbx(domainsupers);

--- a/libs/kokkosaliases.hpp
+++ b/libs/kokkosaliases.hpp
@@ -59,4 +59,9 @@ using viewd_counts = Kokkos::View<size_t *>; /**< View in device memory for sort
 /**< Scatter view for abstracted use of atomics/duplicates when computing sums for viewd_counts */
 using scatterviewd_counts = Kokkos::Experimental::ScatterView<size_t *>;
 
+namespace KokkosCleoSettings {
+constexpr auto team_size = Kokkos::AUTO();
+/**< configurable number threads per team for hierarchical parallelism over superdroplets */
+}  // namespace KokkosCleoSettings
+
 #endif  // LIBS_KOKKOSALIASES_HPP_

--- a/libs/observers/parallel_write_data.hpp
+++ b/libs/observers/parallel_write_data.hpp
@@ -29,6 +29,8 @@
 #include "../kokkosaliases.hpp"
 #include "zarr/collective_dataset.hpp"
 
+namespace KCS = KokkosCleoSettings;
+
 /**
  * @brief Struct for a function-like object with operator() to call when using type as
  * parallel_gridboxes_func object in ParallelWriteGridboxes.
@@ -82,7 +84,7 @@ struct ParallelGridboxesTeamPolicyFunc {
   template <typename Functor>
   void operator()(const Functor functor, const viewd_constgbx d_gbxs) const {
     const size_t ngbxs(d_gbxs.extent(0));
-    Kokkos::parallel_for("write_gridboxes_team", TeamPolicy(ngbxs, Kokkos::AUTO()), functor);
+    Kokkos::parallel_for("write_gridboxes_team", TeamPolicy(ngbxs, KCS::team_size), functor);
   }
 };
 

--- a/libs/observers/sdmmonitor/monitor_massmoments.hpp
+++ b/libs/observers/sdmmonitor/monitor_massmoments.hpp
@@ -33,6 +33,8 @@
 #include "observers/massmoments_observer.hpp"
 #include "zarr/buffer.hpp"
 
+namespace KCS = KokkosCleoSettings;
+
 struct MonitorMassMomentViews {
   Buffer<uint64_t>::mirrorviewd_buffer d_mom0;  // view on device for monitoring 0th mass moment
   Buffer<float>::mirrorviewd_buffer d_mom1;     // view on device for monitoring 1st mass moment
@@ -171,7 +173,7 @@ struct MonitorMassMoments {
   void monitor_motion(const viewd_constgbx d_gbxs, const subviewd_constsupers domainsupers) const {
     const size_t ngbxs(d_gbxs.extent(0));
     Kokkos::parallel_for(
-        "monitor_motion", TeamPolicy(ngbxs, Kokkos::AUTO()),
+        "monitor_motion", TeamPolicy(ngbxs, KCS::team_size),
         KOKKOS_CLASS_LAMBDA(const TeamMember& team_member) {
           const auto ii = team_member.league_rank();
           const auto supers = d_gbxs(ii).supersingbx.readonly(domainsupers);

--- a/libs/runcleo/sdmmethods.hpp
+++ b/libs/runcleo/sdmmethods.hpp
@@ -39,6 +39,8 @@
 #include "superdrops/sdmmonitor.hpp"
 #include "superdrops/superdrop.hpp"
 
+namespace KCS = KokkosCleoSettings;
+
 /**
  * @class SDMMethods
  * @brief Struct wrapping the core ingredients of the Super-droplet Model (SDM) part of CLEO.
@@ -145,7 +147,7 @@ class SDMMethods {
       // TODO(all) use scratch space for parallel region
       const size_t ngbxs(d_gbxs.extent(0));
       Kokkos::parallel_for(
-          "sdm_microphysics", TeamPolicy(ngbxs, Kokkos::AUTO()),
+          "sdm_microphysics", TeamPolicy(ngbxs, KCS::team_size),
           KOKKOS_CLASS_LAMBDA(const TeamMember &team_member) {
             const auto ii = team_member.league_rank();
 


### PR DESCRIPTION
- refactor fromfile example to make running different threads easier
- move use of Kokkos::AUTO() in hierarchal paralleism for superdroplets into new namespace "KokkosCleoSettings" so it can be more easily changed at compile time if desired