### PR TITLE
use chosen python not levante python to build yac python bindings

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: cleoenv
 channels:
     - conda-forge
 dependencies:
-    - python==3.9.9 # matches version of python used to make yac bindings on levante
+    - python==3.13
     - doxygen>=1.10.0
     - pip
     - pip:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pre-commit
 pytest
 sphinx
 furo
@@ -12,7 +13,8 @@ matplotlib
 xarray
 awkward
 zarr
-pre-commit
-mpi4py
 ruamel.yaml
+mpi4py
 cython
+netcdf4
+isodate

--- a/scripts/levante/bash/install_yac.sh
+++ b/scripts/levante/bash/install_yac.sh
@@ -18,9 +18,9 @@ source /etc/profile
 module purge
 spack unload --all
 
-set -ex
-
 root4YAC=$1 # absolute path for YAC and YAXT installations
+python=$2 # name or absolute path to python to make YAC python bindngs with
+### Note: python version used to install yac must match version used to run model
 
 yaxt_tag=0.11.1
 yaxt_version=yaxt-${yaxt_tag}
@@ -43,22 +43,13 @@ fyaml_root=${levante_gcc_fyaml_root}
 CC=${levante_gcc_compiler}
 FC=${levante_f90_compiler}
 
-python=${levante_gcc_python_yac}
-pycython=${levante_gcc_cython_yac}
-pympi4py=${levante_gcc_mpi4py_yac}
-
-if [ "${root4YAC}" == "" ]
+if [[ "${root4YAC}" == "" || "${python}" == "" ]]
 then
-  echo "Bad input, please specify absolute path for where you want to install YAC"
+  echo "Bad input, please specify absolute path for where you want to install YAC and python to use to make bindings"
 else
   mkdir ${root4YAC}
   module load ${gcc} ${netcdf}
   spack load ${openmpi}
-  ### ----------------- load Python ------------------------ ###
-  spack load ${python}
-  spack load ${pycython}
-  spack load ${pympi4py}
-  ### ------------------------------------------------------ ###
 
   ### --------------------- install YAXT ------------------- ###
   mkdir ${root4YAC}/${yaxt_version}
@@ -90,6 +81,7 @@ else
     CFLAGS="-O0 -g -Wall" \
     FCFLAGS="-O0 -g -Wall -cpp -fimplicit-none" \
     LDFLAGS="-lm" \
+    PYTHON=${python} \
     --disable-mpi-checks \
     --with-yaxt-root=${root4YAC}/yaxt \
     --with-netcdf-root=${netcdf_root} \

--- a/scripts/levante/bash/src/levante_packages.sh
+++ b/scripts/levante/bash/src/levante_packages.sh
@@ -14,7 +14,6 @@ levante_gcc_netcdf_yac=netcdf-c/4.8.1-openmpi-4.1.2-gcc-11.2.0 # module load
 levante_gcc_openblas_yac=openblas@0.3.18%gcc@=11.2.0 # spack load
 levante_gcc_fyaml_root=/sw/spack-levante/libfyaml-0.7.12-fvbhgo # match `spack location -i libfyaml`
 levante_gcc_fyamllib="${levante_gcc_fyaml_root}/lib"
-levante_gcc_mpi4py_yac=py-mpi4py@3.1.2%gcc@=11.2.0/hdi5yl6 # spack load
 ### specific packages for YAC installation only
 levante_f90_compiler="/sw/spack-levante/openmpi-4.1.2-mnmady/bin/mpif90"
 levante_gcc_netcdf_root=/sw/spack-levante/netcdf-c-4.8.1-6qheqr # match `module show ${netcdf}`

--- a/scripts/levante/bash/src/levante_packages.sh
+++ b/scripts/levante/bash/src/levante_packages.sh
@@ -16,10 +16,7 @@ levante_gcc_fyaml_root=/sw/spack-levante/libfyaml-0.7.12-fvbhgo # match `spack l
 levante_gcc_fyamllib="${levante_gcc_fyaml_root}/lib"
 levante_gcc_mpi4py_yac=py-mpi4py@3.1.2%gcc@=11.2.0/hdi5yl6 # spack load
 ### specific packages for YAC installation only
-### Note: python version used to install yac must match version used to run model
 levante_f90_compiler="/sw/spack-levante/openmpi-4.1.2-mnmady/bin/mpif90"
-levante_gcc_python_yac=python@3.9.9%gcc@=11.2.0/fwv # spack load
-levante_gcc_cython_yac=py-cython@0.29.33%gcc@=11.2.0/j7b4fa # spack load
 levante_gcc_netcdf_root=/sw/spack-levante/netcdf-c-4.8.1-6qheqr # match `module show ${netcdf}`
 ### ---------------------------------------------------- ###
 

--- a/scripts/levante/bash/src/runtime_settings.sh
+++ b/scripts/levante/bash/src/runtime_settings.sh
@@ -17,7 +17,7 @@ then
   check_args_not_empty "${CLEO_YACYAXTROOT}"
   source ${bashsrc}/levante_packages.sh
 
-  spack load ${levante_gcc_mpi4py_yac}
+  spack load ${levante_gcc_openmpi}
 
   export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${levante_gcc_fyamllib}
   export PYTHONPATH=${PYTHONPATH}:${CLEO_YACYAXTROOT}/yac/python # path to YAC python bindings


### PR DESCRIPTION
- use PYTHON=[...] in YAC configure during installation to specify python to make bindings with (e.g. cleoenv python)
- remove cleo dependency on levante python packages