### PR TITLE
tidy up kokkos configuration parameters

### DIFF
--- a/docs/source/cxx/superdrops/collisions/collisionsmod.rst
+++ b/docs/source/cxx/superdrops/collisions/collisionsmod.rst
@@ -18,3 +18,5 @@ modeling rebound and/or breakup as well as coalescence.
    collisionkinetics
    coalescence
    coalbure
+   shuffle
+   urbg

--- a/docs/source/cxx/superdrops/collisions/shuffle.rst
+++ b/docs/source/cxx/superdrops/collisions/shuffle.rst
@@ -1,0 +1,12 @@
+Thread-Safe Superdroplet Shuffling Algorithms
+=============================================
+
+Header file: ``<libs/superdrops/collisions/shuffle.hpp>``
+`[source] <https://github.com/yoctoyotta1024/CLEO/blob/main/libs/superdrops/collisions/shuffle.hpp>`_
+
+.. doxygenstruct:: FisherYatesShuffle
+   :project: superdrops
+   :private-members:
+   :protected-members:
+   :members:
+   :undoc-members:

--- a/docs/source/cxx/superdrops/collisions/urbg.rst
+++ b/docs/source/cxx/superdrops/collisions/urbg.rst
@@ -10,12 +10,3 @@ Header file: ``<libs/superdrops/collisions/urbg.hpp>``
    :protected-members:
    :members:
    :undoc-members:
-
-.. doxygenfunction:: device_swap
-   :project: superdrops
-
-.. doxygenfunction:: shuffle_supers
-   :project: superdrops
-
-.. doxygenfunction:: one_shuffle_supers
-   :project: superdrops

--- a/docs/source/cxx/superdrops/superdropsmod.rst
+++ b/docs/source/cxx/superdrops/superdropsmod.rst
@@ -26,4 +26,3 @@ and collision-coalescence.
    superdrop_attrs
    terminalvelocity
    thermodynamic_equations
-   urbg

--- a/docs/source/cxx/superdrops/urbg.rst
+++ b/docs/source/cxx/superdrops/urbg.rst
@@ -1,8 +1,8 @@
 Randomness Generation
 =====================
 
-Header file: ``<libs/superdrops/urbg.hpp>``
-`[source] <https://github.com/yoctoyotta1024/CLEO/blob/main/libs/superdrops/urbg.hpp>`_
+Header file: ``<libs/superdrops/collisions/urbg.hpp>``
+`[source] <https://github.com/yoctoyotta1024/CLEO/blob/main/libs/superdrops/collisions/urbg.hpp>`_
 
 .. doxygenstruct:: URBG
    :project: superdrops

