### PR TITLE
more compatible yac installation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: cleoenv
 channels:
     - conda-forge
 dependencies:
-    - python==3.13
+    - python==3.9.9 # matches version of python used to make yac bindings on levante
     - doxygen>=1.10.0
     - pip
     - pip:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ zarr
 pre-commit
 mpi4py
 ruamel.yaml
+cython

--- a/scripts/levante/bash/install_yac.sh
+++ b/scripts/levante/bash/install_yac.sh
@@ -31,24 +31,29 @@ yac_tag=v3.5.2
 yac_version=yac_$yac_tag
 yac_source=https://gitlab.dkrz.de/dkrz-sw/yac/-/archive/$yac_tag/$yac_version.tar.gz
 
-gcc=gcc/11.2.0-gcc-11.2.0
-openmpi=openmpi/4.1.2-gcc-11.2.0
-netcdf=netcdf-c/4.8.1-openmpi-4.1.2-gcc-11.2.0 # must match gcc and openmpi
-netcdf_root=/sw/spack-levante/netcdf-c-4.8.1-6qheqr # must match with `module show ${netcdf}`
-fyaml_root=/sw/spack-levante/libfyaml-0.7.12-fvbhgo # must match with `spack location -i libfyaml``
-python=python@3.9.9%gcc@=11.2.0/fwv
-pycython=py-cython@0.29.33%gcc@=11.2.0/j7b4fa
-pympi4py=py-mpi4py@3.1.2%gcc@=11.2.0/hdi5yl6
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+bashsrc=${SCRIPT_DIR}/src
+source ${bashsrc}/levante_packages.sh
 
-CC=/sw/spack-levante/openmpi-4.1.2-mnmady/bin/mpicc # must match gcc
-FC=/sw/spack-levante/openmpi-4.1.2-mnmady/bin/mpif90 # must match gcc
+gcc=${levante_gcc}
+openmpi=${levante_gcc_openmpi}
+netcdf=${levante_gcc_netcdf_yac}
+netcdf_root=${levante_gcc_netcdf_root}
+fyaml_root=${levante_gcc_fyaml_root}
+CC=${levante_gcc_compiler}
+FC=${levante_f90_compiler}
+
+python=${levante_gcc_python_yac}
+pycython=${levante_gcc_cython_yac}
+pympi4py=${levante_gcc_mpi4py_yac}
 
 if [ "${root4YAC}" == "" ]
 then
   echo "Bad input, please specify absolute path for where you want to install YAC"
 else
   mkdir ${root4YAC}
-  module load ${gcc} ${openmpi} ${netcdf}
+  module load ${gcc} ${netcdf}
+  spack load ${openmpi}
   ### ----------------- load Python ------------------------ ###
   spack load ${python}
   spack load ${pycython}

--- a/scripts/levante/bash/src/levante_packages.sh
+++ b/scripts/levante/bash/src/levante_packages.sh
@@ -8,12 +8,19 @@ levante_gxx_compiler="/sw/spack-levante/openmpi-4.1.2-mnmady/bin/mpic++"
 levante_gcc_compiler="/sw/spack-levante/openmpi-4.1.2-mnmady/bin/mpicc"
 levante_gcc_cuda=cuda@12.2.0%gcc@=11.2.0  # spack load
 levante_gcc_cuda_root="/sw/spack-levante/cuda-12.2.0-2ttufp/" # [cuda_root]/bin/nvcc") (can get hint for correct path via 'spack find -p nvhpc@23.9')
+
+### specific gcc compiler compatible packages for YAC installation and usage
 levante_gcc_netcdf_yac=netcdf-c/4.8.1-openmpi-4.1.2-gcc-11.2.0 # module load
 levante_gcc_openblas_yac=openblas@0.3.18%gcc@=11.2.0 # spack load
+levante_gcc_fyaml_root=/sw/spack-levante/libfyaml-0.7.12-fvbhgo # match `spack location -i libfyaml`
+levante_gcc_fyamllib="${levante_gcc_fyaml_root}/lib"
+### specific packages for YAC installation only
+### Note: python version used to install yac must match version used to run model
+levante_f90_compiler="/sw/spack-levante/openmpi-4.1.2-mnmady/bin/mpif90"
 levante_gcc_python_yac=python@3.9.9%gcc@=11.2.0/fwv # spack load
 levante_gcc_cython_yac=py-cython@0.29.33%gcc@=11.2.0/j7b4fa # spack load
 levante_gcc_mpi4py_yac=py-mpi4py@3.1.2%gcc@=11.2.0/hdi5yl6 # spack load
-levante_gcc_fyamllib="/sw/spack-levante/libfyaml-0.7.12-fvbhgo/lib"
+levante_gcc_netcdf_root=/sw/spack-levante/netcdf-c-4.8.1-6qheqr # match `module show ${netcdf}`
 ### ---------------------------------------------------- ###
 
 ### ------------- Intel compiler(s) Packages ------------ ###

--- a/scripts/levante/bash/src/runtime_settings.sh
+++ b/scripts/levante/bash/src/runtime_settings.sh
@@ -17,10 +17,6 @@ then
   check_args_not_empty "${CLEO_YACYAXTROOT}"
   source ${bashsrc}/levante_packages.sh
 
-  spack load ${levante_gcc_python_yac}
-  spack load ${levante_gcc_cython_yac}
-  spack load ${levante_gcc_mpi4py_yac}
-
   export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${levante_gcc_fyamllib}
   export PYTHONPATH=${PYTHONPATH}:${CLEO_YACYAXTROOT}/yac/python # path to YAC python bindings
 fi


### PR DESCRIPTION
- use levante_packages.sh script to control packages used to build yac
- use same python version in cleoenv as in python bindings made by yac on levante