### PR TITLE
Sprinttest 2b debug2

### DIFF
--- a/examples/bubble3d/src/main_bubble3d.cpp
+++ b/examples/bubble3d/src/main_bubble3d.cpp
@@ -157,7 +157,7 @@ int main(int argc, char *argv[]) {
   const Config config(config_filename);
 
   /* Initialize Communicator here */
-  init_communicator init_comm(config);
+  init_communicator init_comm(argc, argv, config);
 
   /* Initialise Kokkos parallel environment */
   Kokkos::initialize(config.get_kokkos_initialization_settings());

--- a/examples/fromfile/src/main_fromfile.cpp
+++ b/examples/fromfile/src/main_fromfile.cpp
@@ -155,7 +155,7 @@ int main(int argc, char *argv[]) {
   const Config config(config_filename);
 
   /* Initialize Communicator here */
-  init_communicator init_comm(config);
+  init_communicator init_comm(argc, argv, config);
 
   /* Initialise Kokkos parallel environment */
   Kokkos::initialize(config.get_kokkos_initialization_settings());

--- a/examples/fromfile_irreg/src/main_fromfile_irreg.cpp
+++ b/examples/fromfile_irreg/src/main_fromfile_irreg.cpp
@@ -152,7 +152,7 @@ int main(int argc, char *argv[]) {
   const Config config(config_filename);
 
   /* Initialize Communicator here */
-  init_communicator init_comm(config);
+  init_communicator init_comm(argc, argv, config);
 
   /* Initialise Kokkos parallel environment */
   Kokkos::initialize(config.get_kokkos_initialization_settings());

--- a/libs/configuration/communicator.cpp
+++ b/libs/configuration/communicator.cpp
@@ -31,7 +31,7 @@ MPI_Comm init_communicator::comm = NULL;
 int init_communicator::comm_size = -1;
 int init_communicator::my_rank = -1;
 
-init_communicator::init_communicator(const Config &config) {
+init_communicator::init_communicator(int argc, char *argv[], const Config &config) {
   if (!(std::isnan(config.get_yac_dynamics().lower_longitude))) {
     std::cout << "yac is present";
     // -- YAC initialization and calendar definitions ---
@@ -46,9 +46,10 @@ init_communicator::init_communicator(const Config &config) {
 
   } else {
     std::cout << "yac is not present" << yac_present;
-    MPI_Init(NULL, NULL);
+    MPI_Init(&argc, &argv);
     comm = MPI_COMM_WORLD;
     MPI_Comm_size(comm, &comm_size);
+    MPI_Comm_rank(comm, &my_rank);
     yac_present = false;
   }
 };

--- a/libs/configuration/communicator.hpp
+++ b/libs/configuration/communicator.hpp
@@ -41,7 +41,7 @@ class init_communicator {
   static int comm_size;
   static int my_rank;
  public:
-  explicit init_communicator(const Config &config);
+  explicit init_communicator(int argc, char *argv[], const Config &config);
   ~init_communicator();
   static MPI_Comm get_communicator();
   static int get_yac_comp_id();


### PR DESCRIPTION
Changes in the Communicator class
Adapted main files of fromfile, fromfile_irreg, bubble3d

Tested the working and checked the output images for :
1. fromfile example running with communicator and just 1 mpi task
2. fromfile example running with communicator and more than 1 mpi task
3. fromfile_irreg example running with communicator and just 1 mpi task

Bubble3d compiles (actual run test in progress)