### PR TITLE
tidy up kokkos configuration parameters

### DIFF
--- a/libs/initialise/config.hpp
+++ b/libs/initialise/config.hpp
@@ -79,7 +79,7 @@ struct Config {
   RequiredConfigParams::TimestepsParams get_timesteps() const { return required.timesteps; }
 
   Kokkos::InitializationSettings get_kokkos_initialization_settings() const {
-    return optional.kokkos_settings;
+    return optional.kokkos_settings.kokkos_initialization_settings;
   };
 
   OptionalConfigParams::CondensationParams get_condensation() const {

--- a/libs/initialise/optional_config_params.cpp
+++ b/libs/initialise/optional_config_params.cpp
@@ -51,32 +51,35 @@ void OptionalConfigParams::set_kokkos_settings(const YAML::Node &config) {
   const YAML::Node node = config["kokkos_settings"];
 
   if (node["num_threads"]) {
-    kokkos_settings.set_num_threads(node["num_threads"].as<int>());
-    is_default_kokkos_settings = false;
+    kokkos_settings.kokkos_initialization_settings.set_num_threads(node["num_threads"].as<int>());
+    kokkos_settings.is_default = false;
   }
 
   if (node["device_id"]) {
-    kokkos_settings.set_device_id(node["device_id"].as<int>());
-    is_default_kokkos_settings = false;
+    kokkos_settings.kokkos_initialization_settings.set_device_id(node["device_id"].as<int>());
+    kokkos_settings.is_default = false;
   }
 
   if (node["map_device_id_by"]) {
-    kokkos_settings.set_map_device_id_by(node["map_device_id_by"].as<std::string>());
-    is_default_kokkos_settings = false;
+    kokkos_settings.kokkos_initialization_settings.set_map_device_id_by(
+        node["map_device_id_by"].as<std::string>());
+    kokkos_settings.is_default = false;
   }
 }
 
 void OptionalConfigParams::print_kokkos_settings() const {
   std::cout << "\n-------- Kokkos Configuration Parameters --------------"
-            << "\nusing default kokkos settings (bool): " << is_default_kokkos_settings;
-  if (kokkos_settings.has_num_threads()) {
-    std::cout << "\nnum_threads: " << kokkos_settings.get_num_threads();
+            << "\nusing default kokkos settings (bool): " << kokkos_settings.is_default;
+  if (kokkos_settings.kokkos_initialization_settings.has_num_threads()) {
+    std::cout << "\nnum_threads: "
+              << kokkos_settings.kokkos_initialization_settings.get_num_threads();
   }
-  if (kokkos_settings.has_device_id()) {
-    std::cout << "\ndevice_id: " << kokkos_settings.get_device_id();
+  if (kokkos_settings.kokkos_initialization_settings.has_device_id()) {
+    std::cout << "\ndevice_id: " << kokkos_settings.kokkos_initialization_settings.get_device_id();
   }
-  if (kokkos_settings.has_map_device_id_by()) {
-    std::cout << "\nmap_device_id_by: " << kokkos_settings.get_map_device_id_by();
+  if (kokkos_settings.kokkos_initialization_settings.has_map_device_id_by()) {
+    std::cout << "\nmap_device_id_by: "
+              << kokkos_settings.kokkos_initialization_settings.get_map_device_id_by();
   }
   std::cout << "\n---------------------------------------------------------\n";
 }

--- a/libs/initialise/optional_config_params.hpp
+++ b/libs/initialise/optional_config_params.hpp
@@ -62,8 +62,10 @@ struct OptionalConfigParams {
   void set_boundary_conditions(const YAML::Node& config);
 
   /*** Kokkos Initialization Parameters ***/
-  bool is_default_kokkos_settings = true;         /**< true = default kokkos initialization */
-  Kokkos::InitializationSettings kokkos_settings; /**< is default unless config */
+  struct KokkosSettings {
+    bool is_default = true; /**< true = default kokkos initialization */
+    Kokkos::InitializationSettings kokkos_initialization_settings; /**< is default unless config */
+  } kokkos_settings;
 
   /*** Super-Droplet Microphysics Parameters ***/
   struct CondensationParams {


### PR DESCRIPTION
This PR moves kokkos related configuration parameters into a struct within optional params rather than let them dangle loose.

PR is initial step towards changing how manual team_size for some thread range loops is set. Currently it is set by team_size variable in KokkosCleoSettings (KCS) namespace and is read by kokkos at runtime. Would be better to use configuration parameter read from config .yaml file in the future.