--- a/libs/gridboxes/movesupersindomain.hpp
+++ b/libs/gridboxes/movesupersindomain.hpp
@@ -106,7 +106,7 @@ class MoveSupersInDomain {
                                       const viewd_constsupers totsupers) const {
     const auto ngbxs = d_gbxs.extent(0);
     Kokkos::parallel_for(
-        "check_sdgbxindex_during_motion", TeamPolicy(ngbxs, Kokkos::AUTO()),
+        "check_sdgbxindex_during_motion", TeamPolicy(ngbxs, KCS::team_size),
         KOKKOS_LAMBDA(const TeamMember &team_member) {
           const auto ii = team_member.league_rank();
           assert(d_gbxs(ii).supersingbx.iscorrect(team_member, totsupers) &&

--- a/libs/initialise/config.hpp
+++ b/libs/initialise/config.hpp
@@ -79,7 +79,7 @@ struct Config {
   RequiredConfigParams::TimestepsParams get_timesteps() const { return required.timesteps; }
 
   Kokkos::InitializationSettings get_kokkos_initialization_settings() const {
-    return optional.kokkos_settings;
+    return optional.kokkos_settings.kokkos_initialization_settings;
   };
 
   OptionalConfigParams::CondensationParams get_condensation() const {

--- a/libs/initialise/optional_config_params.cpp
+++ b/libs/initialise/optional_config_params.cpp
@@ -51,32 +51,35 @@ void OptionalConfigParams::set_kokkos_settings(const YAML::Node &config) {
   const YAML::Node node = config["kokkos_settings"];
 
   if (node["num_threads"]) {
-    kokkos_settings.set_num_threads(node["num_threads"].as<int>());
-    is_default_kokkos_settings = false;
+    kokkos_settings.kokkos_initialization_settings.set_num_threads(node["num_threads"].as<int>());
+    kokkos_settings.is_default = false;
   }
 
   if (node["device_id"]) {
-    kokkos_settings.set_device_id(node["device_id"].as<int>());
-    is_default_kokkos_settings = false;
+    kokkos_settings.kokkos_initialization_settings.set_device_id(node["device_id"].as<int>());
+    kokkos_settings.is_default = false;
   }
 
   if (node["map_device_id_by"]) {
-    kokkos_settings.set_map_device_id_by(node["map_device_id_by"].as<std::string>());
-    is_default_kokkos_settings = false;
+    kokkos_settings.kokkos_initialization_settings.set_map_device_id_by(
+        node["map_device_id_by"].as<std::string>());
+    kokkos_settings.is_default = false;
   }
 }
 
 void OptionalConfigParams::print_kokkos_settings() const {
   std::cout << "\n-------- Kokkos Configuration Parameters --------------"
-            << "\nusing default kokkos settings (bool): " << is_default_kokkos_settings;
-  if (kokkos_settings.has_num_threads()) {
-    std::cout << "\nnum_threads: " << kokkos_settings.get_num_threads();
+            << "\nusing default kokkos settings (bool): " << kokkos_settings.is_default;
+  if (kokkos_settings.kokkos_initialization_settings.has_num_threads()) {
+    std::cout << "\nnum_threads: "
+              << kokkos_settings.kokkos_initialization_settings.get_num_threads();
   }
-  if (kokkos_settings.has_device_id()) {
-    std::cout << "\ndevice_id: " << kokkos_settings.get_device_id();
+  if (kokkos_settings.kokkos_initialization_settings.has_device_id()) {
+    std::cout << "\ndevice_id: " << kokkos_settings.kokkos_initialization_settings.get_device_id();
   }
-  if (kokkos_settings.has_map_device_id_by()) {
-    std::cout << "\nmap_device_id_by: " << kokkos_settings.get_map_device_id_by();
+  if (kokkos_settings.kokkos_initialization_settings.has_map_device_id_by()) {
+    std::cout << "\nmap_device_id_by: "
+              << kokkos_settings.kokkos_initialization_settings.get_map_device_id_by();
   }
   std::cout << "\n---------------------------------------------------------\n";
 }

--- a/libs/initialise/optional_config_params.hpp
+++ b/libs/initialise/optional_config_params.hpp
@@ -62,8 +62,10 @@ struct OptionalConfigParams {
   void set_boundary_conditions(const YAML::Node& config);
 
   /*** Kokkos Initialization Parameters ***/
-  bool is_default_kokkos_settings = true;         /**< true = default kokkos initialization */
-  Kokkos::InitializationSettings kokkos_settings; /**< is default unless config */
+  struct KokkosSettings {
+    bool is_default = true; /**< true = default kokkos initialization */
+    Kokkos::InitializationSettings kokkos_initialization_settings; /**< is default unless config */
+  } kokkos_settings;
 
   /*** Super-Droplet Microphysics Parameters ***/
   struct CondensationParams {

--- a/libs/runcleo/creategbxs.cpp
+++ b/libs/runcleo/creategbxs.cpp
@@ -47,7 +47,7 @@ void is_gbxinit_complete(const size_t ngbxs_from_maps, dualview_gbx gbxs,
 
   const auto d_gbxs = gbxs.view_device();
   Kokkos::parallel_for(
-      "is_gbxinit_complete", TeamPolicy(ngbxs, Kokkos::AUTO()),
+      "is_gbxinit_complete", TeamPolicy(ngbxs, KCS::team_size),
       KOKKOS_LAMBDA(const TeamMember &team_member) {
         const auto ii = team_member.league_rank();
         assert(d_gbxs(ii).supersingbx.iscorrect(team_member, totsupers) &&

--- a/libs/runcleo/creategbxs.hpp
+++ b/libs/runcleo/creategbxs.hpp
@@ -44,6 +44,8 @@
 #include "superdrops/state.hpp"
 #include "superdrops/superdrop.hpp"
 
+namespace KCS = KokkosCleoSettings;
+
 /**
  * @brief A generator for initial Gridboxes.
  *

--- a/libs/superdrops/collisions/CMakeLists.txt
+++ b/libs/superdrops/collisions/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIB_BINARY_DIR ${CMAKE_BINARY_DIR}/lib)
 
 # Add executables and create library target
 set(SOURCES
+  "shuffle.cpp"
   "coalbure_flag.cpp"
   "coalescence.cpp"
   "collisionkinetics.cpp"

--- a/libs/superdrops/collisions/collisions.hpp
+++ b/libs/superdrops/collisions/collisions.hpp
@@ -189,7 +189,7 @@ struct DoCollisions {
    *
    * Function uses Kokkos nested parallelism for paralelism over supers inside parallelised loop
    * for member 'teamMember'.
-   * In serial Kokkos::parallel_reduce([...]) is equivalent to summing numnull over for loop:
+   * In serial Kokkos::parallel_for([...]) is equivalent to loop:
    * for (size_t jj(0); jj < npairs; ++jj) {[...]}.
    *
    * _NOTE:_ function assumes supers is already randomly shuffled and these superdrops are

--- a/libs/superdrops/collisions/collisions.hpp
+++ b/libs/superdrops/collisions/collisions.hpp
@@ -32,7 +32,7 @@
 #include "../sdmmonitor.hpp"
 #include "../state.hpp"
 #include "../superdrop.hpp"
-#include "../urbg.hpp"
+#include "./shuffle.hpp"
 
 namespace dlc = dimless_constants;
 
@@ -230,7 +230,7 @@ struct DoCollisions {
                                             const double volume) const {
     /* Randomly shuffle order of superdroplet objects
     in supers in order to generate random pairs */
-    supers = one_shuffle_supers(team_member, supers, genpool);
+    supers = shuffle_supers(team_member, supers, genpool);
 
     /* collide all randomly generated pairs of SDs */
     collide_supers(team_member, supers, volume);

--- a/libs/superdrops/collisions/shuffle.cpp
+++ b/libs/superdrops/collisions/shuffle.cpp
@@ -15,35 +15,94 @@
  * https://opensource.org/licenses/BSD-3-Clause
  * -----
  * File Description:
- * Implementaiton file for functions for Kokkos compatibile thread-safe versions of C++
- * Fisher-Yates serial shuffling algorithm, and of MergeShuffle parallelsised shuffling
- * algorithm. MergeShuffle comes from "A Very Fast, Parallel Random Permutation Algorithm",
- * Axel Bacher, Olivier Bodini, Alexandros Hollender, and Jérémie Lumbroso, August 14, 2015.
- * See also their code repository: https://github.com/axel-bacher/mergeshuffle)
+ * Implementaiton file for functions for Kokkos compatibile thread-safe versions
+ * of C++ Fisher-Yates serial shuffling algorithm, and of MergeShuffle
+ * parallelsised shuffling algorithm. MergeShuffle comes from "A Very Fast,
+ * Parallel Random Permutation Algorithm", Axel Bacher, Olivier Bodini,
+ * Alexandros Hollender, and Jérémie Lumbroso, August 14, 2015. See also their
+ * code repository: https://github.com/axel-bacher/mergeshuffle)
  */
 
 #include "./shuffle.hpp"
 
+/*
+ * C++ and Kokkos compatible version of ```shuffle(unsigned int *t, unsigned int
+ * n)``` from "A Very Fast, Parallel Random Permutation Algorithm", Axel Bacher,
+ * Olivier Bodini, Alexandros Hollender, and Jérémie Lumbroso, August 14, 2015.
+ * see: https://github.com/axel-bacher/mergeshuffle/blob/master/merge_omp.c
+ */
+KOKKOS_FUNCTION viewd_supers merge_shuffle_supers(const TeamMember &team_member,
+                                                  const viewd_supers supers,
+                                                  const GenRandomPool genpool) {
+  namespace KE = Kokkos::Experimental;
+
+  Kokkos::single(Kokkos::PerTeam(team_member), [=]() {
+    constexpr unsigned int cutoff = 1024;  // below, c is largest integer < log_2(nn / cutoff)
+    /**< determines smallest number of superdroplets for which merge sort
+     * resorts to fisher-yates */
+
+    const size_t nn = supers.extent(0);  // total number of superdroplets to shuffle
+    unsigned int c = 0;                  // length of blocks for fisher-yates = (n/2^c) +/- 1
+    while ((nn >> c) > cutoff) c++;      // c is largest number such that (n/2^c > cutoff)
+    unsigned int q = 1 << c;             // number of blocks, q = 2^c
+
+    const auto fisher_yates = FisherYatesShuffle{};
+    for (unsigned int i = 0; i < q; i++) {
+      const size_t j = (nn * i) >> c;        // (nn+i)/2^c
+      const size_t k = (nn * (i + 1)) >> c;  // (nn+nn*i)/2^c
+
+      const auto first = KE::begin(supers);
+      const auto block_first = first + j;  // distance from 1st to j'th element
+      const auto block_dist =
+          KE::distance(block_first, first + k - 1);  // distance from 1st to k'th
+
+      URBG<ExecSpace> urbg{genpool.get_state()};
+      fisher_yates.shuffle_supers(urbg, supers, block_first, block_dist);
+      genpool.free_state(urbg.gen);
+    }
+
+    for (unsigned int p = 1; p < q; p += p) {
+      for (unsigned int _i = 0; _i * (2 * p) < q; _i++) {
+        const auto i = _i * 2 * p;
+        const size_t j = (nn * i) >> c;
+        const size_t k = (nn * (i + p)) >> c;
+        const size_t l = (nn * (i + 2 * p)) >> c;
+        URBG<ExecSpace> urbg{genpool.get_state()};
+        merge_blocks(urbg, supers, j, k, l);
+        genpool.free_state(urbg.gen);
+      }
+    }
+  });
+  team_member.team_barrier();  // synchronise threads
+
+  return supers;
+}
+
 /**
- * @brief Randomly shuffles the order of super-droplet objects in a view using a single thread in
- * a Kokkos team (i.e. a single team member).
+ * @brief Randomly shuffles the order of super-droplet objects in a view using a
+ * single thread in a Kokkos team (i.e. a single team member).
  *
- * Uses only one member of a Kokkos team to randomly shuffle the order of super-droplet objects
- * in the 'supers' view using Kokkos compatible rewrite of C++ standard library Fisher-Yates
- * shuffling algorithm. Afterwards synchronizes the team and returns the view of
- * shuffled super-droplets. Uses Kokkos thread safe random number generator from pool.
+ * Uses only one member of a Kokkos team to randomly shuffle the order of
+ * super-droplet objects in the 'supers' view using Kokkos compatible rewrite of
+ * C++ standard library Fisher-Yates shuffling algorithm. Afterwards
+ * synchronizes the team and returns the view of shuffled super-droplets. Uses
+ * Kokkos thread safe random number generator from pool.
  *
  * @param team_member The Kokkos team member.
  * @param supers The view of superdroplets to shuffle.
  * @param genpool The random number generator pool.
  * @return The shuffled view of superdroplets.
  */
-KOKKOS_FUNCTION viewd_supers FisherYatesShuffle::operator()(const TeamMember& team_member,
+KOKKOS_FUNCTION viewd_supers FisherYatesShuffle::operator()(const TeamMember &team_member,
                                                             const viewd_supers supers,
                                                             const GenRandomPool genpool) const {
+  namespace KE = Kokkos::Experimental;
+
   Kokkos::single(Kokkos::PerTeam(team_member), [=, *this]() {
+    const auto first = KE::begin(supers);
+    const auto dist = KE::distance(first, KE::end(supers) - 1);  // distance to last elemnt from 1st
     URBG<ExecSpace> urbg{genpool.get_state()};
-    shuffle_supers(supers, urbg);
+    shuffle_supers(urbg, supers, first, dist);
     genpool.free_state(urbg.gen);
   });
   team_member.team_barrier();  // synchronise threads

--- a/libs/superdrops/collisions/shuffle.cpp
+++ b/libs/superdrops/collisions/shuffle.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 MPI-M, Clara Bayley
+ *
+ * ----- CLEO -----
+ * File: shuffle.hpp
+ * Project: collisions
+ * Created Date: Thursday 6th March 2025
+ * Author: Clara Bayley (CB)
+ * Additional Contributors:
+ * -----
+ * Last Modified: Thursday 6th March 2025
+ * Modified By: CB
+ * -----
+ * License: BSD 3-Clause "New" or "Revised" License
+ * https://opensource.org/licenses/BSD-3-Clause
+ * -----
+ * File Description:
+ * Implementaiton file for functions for Kokkos compatibile thread-safe versions of C++
+ * Fisher-Yates serial shuffling algorithm, and of MergeShuffle parallelsised shuffling
+ * algorithm. MergeShuffle comes from "A Very Fast, Parallel Random Permutation Algorithm",
+ * Axel Bacher, Olivier Bodini, Alexandros Hollender, and Jérémie Lumbroso, August 14, 2015.
+ * See also their code repository: https://github.com/axel-bacher/mergeshuffle)
+ */
+
+#include "./shuffle.hpp"
+
+/**
+ * @brief Randomly shuffles the order of super-droplet objects in a view using a single thread in
+ * a Kokkos team (i.e. a single team member).
+ *
+ * Uses only one member of a Kokkos team to randomly shuffle the order of super-droplet objects
+ * in the 'supers' view using Kokkos compatible rewrite of C++ standard library Fisher-Yates
+ * shuffling algorithm. Afterwards synchronizes the team and returns the view of
+ * shuffled super-droplets. Uses Kokkos thread safe random number generator from pool.
+ *
+ * @param team_member The Kokkos team member.
+ * @param supers The view of superdroplets to shuffle.
+ * @param genpool The random number generator pool.
+ * @return The shuffled view of superdroplets.
+ */
+KOKKOS_FUNCTION viewd_supers FisherYatesShuffle::operator()(const TeamMember& team_member,
+                                                            const viewd_supers supers,
+                                                            const GenRandomPool genpool) const {
+  Kokkos::single(Kokkos::PerTeam(team_member), [=, *this]() {
+    URBG<ExecSpace> urbg{genpool.get_state()};
+    shuffle_supers(supers, urbg);
+    genpool.free_state(urbg.gen);
+  });
+  team_member.team_barrier();  // synchronise threads
+
+  return supers;
+}

--- a/libs/superdrops/collisions/shuffle.cpp
+++ b/libs/superdrops/collisions/shuffle.cpp
@@ -36,43 +36,43 @@ KOKKOS_FUNCTION viewd_supers merge_shuffle_supers(const TeamMember &team_member,
                                                   const GenRandomPool genpool) {
   namespace KE = Kokkos::Experimental;
 
-  Kokkos::single(Kokkos::PerTeam(team_member), [=]() {
-    constexpr unsigned int cutoff = 1024;  // below, c is largest integer < log_2(nn / cutoff)
-    /**< determines smallest number of superdroplets for which merge sort
-     * resorts to fisher-yates */
+  constexpr unsigned int cutoff = 1024;  // below, c is largest integer < log_2(nn / cutoff)
+  /**< determines smallest number of superdroplets for which merge sort
+   * resorts to fisher-yates */
 
-    const size_t nn = supers.extent(0);  // total number of superdroplets to shuffle
-    unsigned int c = 0;                  // length of blocks for fisher-yates = (n/2^c) +/- 1
-    while ((nn >> c) > cutoff) c++;      // c is largest number such that (n/2^c > cutoff)
-    unsigned int q = 1 << c;             // number of blocks, q = 2^c
+  const size_t nn = supers.extent(0);  // total number of superdroplets to shuffle
+  unsigned int c = 0;                  // length of blocks for fisher-yates = (n/2^c) +/- 1
+  while ((nn >> c) > cutoff) c++;      // c is largest number such that (n/2^c > cutoff)
+  unsigned int q = 1 << c;             // number of blocks, q = 2^c
 
+  Kokkos::parallel_for(Kokkos::TeamThreadRange(team_member, q), [=](const unsigned int i) {
     const auto fisher_yates = FisherYatesShuffle{};
-    for (unsigned int i = 0; i < q; i++) {
-      const size_t j = (nn * i) >> c;        // (nn+i)/2^c
-      const size_t k = (nn * (i + 1)) >> c;  // (nn+nn*i)/2^c
+    const size_t j = (nn * i) >> c;        // (nn+i)/2^c
+    const size_t k = (nn * (i + 1)) >> c;  // (nn+nn*i)/2^c
 
-      const auto first = KE::begin(supers);
-      const auto block_first = first + j;  // distance from 1st to j'th element
-      const auto block_dist =
-          KE::distance(block_first, first + k - 1);  // distance from 1st to k'th
+    const auto first = KE::begin(supers);
+    const auto block_first = first + j;  // distance from 1st to j'th element
+    const auto block_dist = KE::distance(block_first, first + k - 1);  // distance from 1st to k'th
 
-      URBG<ExecSpace> urbg{genpool.get_state()};
-      fisher_yates.shuffle_supers(urbg, supers, block_first, block_dist);
-      genpool.free_state(urbg.gen);
-    }
-
-    for (unsigned int p = 1; p < q; p += p) {
-      for (unsigned int _i = 0; _i * (2 * p) < q; _i++) {
-        const auto i = _i * 2 * p;
-        const size_t j = (nn * i) >> c;
-        const size_t k = (nn * (i + p)) >> c;
-        const size_t l = (nn * (i + 2 * p)) >> c;
-        URBG<ExecSpace> urbg{genpool.get_state()};
-        merge_blocks(urbg, supers, j, k, l);
-        genpool.free_state(urbg.gen);
-      }
-    }
+    URBG<ExecSpace> urbg{genpool.get_state()};
+    fisher_yates.shuffle_supers(urbg, supers, block_first, block_dist);
+    genpool.free_state(urbg.gen);
   });
+  team_member.team_barrier();  // synchronise threads
+
+  for (unsigned int p = 1; p < q; p += p) {
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team_member, q / (2 * p)),
+                         [=](const unsigned int _i) {
+                           const auto i = _i * 2 * p;
+                           const size_t j = (nn * i) >> c;
+                           const size_t k = (nn * (i + p)) >> c;
+                           const size_t l = (nn * (i + 2 * p)) >> c;
+                           URBG<ExecSpace> urbg{genpool.get_state()};
+                           merge_blocks(urbg, supers, j, k, l);
+                           genpool.free_state(urbg.gen);
+                         });
+  }
+
   team_member.team_barrier();  // synchronise threads
 
   return supers;

--- a/libs/superdrops/collisions/shuffle.cpp
+++ b/libs/superdrops/collisions/shuffle.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2024 MPI-M, Clara Bayley
  *
  * ----- CLEO -----
- * File: shuffle.hpp
+ * File: shuffle.cpp
  * Project: collisions
  * Created Date: Thursday 6th March 2025
  * Author: Clara Bayley (CB)

--- a/libs/superdrops/collisions/shuffle.hpp
+++ b/libs/superdrops/collisions/shuffle.hpp
@@ -32,76 +32,78 @@
 #include "../superdrop.hpp"
 #include "./urbg.hpp"
 
-/**
- * @brief Swaps the values of two super-droplets.
- *
- * Equivalent to C++98 std::swap but works on device as well as host (gpu compatible).
- *
- * _Note:_ Involves a copy construction and two assignment operations, which may not be efficient
- * if Superdrop class stores large quantities of data.
- *
- * @param a The first super-droplet.
- * @param b The second super-droplet.
- */
-KOKKOS_INLINE_FUNCTION
-void device_swap(Superdrop& a, Superdrop& b) {
-  Superdrop c(a);
-  a = b;
-  b = c;
-}
-
-/**
- * @brief Shuffles the order of super-droplets in a view.
- *
- * Randomly shuffles the order of super-droplets using the
- * URBG (Uniform Random Bit Generator) struct (on device).
- *
- * @tparam DeviceType The Kokkos device type.
- * @param supers The view of super-droplets to shuffle.
- * @param urbg The random number generator.
- * @return The shuffled view of super-droplets.
- */
-template <class DeviceType>
-KOKKOS_INLINE_FUNCTION viewd_supers shuffle_supers(const viewd_supers supers,
-                                                   URBG<DeviceType> urbg) {
-  namespace KE = Kokkos::Experimental;
-
-  const auto first = KE::begin(supers);
-  const auto dist = KE::distance(first, KE::end(supers) - 1);  // distance to last element from 1st
-
-  for (auto iter(dist); iter > 0; --iter) {
-    const auto randiter = urbg(0, iter);  // random uint64_t equidistributed between [0, i]
-    device_swap(*(first + iter), *(first + randiter));
+struct FisherYatesShuffle {
+  /**
+   * @brief Swaps the values of two super-droplets.
+   *
+   * Equivalent to C++98 std::swap but works on device as well as host (gpu compatible).
+   *
+   * _Note:_ Involves a copy construction and two assignment operations, which may not be
+   * efficient if Superdrop class stores large quantities of data.
+   *
+   * @param a The first super-droplet.
+   * @param b The second super-droplet.
+   */
+  KOKKOS_INLINE_FUNCTION void device_swap(Superdrop& a, Superdrop& b) const {
+    Superdrop c(a);
+    a = b;
+    b = c;
   }
 
-  return supers;
-}
+  /**
+   * @brief Shuffles the order of super-droplets in a view.
+   *
+   * Randomly shuffles the order of super-droplets using the
+   * URBG (Uniform Random Bit Generator) struct (on device).
+   *
+   * @tparam DeviceType The Kokkos device type.
+   * @param supers The view of super-droplets to shuffle.
+   * @param urbg The random number generator.
+   * @return The shuffled view of super-droplets.
+   */
+  template <class DeviceType>
+  KOKKOS_INLINE_FUNCTION viewd_supers shuffle_supers(const viewd_supers supers,
+                                                     URBG<DeviceType> urbg) const {
+    namespace KE = Kokkos::Experimental;
 
-/**
- * @brief Randomly shuffles the order of super-droplet objects in a view using a single thread in
- * a Kokkos team (i.e. a single team member).
- *
- * Uses only one member of a Kokkos team to randomly shuffle the order of super-droplet objects
- * in the 'supers' view. Then synchronizes the team and returns the view of shuffled super-droplets.
- * Uses Kokkos thread safe random number generator from pool.
- *
- * @param team_member The Kokkos team member.
- * @param supers The view of superdroplets to shuffle.
- * @param genpool The random number generator pool.
- * @return The shuffled view of superdroplets.
- */
-KOKKOS_INLINE_FUNCTION viewd_supers shuffle_supers(const TeamMember& team_member,
-                                                   const viewd_supers supers,
-                                                   const GenRandomPool genpool) {
-  Kokkos::single(Kokkos::PerTeam(team_member), [=]() {
-    URBG<ExecSpace> urbg{genpool.get_state()};
-    shuffle_supers(supers, urbg);
-    genpool.free_state(urbg.gen);
-  });
+    const auto first = KE::begin(supers);
+    const auto dist =
+        KE::distance(first, KE::end(supers) - 1);  // distance to last element from 1st
 
-  team_member.team_barrier();  // synchronise threads
+    for (auto iter(dist); iter > 0; --iter) {
+      const auto randiter = urbg(0, iter);  // random uint64_t equidistributed between [0, i]
+      device_swap(*(first + iter), *(first + randiter));
+    }
 
-  return supers;
-}
+    return supers;
+  }
+
+  /**
+   * @brief Randomly shuffles the order of super-droplet objects in a view using a single thread in
+   * a Kokkos team (i.e. a single team member).
+   *
+   * Uses only one member of a Kokkos team to randomly shuffle the order of super-droplet objects
+   * in the 'supers' view using Kokkos compatible rewrite of C++ standard library Fisher-Yates
+   * shuffling algorithm. Afterwards synchronizes the team and returns the view of
+   * shuffled super-droplets. Uses Kokkos thread safe random number generator from pool.
+   *
+   * @param team_member The Kokkos team member.
+   * @param supers The view of superdroplets to shuffle.
+   * @param genpool The random number generator pool.
+   * @return The shuffled view of superdroplets.
+   */
+  KOKKOS_INLINE_FUNCTION viewd_supers shuffle_supers(const TeamMember& team_member,
+                                                     const viewd_supers supers,
+                                                     const GenRandomPool genpool) const {
+    Kokkos::single(Kokkos::PerTeam(team_member), [=, *this]() {
+      URBG<ExecSpace> urbg{genpool.get_state()};
+      shuffle_supers(supers, urbg);
+      genpool.free_state(urbg.gen);
+    });
+    team_member.team_barrier();  // synchronise threads
+
+    return supers;
+  }
+};
 
 #endif  // LIBS_SUPERDROPS_COLLISIONS_SHUFFLE_HPP_

--- a/libs/superdrops/collisions/shuffle.hpp
+++ b/libs/superdrops/collisions/shuffle.hpp
@@ -141,20 +141,23 @@ KOKKOS_INLINE_FUNCTION void merge_blocks(URBG<DeviceType> urbg, const viewd_supe
     if (urbg.flip()) {
       if (v == w) {
         break;
-      };
-      const auto iter = v++;
-      device_swap(*(first + u), *(first + iter));
-    } else if (u == v) {
-      break;
+      }
+      device_swap(*(first + u), *(first + v));
+      ++v;
+    } else {
+      if (u == v) {
+        break;
+      }
+      // no swap nor increment here
     }
-    u++;
+    ++u;
   }
 
   // finish merge with Fisher-Yates
   while (u < w) {
     const auto randiter = urbg(0, u + 1);  // random uint64_t equidistributed between [0, u]
-    const auto iter = u++;
-    device_swap(*(first + randiter), *(first + iter));
+    device_swap(*(first + randiter), *(first + u));
+    ++u;
   }
 }
 

--- a/libs/superdrops/collisions/shuffle.hpp
+++ b/libs/superdrops/collisions/shuffle.hpp
@@ -15,11 +15,12 @@
  * https://opensource.org/licenses/BSD-3-Clause
  * -----
  * File Description:
- * Functions for Kokkos compatibile thread-safe versions of C++ Fisher-Yates serial shuffling
- * algorithm, and of MergeShuffle parallelsised shuffling algorithm. MergeShuffle comes from
- * "A Very Fast, Parallel Random Permutation Algorithm", Axel Bacher, Olivier Bodini,
- * Alexandros Hollender, and Jérémie Lumbroso, August 14, 2015. See also their code
- * repository: https://github.com/axel-bacher/mergeshuffle)
+ * Functions for Kokkos compatibile thread-safe versions of C++ Fisher-Yates
+ * serial shuffling algorithm, and of MergeShuffle parallelsised shuffling
+ * algorithm. MergeShuffle comes from "A Very Fast, Parallel Random Permutation
+ * Algorithm", Axel Bacher, Olivier Bodini, Alexandros Hollender, and Jérémie
+ * Lumbroso, August 14, 2015. See also their code repository:
+ * https://github.com/axel-bacher/mergeshuffle)
  */
 
 #ifndef LIBS_SUPERDROPS_COLLISIONS_SHUFFLE_HPP_
@@ -32,51 +33,67 @@
 #include "../superdrop.hpp"
 #include "./urbg.hpp"
 
+KOKKOS_FUNCTION viewd_supers merge_shuffle_supers(const TeamMember& team_member,
+                                                  const viewd_supers supers,
+                                                  const GenRandomPool genpool);
+
+/*
+ * wrapper function to make it easier to chaneg shuffling algorithm (e.g. to
+ * switch to FisherYates for debugging)
+ */
+KOKKOS_INLINE_FUNCTION viewd_supers shuffle_supers(const TeamMember& team_member,
+                                                   const viewd_supers supers,
+                                                   const GenRandomPool genpool) {
+  return merge_shuffle_supers(team_member, supers, genpool);
+}
+
+/**
+ * @brief Swaps the values of two super-droplets.
+ *
+ * Equivalent to C++98 std::swap but works on device as well as host (gpu
+ * compatible).
+ *
+ * _Note:_ Involves a copy construction and two assignment operations, which may
+ * not be efficient if Superdrop class stores large quantities of data.
+ *
+ * @param a The first super-droplet.
+ * @param b The second super-droplet.
+ */
+KOKKOS_INLINE_FUNCTION void device_swap(Superdrop& a, Superdrop& b) {
+  Superdrop c(a);
+  a = b;
+  b = c;
+}
+
 /*
 Thread-Safe Kokkos compatible version of Fisher-Yates shuffling algorithm for
-super-droplets. Shuffling is done in serial (slow!) on single thread per team, we
-maintain this code in case it's needed for easier debugging (not for performance!)
+super-droplets. Shuffling is done in serial (slow!) on single thread per team,
+we maintain this code in case it's needed for easier debugging (not for
+performance!)
 */
 struct FisherYatesShuffle {
   /**
-   * @brief Swaps the values of two super-droplets.
-   *
-   * Equivalent to C++98 std::swap but works on device as well as host (gpu compatible).
-   *
-   * _Note:_ Involves a copy construction and two assignment operations, which may not be
-   * efficient if Superdrop class stores large quantities of data.
-   *
-   * @param a The first super-droplet.
-   * @param b The second super-droplet.
-   */
-  KOKKOS_INLINE_FUNCTION void device_swap(Superdrop& a, Superdrop& b) const {
-    Superdrop c(a);
-    a = b;
-    b = c;
-  }
-
-  /**
    * @brief Shuffles the order of super-droplets in a view.
    *
-   * Randomly shuffles the order of super-droplets using the
-   * URBG (Uniform Random Bit Generator) struct (on device).
+   * Randomly shuffles the order of super-droplets using the URBG
+   * (Uniform Random Bit Generator) struct (on device). Supers included in
+   * shuffle are from iterators in range [first, first+dist] (inclusive), e.g.
+   * if first points to the 5th superdroplet and dist=2, then the 5th, 6th and
+   * 7th superdroplets will be shuffled amongst each other.
    *
    * @tparam DeviceType The Kokkos device type.
    * @param supers The view of super-droplets to shuffle.
    * @param urbg The random number generator.
+   * @param first iterator/pointer to first element in supers to shuffle
+   * @param dist number of elements (including first) to shuffle
    * @return The shuffled view of super-droplets.
    */
   template <class DeviceType>
-  KOKKOS_INLINE_FUNCTION viewd_supers shuffle_supers(const viewd_supers supers,
-                                                     URBG<DeviceType> urbg) const {
-    namespace KE = Kokkos::Experimental;
-
-    const auto first = KE::begin(supers);
-    const auto dist =
-        KE::distance(first, KE::end(supers) - 1);  // distance to last element from 1st
-
+  KOKKOS_INLINE_FUNCTION viewd_supers shuffle_supers(URBG<DeviceType> urbg,
+                                                     const viewd_supers supers, const auto first,
+                                                     const auto dist) const {
     for (auto iter(dist); iter > 0; --iter) {
-      const auto randiter = urbg(0, iter);  // random uint64_t equidistributed between [0, i]
+      const auto randiter = urbg(0, iter + 1);  // random uint64_t equidistributed between [0, iter]
       device_swap(*(first + iter), *(first + randiter));
     }
 
@@ -84,13 +101,14 @@ struct FisherYatesShuffle {
   }
 
   /**
-   * @brief Randomly shuffles the order of super-droplet objects in a view using a single thread in
-   * a Kokkos team (i.e. a single team member).
+   * @brief Randomly shuffles the order of super-droplet objects in a view using
+   * a single thread in a Kokkos team (i.e. a single team member).
    *
-   * Uses only one member of a Kokkos team to randomly shuffle the order of super-droplet objects
-   * in the 'supers' view using Kokkos compatible rewrite of C++ standard library Fisher-Yates
-   * shuffling algorithm. Afterwards synchronizes the team and returns the view of
-   * shuffled super-droplets. Uses Kokkos thread safe random number generator from pool.
+   * Uses only one member of a Kokkos team to randomly shuffle the order of
+   * super-droplet objects in the 'supers' view using Kokkos compatible rewrite
+   * of C++ standard library Fisher-Yates shuffling algorithm. Afterwards
+   * synchronizes the team and returns the view of shuffled super-droplets. Uses
+   * Kokkos thread safe random number generator from pool.
    *
    * @param team_member The Kokkos team member.
    * @param supers The view of superdroplets to shuffle.
@@ -101,11 +119,43 @@ struct FisherYatesShuffle {
                                           const GenRandomPool genpool) const;
 };
 
-KOKKOS_INLINE_FUNCTION viewd_supers shuffle_supers(const TeamMember& team_member,
-                                                   const viewd_supers supers,
-                                                   const GenRandomPool genpool) {
-  const auto shuffle = FisherYatesShuffle{};
-  return shuffle(team_member, supers, genpool);
+/*
+ * C++ and Kokkos compatible version of ```merge(unsigned int *t, unsigned int
+ * m, unsigned int n)``` from "A Very Fast, Parallel Random Permutation
+ * Algorithm", Axel Bacher, Olivier Bodini, Alexandros Hollender, and Jérémie
+ * Lumbroso, August 14, 2015. see:
+ * https://github.com/axel-bacher/mergeshuffle/blob/master/merge.c
+ */
+template <class DeviceType>
+KOKKOS_INLINE_FUNCTION void merge_blocks(URBG<DeviceType> urbg, const viewd_supers supers,
+                                         const size_t j, const size_t k, const size_t l) {
+  namespace KE = Kokkos::Experimental;
+
+  const auto first = KE::begin(supers);  // iterator to first superdrop (like C pointer in merge.c)
+  auto u = KE::distance(first, first + j);  // initial start position of 1st block
+  auto v = KE::distance(first, first + k);  // initial start position of 2nd block
+  auto w = KE::distance(first, first + l);  // initial end position of 2nd block
+
+  // take elements from two blocks until one block is exhausted
+  while (true) {
+    if (urbg.flip()) {
+      if (v == w) {
+        break;
+      };
+      const auto iter = v++;
+      device_swap(*(first + u), *(first + iter));
+    } else if (u == v) {
+      break;
+    }
+    u++;
+  }
+
+  // finish merge with Fisher-Yates
+  while (u < w) {
+    const auto randiter = urbg(0, u + 1);  // random uint64_t equidistributed between [0, u]
+    const auto iter = u++;
+    device_swap(*(first + randiter), *(first + iter));
+  }
 }
 
 #endif  // LIBS_SUPERDROPS_COLLISIONS_SHUFFLE_HPP_

--- a/libs/superdrops/collisions/urbg.hpp
+++ b/libs/superdrops/collisions/urbg.hpp
@@ -30,12 +30,12 @@
 /**
  * @brief Struct wrapping Kokkos random number generator.
  *
- * Generates random numbers in the range [start, end]. Result equivalent to
- * std::uniform_int_distribution with parameters [a, b] = [start, end], where g = C++11
+ * Generates random numbers in the range [start, end). Result equivalent to
+ * std::uniform_int_distribution with parameters [a, b) = [start, end), where g = C++11
  * UniformRandomBitGenerator (URBG). Useful e.g. for using urand(start, end) function of Kokkos
  * random number generator 'gen' to generate random numbers for shuffling super-droplets array by
- * swapping elements in range [start, end] (e.g, for linear sampling of super-droplet pairs in
- * SDM collision algorithm).
+ * swapping elements in range [start, end), e.g, for linear sampling of super-droplet pairs in
+ * SDM collision algorithm.
  *
  * @tparam DeviceType The Kokkos device type.
  */
@@ -45,7 +45,9 @@ struct URBG {
 
   /**
    * @brief Draws a random 64-bit unsigned integer (uint64_t) from a uniform distribution in the
-   * range [start, end].
+   * range [start, end).
+   *
+   * includes start, excludes end value.
    *
    * @param start The lower bound of the range.
    * @param end The upper bound of the range.
@@ -57,7 +59,9 @@ struct URBG {
   }
 
   /**
-   * @brief Draws a random number (double) from a uniform distribution in the range [start, end].
+   * @brief Draws a random number (double) from a uniform distribution in the range [start, end).
+   *
+   * includes start, excludes end value.
    *
    * @param start The lower bound of the range.
    * @param end The upper bound of the range.

--- a/libs/superdrops/collisions/urbg.hpp
+++ b/libs/superdrops/collisions/urbg.hpp
@@ -71,6 +71,16 @@ struct URBG {
   double drand(const double start, const double end) {
     return gen.drand(start, end);  // double rand
   }
+
+  /**
+   * @brief Draws a random byte either 0 or 1 with 50% chance of either.
+   *
+   * @return The random single-byte boolean.
+   */
+  KOKKOS_INLINE_FUNCTION
+  bool flip() {
+    return static_cast<bool>(gen.rand(0, 2));  // 1 byte: 0 or 1
+  }
 };
 
 #endif  // LIBS_SUPERDROPS_COLLISIONS_URBG_HPP_

--- a/libs/superdrops/collisions/urbg.hpp
+++ b/libs/superdrops/collisions/urbg.hpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 MPI-M, Clara Bayley
+ *
+ * ----- CLEO -----
+ * File: urbg.hpp
+ * Project: collisions
+ * Created Date: Friday 13th October 2023
+ * Author: Clara Bayley (CB)
+ * Additional Contributors:
+ * -----
+ * Last Modified: Thursday 6th March 2025
+ * Modified By: CB
+ * -----
+ * License: BSD 3-Clause "New" or "Revised" License
+ * https://opensource.org/licenses/BSD-3-Clause
+ * -----
+ * File Description:
+ * Struct (for Kokkos compatibility) to generate random numbers for SDM (e.g. to randomly shuffle
+ * super-droplet's vector) based on C++11 standard UniformRandomBitGenerator (URBG). File also
+ * contains Kokkos compatibile thread-safe versions of C++ shuffling algorithms.
+ */
+
+#ifndef LIBS_SUPERDROPS_COLLISIONS_URBG_HPP_
+#define LIBS_SUPERDROPS_COLLISIONS_URBG_HPP_
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+#include <cstdint>
+
+/**
+ * @brief Struct wrapping Kokkos random number generator.
+ *
+ * Generates random numbers in the range [start, end]. Result equivalent to
+ * std::uniform_int_distribution with parameters [a, b] = [start, end], where g = C++11
+ * UniformRandomBitGenerator (URBG). Useful e.g. for using urand(start, end) function of Kokkos
+ * random number generator 'gen' to generate random numbers for shuffling super-droplets array by
+ * swapping elements in range [start, end] (e.g, for linear sampling of super-droplet pairs in
+ * SDM collision algorithm).
+ *
+ * @tparam DeviceType The Kokkos device type.
+ */
+template <class DeviceType>
+struct URBG {
+  Kokkos::Random_XorShift64<DeviceType> gen; /**< Kokkos random number generator */
+
+  /**
+   * @brief Draws a random 64-bit unsigned integer (uint64_t) from a uniform distribution in the
+   * range [start, end].
+   *
+   * @param start The lower bound of the range.
+   * @param end The upper bound of the range.
+   * @return The random 8-byte unsigned integer.
+   */
+  KOKKOS_INLINE_FUNCTION
+  uint64_t operator()(const uint64_t start, const uint64_t end) {
+    return gen.urand(start, end);  // unsigned int rand
+  }
+
+  /**
+   * @brief Draws a random number (double) from a uniform distribution in the range [start, end].
+   *
+   * @param start The lower bound of the range.
+   * @param end The upper bound of the range.
+   * @return The random double.
+   */
+  KOKKOS_INLINE_FUNCTION
+  double drand(const double start, const double end) {
+    return gen.drand(start, end);  // double rand
+  }
+};
+
+#endif  // LIBS_SUPERDROPS_COLLISIONS_URBG_HPP_


### PR DESCRIPTION
Team size for some thread range loops is currently set by team_size variable in KokkosCleoSettings (KCS) namespace and is read by kokkos at runtime. Would be better to use configuration parameter read from config .yaml file. As initial step, this PR moves kokkos related configuration parameters into a struct within optional params rather than let them dangle loose.