### PR TITLE
MPI-YAC-Compatibility 0: bonus step

### DIFF
--- a/docs/source/cxx/observers/write_to_dataset_observer.rst
+++ b/docs/source/cxx/observers/write_to_dataset_observer.rst
@@ -14,8 +14,8 @@ Header file: ``<libs/observers/write_to_dataset_observer.hpp>``
 .. doxygenfunction:: WriteToDatasetObserver(const unsigned int interval, ParallelWriteData parallel_write)
    :project: observers
 
-.. doxygenfunction:: WriteToDatasetObserver(const unsigned int interval, const SimpleDataset<Store> &dataset, CollectData collect_data)
+.. doxygenfunction:: WriteToDatasetObserver(const unsigned int interval, const Dataset &dataset, CollectData collect_data)
    :project: observers
 
-.. doxygenfunction:: WriteToDatasetObserver(const unsigned int interval, const SimpleDataset<Store> &dataset, CollectData collect_data, RaggedCount ragged_count)
+.. doxygenfunction:: WriteToDatasetObserver(const unsigned int interval, const Dataset &dataset, CollectData collect_data, RaggedCount ragged_count)
    :project: observers

--- a/docs/source/cxx/observers/write_to_dataset_observer.rst
+++ b/docs/source/cxx/observers/write_to_dataset_observer.rst
@@ -14,8 +14,8 @@ Header file: ``<libs/observers/write_to_dataset_observer.hpp>``
 .. doxygenfunction:: WriteToDatasetObserver(const unsigned int interval, ParallelWriteData parallel_write)
    :project: observers
 
-.. doxygenfunction:: WriteToDatasetObserver(const unsigned int interval, const Dataset<Store> &dataset, CollectData collect_data)
+.. doxygenfunction:: WriteToDatasetObserver(const unsigned int interval, const SimpleDataset<Store> &dataset, CollectData collect_data)
    :project: observers
 
-.. doxygenfunction:: WriteToDatasetObserver(const unsigned int interval, const Dataset<Store> &dataset, CollectData collect_data, RaggedCount ragged_count)
+.. doxygenfunction:: WriteToDatasetObserver(const unsigned int interval, const SimpleDataset<Store> &dataset, CollectData collect_data, RaggedCount ragged_count)
    :project: observers

--- a/docs/source/cxx/zarr/dataset.rst
+++ b/docs/source/cxx/zarr/dataset.rst
@@ -1,7 +1,7 @@
 Dataset
 =======
 
-Header file: ``<libs/zarr/dataset.hpp>``
-`[source] <https://github.com/yoctoyotta1024/CLEO/blob/main/libs/zarr/dataset.hpp>`_
+Header file: ``<libs/zarr/simple_dataset.hpp>``
+`[source] <https://github.com/yoctoyotta1024/CLEO/blob/main/libs/zarr/simple_dataset.hpp>`_
 
 (Work in Progress, no doxygen strings yet).

--- a/docs/source/cxx/zarr/dataset.rst
+++ b/docs/source/cxx/zarr/dataset.rst
@@ -5,3 +5,8 @@ Header file: ``<libs/zarr/simple_dataset.hpp>``
 `[source] <https://github.com/yoctoyotta1024/CLEO/blob/main/libs/zarr/simple_dataset.hpp>`_
 
 (Work in Progress, no doxygen strings yet).
+
+Header file: ``<libs/zarr/collective_dataset.hpp>``
+`[source] <https://github.com/yoctoyotta1024/CLEO/blob/main/libs/zarr/collective_dataset.hpp>`_
+
+(Work in Progress, no doxygen strings yet).

--- a/docs/source/usage/quickstart.rst
+++ b/docs/source/usage/quickstart.rst
@@ -68,9 +68,9 @@ where for example the SDM is set-up as:
 
 .. code-block:: c++
 
-  template <typename Store>
+  template <typename Dataset, typename Store>
   inline auto create_sdm(const Config &config, const Timesteps &tsteps,
-                       SimpleDataset<Store> &dataset) {
+                         Dataset &dataset, Store &store) {
     const auto couplstep = (unsigned int)tsteps.get_couplstep();
     const GridboxMaps auto gbxmaps = create_gbxmaps(config);
     const MicrophysicalProcess auto microphys = create_microphysics(config, tsteps);

--- a/docs/source/usage/quickstart.rst
+++ b/docs/source/usage/quickstart.rst
@@ -38,7 +38,7 @@ the end of your ``main.cpp`` contains a main function that looks something like 
 
       /* Create Xarray dataset wit Zarr backend for writing output data to a store */
       auto store = FSStore(config.get_zarrbasedir());
-      auto dataset = Dataset(store);
+      auto dataset = SimpleDataset(store);
 
       /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
       const SDMMethods sdm = create_sdm(config, tsteps, dataset);
@@ -69,7 +69,8 @@ where for example the SDM is set-up as:
 .. code-block:: c++
 
   template <typename Store>
-  inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+  inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       SimpleDataset<Store> &dataset) {
     const auto couplstep = (unsigned int)tsteps.get_couplstep();
     const GridboxMaps auto gbxmaps = create_gbxmaps(config);
     const MicrophysicalProcess auto microphys = create_microphysics(config, tsteps);

--- a/examples/adiabaticparcel/src/main_adia0d.cpp
+++ b/examples/adiabaticparcel/src/main_adia0d.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 28th May 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -26,7 +26,7 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_movement.hpp"
@@ -89,7 +89,7 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
 
 template <typename Store>
 inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                Dataset<Store> &dataset, const int maxchunk) {
+                                                SimpleDataset<Store> &dataset, const int maxchunk) {
   CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
   CollectDataForDataset<Store> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
   CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
@@ -102,7 +102,7 @@ inline Observer auto create_superdrops_observer(const unsigned int interval,
 
 template <typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset<Store> &dataset) {
+                                     SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
   const auto ngbxs = config.get_ngbxs();
@@ -121,7 +121,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 }
 
 template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       SimpleDataset<Store> &dataset) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
@@ -162,7 +163,7 @@ int main(int argc, char *argv[]) {
 
     /* Create Xarray dataset wit Zarr backend for writing output data to a store */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = Dataset(store);
+    auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));

--- a/examples/adiabaticparcel/src/main_adia0d.cpp
+++ b/examples/adiabaticparcel/src/main_adia0d.cpp
@@ -26,7 +26,6 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_movement.hpp"
@@ -53,6 +52,7 @@
 #include "superdrops/microphysicalprocess.hpp"
 #include "superdrops/motion.hpp"
 #include "zarr/fsstore.hpp"
+#include "zarr/simple_dataset.hpp"
 
 inline CoupledDynamics auto create_coupldyn(const Config &config, const unsigned int couplstep) {
   return CvodeDynamics(config.get_cvodedynamics(), couplstep, &step2dimlesstime);
@@ -87,47 +87,47 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
                       c.rtol, c.atol, c.MINSUBTSTEP, &realtime2dimless);
 }
 
-template <typename Store>
-inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                SimpleDataset<Store> &dataset, const int maxchunk) {
-  CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
-  CollectDataForDataset<Store> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
-  CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
-  CollectDataForDataset<Store> auto radius = CollectRadius(dataset, maxchunk);
-  CollectDataForDataset<Store> auto msol = CollectMsol(dataset, maxchunk);
+template <typename Dataset, typename Store>
+inline Observer auto create_superdrops_observer(const unsigned int interval, Dataset &dataset,
+                                                Store &store, const int maxchunk) {
+  CollectDataForDataset<Dataset> auto sdid = CollectSdId(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto xi = CollectXi(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto radius = CollectRadius(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto msol = CollectMsol(dataset, maxchunk);
 
   const auto collect_sddata = msol >> radius >> xi >> sdgbxindex >> sdid;
-  return SuperdropsObserver(interval, dataset, maxchunk, collect_sddata);
+  return SuperdropsObserver(interval, dataset, store, maxchunk, collect_sddata);
 }
 
-template <typename Store>
+template <typename Dataset, typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     SimpleDataset<Store> &dataset) {
+                                     Dataset &dataset, Store &store) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
   const auto ngbxs = config.get_ngbxs();
 
   const Observer auto obs1 = StreamOutObserver(obsstep * 10, &step2realtime);
 
-  const Observer auto obs2 = TimeObserver(obsstep, dataset, maxchunk, &step2dimlesstime);
+  const Observer auto obs2 = TimeObserver(obsstep, dataset, store, maxchunk, &step2dimlesstime);
 
-  const Observer auto obs3 = GbxindexObserver(dataset, maxchunk, ngbxs);
+  const Observer auto obs3 = GbxindexObserver(dataset, store, maxchunk, ngbxs);
 
   const Observer auto obs4 = StateObserver(obsstep, dataset, maxchunk, ngbxs);
 
-  const Observer auto obs5 = create_superdrops_observer(obsstep, dataset, maxchunk);
+  const Observer auto obs5 = create_superdrops_observer(obsstep, dataset, store, maxchunk);
 
   return obs5 >> obs4 >> obs3 >> obs2 >> obs1;
 }
 
-template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps,
-                       SimpleDataset<Store> &dataset) {
+template <typename Dataset, typename Store>
+inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset &dataset,
+                       Store &store) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
   const MoveSupersInDomain movesupers(create_movement(gbxmaps));
-  const Observer auto obs(create_observer(config, tsteps, dataset));
+  const Observer auto obs = create_observer(config, tsteps, dataset, store);
 
   return SDMMethods(couplstep, gbxmaps, microphys, movesupers, obs);
 }
@@ -166,7 +166,7 @@ int main(int argc, char *argv[]) {
     auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
-    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+    const SDMMethods sdm = create_sdm(config, tsteps, dataset, store);
 
     /* Create coupldyn solver and coupling between coupldyn and SDM */
     CoupledDynamics auto coupldyn(create_coupldyn(config, tsteps.get_couplstep()));

--- a/examples/boxmodelcollisions/golovin/src/main_golcolls.cpp
+++ b/examples/boxmodelcollisions/golovin/src/main_golcolls.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 28th May 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,7 +28,7 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_movement.hpp"
@@ -86,7 +86,7 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
 
 template <typename Store>
 inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                Dataset<Store> &dataset, const int maxchunk) {
+                                                SimpleDataset<Store> &dataset, const int maxchunk) {
   CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
   CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
   CollectDataForDataset<Store> auto radius = CollectRadius(dataset, maxchunk);
@@ -98,7 +98,7 @@ inline Observer auto create_superdrops_observer(const unsigned int interval,
 
 template <typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset<Store> &dataset) {
+                                     SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
 
@@ -112,7 +112,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 }
 
 template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       SimpleDataset<Store> &dataset) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
@@ -153,7 +154,7 @@ int main(int argc, char *argv[]) {
 
     /* Create Xarray dataset wit Zarr backend for writing output data to a store */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = Dataset(store);
+    auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));

--- a/examples/boxmodelcollisions/golovin/src/main_golcolls.cpp
+++ b/examples/boxmodelcollisions/golovin/src/main_golcolls.cpp
@@ -28,7 +28,6 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_movement.hpp"
@@ -55,6 +54,7 @@
 #include "superdrops/microphysicalprocess.hpp"
 #include "superdrops/motion.hpp"
 #include "zarr/fsstore.hpp"
+#include "zarr/simple_dataset.hpp"
 
 template <GridboxMaps GbxMaps>
 inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
@@ -84,41 +84,41 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
   return colls;
 }
 
-template <typename Store>
-inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                SimpleDataset<Store> &dataset, const int maxchunk) {
-  CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
-  CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
-  CollectDataForDataset<Store> auto radius = CollectRadius(dataset, maxchunk);
-  CollectDataForDataset<Store> auto msol = CollectMsol(dataset, maxchunk);
+template <typename Dataset, typename Store>
+inline Observer auto create_superdrops_observer(const unsigned int interval, Dataset &dataset,
+                                                Store &store, const int maxchunk) {
+  CollectDataForDataset<Dataset> auto sdid = CollectSdId(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto xi = CollectXi(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto radius = CollectRadius(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto msol = CollectMsol(dataset, maxchunk);
 
   const auto collect_sddata = msol >> radius >> xi >> sdid;
-  return SuperdropsObserver(interval, dataset, maxchunk, collect_sddata);
+  return SuperdropsObserver(interval, dataset, store, maxchunk, collect_sddata);
 }
 
-template <typename Store>
+template <typename Dataset, typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     SimpleDataset<Store> &dataset) {
+                                     Dataset &dataset, Store &store) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
 
   const Observer auto obs0 = StreamOutObserver(obsstep, &step2realtime);
 
-  const Observer auto obs1 = TimeObserver(obsstep, dataset, maxchunk, &step2dimlesstime);
+  const Observer auto obs1 = TimeObserver(obsstep, dataset, store, maxchunk, &step2dimlesstime);
 
-  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, maxchunk);
+  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, store, maxchunk);
 
   return obssd >> obs1 >> obs0;
 }
 
-template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps,
-                       SimpleDataset<Store> &dataset) {
+template <typename Dataset, typename Store>
+inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset &dataset,
+                       Store &store) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
   const MoveSupersInDomain movesupers(create_movement(gbxmaps));
-  const Observer auto obs(create_observer(config, tsteps, dataset));
+  const Observer auto obs = create_observer(config, tsteps, dataset, store);
 
   return SDMMethods(couplstep, gbxmaps, microphys, movesupers, obs);
 }
@@ -157,7 +157,7 @@ int main(int argc, char *argv[]) {
     auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
-    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+    const SDMMethods sdm = create_sdm(config, tsteps, dataset, store);
 
     /* Create coupldyn solver and coupling between coupldyn and SDM */
     const CoupledDynamics auto coupldyn = NullDynamics(tsteps.get_couplstep());

--- a/examples/boxmodelcollisions/long/src/main_longcolls.cpp
+++ b/examples/boxmodelcollisions/long/src/main_longcolls.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 28th May 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,7 +28,7 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_movement.hpp"
@@ -86,7 +86,7 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
 
 template <typename Store>
 inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                Dataset<Store> &dataset, const int maxchunk) {
+                                                SimpleDataset<Store> &dataset, const int maxchunk) {
   CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
   CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
   CollectDataForDataset<Store> auto radius = CollectRadius(dataset, maxchunk);
@@ -98,7 +98,7 @@ inline Observer auto create_superdrops_observer(const unsigned int interval,
 
 template <typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset<Store> &dataset) {
+                                     SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
 
@@ -112,7 +112,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 }
 
 template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       SimpleDataset<Store> &dataset) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
@@ -153,7 +154,7 @@ int main(int argc, char *argv[]) {
 
     /* Create Xarray dataset wit Zarr backend for writing output data to a store */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = Dataset(store);
+    auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));

--- a/examples/boxmodelcollisions/long/src/main_longcolls.cpp
+++ b/examples/boxmodelcollisions/long/src/main_longcolls.cpp
@@ -28,7 +28,6 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_movement.hpp"
@@ -55,6 +54,7 @@
 #include "superdrops/microphysicalprocess.hpp"
 #include "superdrops/motion.hpp"
 #include "zarr/fsstore.hpp"
+#include "zarr/simple_dataset.hpp"
 
 template <GridboxMaps GbxMaps>
 inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
@@ -84,41 +84,41 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
   return colls;
 }
 
-template <typename Store>
-inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                SimpleDataset<Store> &dataset, const int maxchunk) {
-  CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
-  CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
-  CollectDataForDataset<Store> auto radius = CollectRadius(dataset, maxchunk);
-  CollectDataForDataset<Store> auto msol = CollectMsol(dataset, maxchunk);
+template <typename Dataset, typename Store>
+inline Observer auto create_superdrops_observer(const unsigned int interval, Dataset &dataset,
+                                                Store &store, const int maxchunk) {
+  CollectDataForDataset<Dataset> auto sdid = CollectSdId(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto xi = CollectXi(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto radius = CollectRadius(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto msol = CollectMsol(dataset, maxchunk);
 
   const auto collect_sddata = msol >> radius >> xi >> sdid;
-  return SuperdropsObserver(interval, dataset, maxchunk, collect_sddata);
+  return SuperdropsObserver(interval, dataset, store, maxchunk, collect_sddata);
 }
 
-template <typename Store>
+template <typename Dataset, typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     SimpleDataset<Store> &dataset) {
+                                     Dataset &dataset, Store &store) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
 
   const Observer auto obs0 = StreamOutObserver(obsstep, &step2realtime);
 
-  const Observer auto obs1 = TimeObserver(obsstep, dataset, maxchunk, &step2dimlesstime);
+  const Observer auto obs1 = TimeObserver(obsstep, dataset, store, maxchunk, &step2dimlesstime);
 
-  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, maxchunk);
+  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, store, maxchunk);
 
   return obssd >> obs1 >> obs0;
 }
 
-template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps,
-                       SimpleDataset<Store> &dataset) {
+template <typename Dataset, typename Store>
+inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset &dataset,
+                       Store &store) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
   const MoveSupersInDomain movesupers(create_movement(gbxmaps));
-  const Observer auto obs(create_observer(config, tsteps, dataset));
+  const Observer auto obs = create_observer(config, tsteps, dataset, store);
 
   return SDMMethods(couplstep, gbxmaps, microphys, movesupers, obs);
 }
@@ -157,7 +157,7 @@ int main(int argc, char *argv[]) {
     auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
-    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+    const SDMMethods sdm = create_sdm(config, tsteps, dataset, store);
 
     /* Create coupldyn solver and coupling between coupldyn and SDM */
     const CoupledDynamics auto coupldyn = NullDynamics(tsteps.get_couplstep());

--- a/examples/boxmodelcollisions/lowlist/src/main_lowlistcolls.cpp
+++ b/examples/boxmodelcollisions/lowlist/src/main_lowlistcolls.cpp
@@ -28,7 +28,6 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_movement.hpp"
@@ -57,6 +56,7 @@
 #include "superdrops/microphysicalprocess.hpp"
 #include "superdrops/motion.hpp"
 #include "zarr/fsstore.hpp"
+#include "zarr/simple_dataset.hpp"
 
 template <GridboxMaps GbxMaps>
 inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
@@ -93,41 +93,41 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
   return coal >> bu;
 }
 
-template <typename Store>
-inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                SimpleDataset<Store> &dataset, const int maxchunk) {
-  CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
-  CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
-  CollectDataForDataset<Store> auto radius = CollectRadius(dataset, maxchunk);
-  CollectDataForDataset<Store> auto msol = CollectMsol(dataset, maxchunk);
+template <typename Dataset, typename Store>
+inline Observer auto create_superdrops_observer(const unsigned int interval, Dataset &dataset,
+                                                Store &store, const int maxchunk) {
+  CollectDataForDataset<Dataset> auto sdid = CollectSdId(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto xi = CollectXi(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto radius = CollectRadius(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto msol = CollectMsol(dataset, maxchunk);
 
   const auto collect_sddata = msol >> radius >> xi >> sdid;
-  return SuperdropsObserver(interval, dataset, maxchunk, collect_sddata);
+  return SuperdropsObserver(interval, dataset, store, maxchunk, collect_sddata);
 }
 
-template <typename Store>
+template <typename Dataset, typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     SimpleDataset<Store> &dataset) {
+                                     Dataset &dataset, Store &store) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
 
   const Observer auto obs0 = StreamOutObserver(obsstep, &step2realtime);
 
-  const Observer auto obs1 = TimeObserver(obsstep, dataset, maxchunk, &step2dimlesstime);
+  const Observer auto obs1 = TimeObserver(obsstep, dataset, store, maxchunk, &step2dimlesstime);
 
-  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, maxchunk);
+  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, store, maxchunk);
 
   return obssd >> obs1 >> obs0;
 }
 
-template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps,
-                       SimpleDataset<Store> &dataset) {
+template <typename Dataset, typename Store>
+inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset &dataset,
+                       Store &store) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
   const MoveSupersInDomain movesupers(create_movement(gbxmaps));
-  const Observer auto obs(create_observer(config, tsteps, dataset));
+  const Observer auto obs = create_observer(config, tsteps, dataset, store);
 
   return SDMMethods(couplstep, gbxmaps, microphys, movesupers, obs);
 }
@@ -166,7 +166,7 @@ int main(int argc, char *argv[]) {
     auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
-    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+    const SDMMethods sdm = create_sdm(config, tsteps, dataset, store);
 
     /* Create coupldyn solver and coupling between coupldyn and SDM */
     const CoupledDynamics auto coupldyn = NullDynamics(tsteps.get_couplstep());

--- a/examples/boxmodelcollisions/lowlist/src/main_lowlistcolls.cpp
+++ b/examples/boxmodelcollisions/lowlist/src/main_lowlistcolls.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 28th May 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,7 +28,7 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_movement.hpp"
@@ -95,7 +95,7 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
 
 template <typename Store>
 inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                Dataset<Store> &dataset, const int maxchunk) {
+                                                SimpleDataset<Store> &dataset, const int maxchunk) {
   CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
   CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
   CollectDataForDataset<Store> auto radius = CollectRadius(dataset, maxchunk);
@@ -107,7 +107,7 @@ inline Observer auto create_superdrops_observer(const unsigned int interval,
 
 template <typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset<Store> &dataset) {
+                                     SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
 
@@ -121,7 +121,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 }
 
 template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       SimpleDataset<Store> &dataset) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
@@ -162,7 +163,7 @@ int main(int argc, char *argv[]) {
 
     /* Create Xarray dataset wit Zarr backend for writing output data to a store */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = Dataset(store);
+    auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));

--- a/examples/boxmodelcollisions/szakallurbich/src/main_szakallurbichcolls.cpp
+++ b/examples/boxmodelcollisions/szakallurbich/src/main_szakallurbichcolls.cpp
@@ -29,7 +29,6 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_movement.hpp"
@@ -60,6 +59,7 @@
 #include "superdrops/microphysicalprocess.hpp"
 #include "superdrops/motion.hpp"
 #include "zarr/fsstore.hpp"
+#include "zarr/simple_dataset.hpp"
 
 template <GridboxMaps GbxMaps>
 inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
@@ -94,41 +94,41 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
   return colls;
 }
 
-template <typename Store>
-inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                SimpleDataset<Store> &dataset, const int maxchunk) {
-  CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
-  CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
-  CollectDataForDataset<Store> auto radius = CollectRadius(dataset, maxchunk);
-  CollectDataForDataset<Store> auto msol = CollectMsol(dataset, maxchunk);
+template <typename Dataset, typename Store>
+inline Observer auto create_superdrops_observer(const unsigned int interval, Dataset &dataset,
+                                                Store &store, const int maxchunk) {
+  CollectDataForDataset<Dataset> auto sdid = CollectSdId(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto xi = CollectXi(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto radius = CollectRadius(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto msol = CollectMsol(dataset, maxchunk);
 
   const auto collect_sddata = msol >> radius >> xi >> sdid;
-  return SuperdropsObserver(interval, dataset, maxchunk, collect_sddata);
+  return SuperdropsObserver(interval, dataset, store, maxchunk, collect_sddata);
 }
 
-template <typename Store>
+template <typename Dataset, typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     SimpleDataset<Store> &dataset) {
+                                     Dataset &dataset, Store &store) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
 
   const Observer auto obs0 = StreamOutObserver(obsstep, &step2realtime);
 
-  const Observer auto obs1 = TimeObserver(obsstep, dataset, maxchunk, &step2dimlesstime);
+  const Observer auto obs1 = TimeObserver(obsstep, dataset, store, maxchunk, &step2dimlesstime);
 
-  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, maxchunk);
+  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, store, maxchunk);
 
   return obssd >> obs1 >> obs0;
 }
 
-template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps,
-                       SimpleDataset<Store> &dataset) {
+template <typename Dataset, typename Store>
+inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset &dataset,
+                       Store &store) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
   const MoveSupersInDomain movesupers(create_movement(gbxmaps));
-  const Observer auto obs(create_observer(config, tsteps, dataset));
+  const Observer auto obs = create_observer(config, tsteps, dataset, store);
 
   return SDMMethods(couplstep, gbxmaps, microphys, movesupers, obs);
 }
@@ -167,7 +167,7 @@ int main(int argc, char *argv[]) {
     auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
-    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+    const SDMMethods sdm = create_sdm(config, tsteps, dataset, store);
 
     /* Create coupldyn solver and coupling between coupldyn and SDM */
     const CoupledDynamics auto coupldyn = NullDynamics(tsteps.get_couplstep());

--- a/examples/boxmodelcollisions/szakallurbich/src/main_szakallurbichcolls.cpp
+++ b/examples/boxmodelcollisions/szakallurbich/src/main_szakallurbichcolls.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 28th May 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -29,7 +29,7 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_movement.hpp"
@@ -96,7 +96,7 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
 
 template <typename Store>
 inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                Dataset<Store> &dataset, const int maxchunk) {
+                                                SimpleDataset<Store> &dataset, const int maxchunk) {
   CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
   CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
   CollectDataForDataset<Store> auto radius = CollectRadius(dataset, maxchunk);
@@ -108,7 +108,7 @@ inline Observer auto create_superdrops_observer(const unsigned int interval,
 
 template <typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset<Store> &dataset) {
+                                     SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
 
@@ -122,7 +122,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 }
 
 template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       SimpleDataset<Store> &dataset) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
@@ -163,7 +164,7 @@ int main(int argc, char *argv[]) {
 
     /* Create Xarray dataset wit Zarr backend for writing output data to a store */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = Dataset(store);
+    auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));

--- a/examples/boxmodelcollisions/testikstraub/src/main_testikstraubcolls.cpp
+++ b/examples/boxmodelcollisions/testikstraub/src/main_testikstraubcolls.cpp
@@ -30,7 +30,6 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_movement.hpp"
@@ -61,6 +60,7 @@
 #include "superdrops/microphysicalprocess.hpp"
 #include "superdrops/motion.hpp"
 #include "zarr/fsstore.hpp"
+#include "zarr/simple_dataset.hpp"
 
 template <GridboxMaps GbxMaps>
 inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
@@ -93,41 +93,41 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
   return colls;
 }
 
-template <typename Store>
-inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                SimpleDataset<Store> &dataset, const int maxchunk) {
-  CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
-  CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
-  CollectDataForDataset<Store> auto radius = CollectRadius(dataset, maxchunk);
-  CollectDataForDataset<Store> auto msol = CollectMsol(dataset, maxchunk);
+template <typename Dataset, typename Store>
+inline Observer auto create_superdrops_observer(const unsigned int interval, Dataset &dataset,
+                                                Store &store, const int maxchunk) {
+  CollectDataForDataset<Dataset> auto sdid = CollectSdId(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto xi = CollectXi(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto radius = CollectRadius(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto msol = CollectMsol(dataset, maxchunk);
 
   const auto collect_sddata = msol >> radius >> xi >> sdid;
-  return SuperdropsObserver(interval, dataset, maxchunk, collect_sddata);
+  return SuperdropsObserver(interval, dataset, store, maxchunk, collect_sddata);
 }
 
-template <typename Store>
+template <typename Dataset, typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     SimpleDataset<Store> &dataset) {
+                                     Dataset &dataset, Store &store) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
 
   const Observer auto obs0 = StreamOutObserver(obsstep, &step2realtime);
 
-  const Observer auto obs1 = TimeObserver(obsstep, dataset, maxchunk, &step2dimlesstime);
+  const Observer auto obs1 = TimeObserver(obsstep, dataset, store, maxchunk, &step2dimlesstime);
 
-  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, maxchunk);
+  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, store, maxchunk);
 
   return obssd >> obs1 >> obs0;
 }
 
-template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps,
-                       SimpleDataset<Store> &dataset) {
+template <typename Dataset, typename Store>
+inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset &dataset,
+                       Store &store) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
   const MoveSupersInDomain movesupers(create_movement(gbxmaps));
-  const Observer auto obs(create_observer(config, tsteps, dataset));
+  const Observer auto obs = create_observer(config, tsteps, dataset, store);
 
   return SDMMethods(couplstep, gbxmaps, microphys, movesupers, obs);
 }
@@ -166,7 +166,7 @@ int main(int argc, char *argv[]) {
     auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
-    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+    const SDMMethods sdm = create_sdm(config, tsteps, dataset, store);
 
     /* Create coupldyn solver and coupling between coupldyn and SDM */
     const CoupledDynamics auto coupldyn = NullDynamics(tsteps.get_couplstep());

--- a/examples/boxmodelcollisions/testikstraub/src/main_testikstraubcolls.cpp
+++ b/examples/boxmodelcollisions/testikstraub/src/main_testikstraubcolls.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 28th May 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -30,7 +30,7 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_movement.hpp"
@@ -95,7 +95,7 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
 
 template <typename Store>
 inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                Dataset<Store> &dataset, const int maxchunk) {
+                                                SimpleDataset<Store> &dataset, const int maxchunk) {
   CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
   CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
   CollectDataForDataset<Store> auto radius = CollectRadius(dataset, maxchunk);
@@ -107,7 +107,7 @@ inline Observer auto create_superdrops_observer(const unsigned int interval,
 
 template <typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset<Store> &dataset) {
+                                     SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
 
@@ -121,7 +121,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 }
 
 template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       SimpleDataset<Store> &dataset) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
@@ -162,7 +163,7 @@ int main(int argc, char *argv[]) {
 
     /* Create Xarray dataset wit Zarr backend for writing output data to a store */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = Dataset(store);
+    auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));

--- a/examples/bubble3d/src/main_bubble3d.cpp
+++ b/examples/bubble3d/src/main_bubble3d.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Thursday 19th June 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,7 +28,7 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_motion.hpp"
@@ -98,7 +98,7 @@ inline auto create_movement(const unsigned int motionstep, const CartesianMaps &
 
 template <typename Store>
 inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                Dataset<Store> &dataset, const int maxchunk) {
+                                                SimpleDataset<Store> &dataset, const int maxchunk) {
   CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
   CollectDataForDataset<Store> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
   CollectDataForDataset<Store> auto coord3 = CollectCoord3(dataset, maxchunk);
@@ -115,7 +115,7 @@ inline Observer auto create_superdrops_observer(const unsigned int interval,
 
 template <typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset<Store> &dataset) {
+                                     SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
   const auto ngbxs = config.get_ngbxs();
@@ -134,7 +134,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 }
 
 template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       SimpleDataset<Store> &dataset) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
@@ -175,7 +176,7 @@ int main(int argc, char *argv[]) {
 
     /* Create Xarray dataset wit Zarr backend for writing output data to a store */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = Dataset(store);
+    auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));

--- a/examples/bubble3d/src/main_bubble3d.cpp
+++ b/examples/bubble3d/src/main_bubble3d.cpp
@@ -28,16 +28,15 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_motion.hpp"
 #include "cartesiandomain/movement/cartesian_movement.hpp"
+#include "configuration/config.hpp"
 #include "coupldyn_yac/yac_cartesian_dynamics.hpp"
 #include "coupldyn_yac/yac_comms.hpp"
 #include "gridboxes/boundary_conditions.hpp"
 #include "gridboxes/gridboxmaps.hpp"
-#include "configuration/config.hpp"
 #include "initialise/init_all_supers_from_binary.hpp"
 #include "initialise/initgbxsnull.hpp"
 #include "initialise/initialconditions.hpp"
@@ -55,6 +54,7 @@
 #include "superdrops/microphysicalprocess.hpp"
 #include "superdrops/motion.hpp"
 #include "zarr/fsstore.hpp"
+#include "zarr/simple_dataset.hpp"
 
 inline CoupledDynamics auto create_coupldyn(const Config &config, const CartesianMaps &gbxmaps,
                                             const unsigned int couplstep,
@@ -96,51 +96,51 @@ inline auto create_movement(const unsigned int motionstep, const CartesianMaps &
   return cartesian_movement(gbxmaps, motion, boundary_conditions);
 }
 
-template <typename Store>
-inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                SimpleDataset<Store> &dataset, const int maxchunk) {
-  CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
-  CollectDataForDataset<Store> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
-  CollectDataForDataset<Store> auto coord3 = CollectCoord3(dataset, maxchunk);
-  CollectDataForDataset<Store> auto coord1 = CollectCoord1(dataset, maxchunk);
-  CollectDataForDataset<Store> auto coord2 = CollectCoord2(dataset, maxchunk);
-  CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
-  CollectDataForDataset<Store> auto radius = CollectRadius(dataset, maxchunk);
-  CollectDataForDataset<Store> auto msol = CollectMsol(dataset, maxchunk);
+template <typename Dataset, typename Store>
+inline Observer auto create_superdrops_observer(const unsigned int interval, Dataset &dataset,
+                                                Store &store, const int maxchunk) {
+  CollectDataForDataset<Dataset> auto sdid = CollectSdId(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto coord3 = CollectCoord3(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto coord1 = CollectCoord1(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto coord2 = CollectCoord2(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto xi = CollectXi(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto radius = CollectRadius(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto msol = CollectMsol(dataset, maxchunk);
 
-  const auto collect_data =
+  const auto collect_sddata =
       coord2 >> coord1 >> coord3 >> sdgbxindex >> sdid >> xi >> radius >> msol;
-  return SuperdropsObserver(interval, dataset, maxchunk, collect_data);
+  return SuperdropsObserver(interval, dataset, store, maxchunk, collect_sddata);
 }
 
-template <typename Store>
+template <typename Dataset, typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     SimpleDataset<Store> &dataset) {
+                                     Dataset &dataset, Store &store) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
   const auto ngbxs = config.get_ngbxs();
 
   const Observer auto obs0 = StreamOutObserver(obsstep, &step2realtime);
 
-  const Observer auto obs1 = TimeObserver(obsstep, dataset, maxchunk, &step2dimlesstime);
+  const Observer auto obs1 = TimeObserver(obsstep, dataset, store, maxchunk, &step2dimlesstime);
 
-  const Observer auto obs2 = GbxindexObserver(dataset, maxchunk, ngbxs);
+  const Observer auto obs2 = GbxindexObserver(dataset, store, maxchunk, ngbxs);
 
   const Observer auto obs3 = StateObserver(obsstep, dataset, maxchunk, ngbxs);
 
-  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, maxchunk);
+  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, store, maxchunk);
 
   return obssd >> obs3 >> obs2 >> obs1 >> obs0;
 }
 
-template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps,
-                       SimpleDataset<Store> &dataset) {
+template <typename Dataset, typename Store>
+inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset &dataset,
+                       Store &store) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
   const MoveSupersInDomain movesupers(create_movement(tsteps.get_motionstep(), gbxmaps));
-  const Observer auto obs(create_observer(config, tsteps, dataset));
+  const Observer auto obs = create_observer(config, tsteps, dataset, store);
 
   return SDMMethods(couplstep, gbxmaps, microphys, movesupers, obs);
 }
@@ -179,7 +179,7 @@ int main(int argc, char *argv[]) {
     auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
-    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+    const SDMMethods sdm = create_sdm(config, tsteps, dataset, store);
 
     /* Solver of dynamics coupled to CLEO SDM */
     CoupledDynamics auto coupldyn(

--- a/examples/constthermo2d/src/main_const2d.cpp
+++ b/examples/constthermo2d/src/main_const2d.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 28th May 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,7 +28,7 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_motion.hpp"
@@ -121,7 +121,7 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
 
 template <typename Store>
 inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                Dataset<Store> &dataset, const int maxchunk) {
+                                                SimpleDataset<Store> &dataset, const int maxchunk) {
   CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
   CollectDataForDataset<Store> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
   CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
@@ -136,7 +136,7 @@ inline Observer auto create_superdrops_observer(const unsigned int interval,
 
 template <typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset<Store> &dataset) {
+                                     SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
   const auto ngbxs = config.get_ngbxs();
@@ -157,7 +157,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 }
 
 template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       SimpleDataset<Store> &dataset) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
@@ -198,7 +199,7 @@ int main(int argc, char *argv[]) {
 
     /* Create Xarray dataset wit Zarr backend for writing output data to a store */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = Dataset(store);
+    auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));

--- a/examples/constthermo2d/src/main_const2d.cpp
+++ b/examples/constthermo2d/src/main_const2d.cpp
@@ -28,7 +28,6 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_motion.hpp"
@@ -60,6 +59,7 @@
 #include "superdrops/motion.hpp"
 #include "superdrops/terminalvelocity.hpp"
 #include "zarr/fsstore.hpp"
+#include "zarr/simple_dataset.hpp"
 
 inline CoupledDynamics auto create_coupldyn(const Config &config, const CartesianMaps &gbxmaps,
                                             const unsigned int couplstep,
@@ -119,51 +119,51 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
   return cond >> colls;
 }
 
-template <typename Store>
-inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                SimpleDataset<Store> &dataset, const int maxchunk) {
-  CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
-  CollectDataForDataset<Store> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
-  CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
-  CollectDataForDataset<Store> auto radius = CollectRadius(dataset, maxchunk);
-  CollectDataForDataset<Store> auto msol = CollectMsol(dataset, maxchunk);
-  CollectDataForDataset<Store> auto coord3 = CollectCoord3(dataset, maxchunk);
-  CollectDataForDataset<Store> auto coord1 = CollectCoord1(dataset, maxchunk);
+template <typename Dataset, typename Store>
+inline Observer auto create_superdrops_observer(const unsigned int interval, Dataset &dataset,
+                                                Store &store, const int maxchunk) {
+  CollectDataForDataset<Dataset> auto sdid = CollectSdId(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto xi = CollectXi(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto radius = CollectRadius(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto msol = CollectMsol(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto coord3 = CollectCoord3(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto coord1 = CollectCoord1(dataset, maxchunk);
 
   const auto collect_sddata = coord1 >> coord3 >> msol >> radius >> xi >> sdgbxindex >> sdid;
-  return SuperdropsObserver(interval, dataset, maxchunk, collect_sddata);
+  return SuperdropsObserver(interval, dataset, store, maxchunk, collect_sddata);
 }
 
-template <typename Store>
+template <typename Dataset, typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     SimpleDataset<Store> &dataset) {
+                                     Dataset &dataset, Store &store) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
   const auto ngbxs = config.get_ngbxs();
 
   const Observer auto obs0 = StreamOutObserver(obsstep * 10, &step2realtime);
 
-  const Observer auto obs1 = TimeObserver(obsstep, dataset, maxchunk, &step2dimlesstime);
+  const Observer auto obs1 = TimeObserver(obsstep, dataset, store, maxchunk, &step2dimlesstime);
 
-  const Observer auto obs2 = GbxindexObserver(dataset, maxchunk, ngbxs);
+  const Observer auto obs2 = GbxindexObserver(dataset, store, maxchunk, ngbxs);
 
   const Observer auto obs3 = NsupersObserver(obsstep, dataset, maxchunk, ngbxs);
 
-  const Observer auto obs4 = MassMomentsObserver(obsstep, dataset, maxchunk, ngbxs);
+  const Observer auto obs4 = MassMomentsObserver(obsstep, dataset, store, maxchunk, ngbxs);
 
-  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, maxchunk);
+  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, store, maxchunk);
 
   return obssd >> obs4 >> obs3 >> obs2 >> obs1 >> obs0;
 }
 
-template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps,
-                       SimpleDataset<Store> &dataset) {
+template <typename Dataset, typename Store>
+inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset &dataset,
+                       Store &store) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
   const MoveSupersInDomain movesupers(create_movement(tsteps.get_motionstep(), gbxmaps));
-  const Observer auto obs(create_observer(config, tsteps, dataset));
+  const Observer auto obs = create_observer(config, tsteps, dataset, store);
 
   return SDMMethods(couplstep, gbxmaps, microphys, movesupers, obs);
 }
@@ -202,7 +202,7 @@ int main(int argc, char *argv[]) {
     auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
-    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+    const SDMMethods sdm = create_sdm(config, tsteps, dataset, store);
 
     /* Solver of dynamics coupled to CLEO SDM */
     CoupledDynamics auto coupldyn(

--- a/examples/divfreemotion/src/main_divfree2d.cpp
+++ b/examples/divfreemotion/src/main_divfree2d.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 28th May 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,7 +28,7 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_motion.hpp"
@@ -97,7 +97,7 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
 
 template <typename Store>
 inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                Dataset<Store> &dataset, const int maxchunk) {
+                                                SimpleDataset<Store> &dataset, const int maxchunk) {
   CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
   CollectDataForDataset<Store> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
   CollectDataForDataset<Store> auto coord3 = CollectCoord3(dataset, maxchunk);
@@ -109,7 +109,7 @@ inline Observer auto create_superdrops_observer(const unsigned int interval,
 
 template <typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset<Store> &dataset) {
+                                     SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
 
@@ -123,7 +123,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 }
 
 template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       SimpleDataset<Store> &dataset) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
@@ -164,7 +165,7 @@ int main(int argc, char *argv[]) {
 
     /* Create Xarray dataset wit Zarr backend for writing output data to a store */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = Dataset(store);
+    auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));

--- a/examples/eurec4a1d/src/main_eurec4a1d.cpp
+++ b/examples/eurec4a1d/src/main_eurec4a1d.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 28th May 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -29,7 +29,7 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/add_supers_at_domain_top.hpp"
@@ -120,7 +120,7 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
 
 template <typename Store>
 inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                Dataset<Store> &dataset, const int maxchunk) {
+                                                SimpleDataset<Store> &dataset, const int maxchunk) {
   CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
   CollectDataForDataset<Store> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
   CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
@@ -133,8 +133,9 @@ inline Observer auto create_superdrops_observer(const unsigned int interval,
 }
 
 template <typename Store>
-inline Observer auto create_gridboxes_observer(const unsigned int interval, Dataset<Store> &dataset,
-                                               const int maxchunk, const size_t ngbxs) {
+inline Observer auto create_gridboxes_observer(const unsigned int interval,
+                                               SimpleDataset<Store> &dataset, const int maxchunk,
+                                               const size_t ngbxs) {
   const CollectDataForDataset<Store> auto thermo = CollectThermo(dataset, maxchunk, ngbxs);
   const CollectDataForDataset<Store> auto wvel =
       CollectWindVariable<Store, WvelFunc>(dataset, WvelFunc{}, "wvel", maxchunk, ngbxs);
@@ -147,7 +148,7 @@ inline Observer auto create_gridboxes_observer(const unsigned int interval, Data
 
 template <typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset<Store> &dataset) {
+                                     SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
   const auto ngbxs = config.get_ngbxs();
@@ -172,7 +173,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 }
 
 template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       SimpleDataset<Store> &dataset) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
@@ -213,7 +215,7 @@ int main(int argc, char *argv[]) {
 
     /* Create Xarray dataset wit Zarr backend for writing output data to a store */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = Dataset(store);
+    auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));

--- a/examples/eurec4a1d/src/main_eurec4a1d.cpp
+++ b/examples/eurec4a1d/src/main_eurec4a1d.cpp
@@ -29,7 +29,6 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/add_supers_at_domain_top.hpp"
@@ -66,6 +65,7 @@
 #include "superdrops/motion.hpp"
 #include "superdrops/terminalvelocity.hpp"
 #include "zarr/fsstore.hpp"
+#include "zarr/simple_dataset.hpp"
 
 inline CoupledDynamics auto create_coupldyn(const Config &config, const CartesianMaps &gbxmaps,
                                             const unsigned int couplstep,
@@ -118,68 +118,68 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
   return coal >> cond;
 }
 
-template <typename Store>
-inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                SimpleDataset<Store> &dataset, const int maxchunk) {
-  CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
-  CollectDataForDataset<Store> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
-  CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
-  CollectDataForDataset<Store> auto radius = CollectRadius(dataset, maxchunk);
-  CollectDataForDataset<Store> auto msol = CollectMsol(dataset, maxchunk);
-  CollectDataForDataset<Store> auto coord3 = CollectCoord3(dataset, maxchunk);
+template <typename Dataset, typename Store>
+inline Observer auto create_superdrops_observer(const unsigned int interval, Dataset &dataset,
+                                                Store &store, const int maxchunk) {
+  CollectDataForDataset<Dataset> auto sdid = CollectSdId(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto xi = CollectXi(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto radius = CollectRadius(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto msol = CollectMsol(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto coord3 = CollectCoord3(dataset, maxchunk);
 
   const auto collect_sddata = coord3 >> msol >> radius >> xi >> sdgbxindex >> sdid;
-  return SuperdropsObserver(interval, dataset, maxchunk, collect_sddata);
+  return SuperdropsObserver(interval, dataset, store, maxchunk, collect_sddata);
 }
 
-template <typename Store>
-inline Observer auto create_gridboxes_observer(const unsigned int interval,
-                                               SimpleDataset<Store> &dataset, const int maxchunk,
-                                               const size_t ngbxs) {
-  const CollectDataForDataset<Store> auto thermo = CollectThermo(dataset, maxchunk, ngbxs);
-  const CollectDataForDataset<Store> auto wvel =
-      CollectWindVariable<Store, WvelFunc>(dataset, WvelFunc{}, "wvel", maxchunk, ngbxs);
+template <typename Dataset>
+inline Observer auto create_gridboxes_observer(const unsigned int interval, Dataset &dataset,
+                                               const int maxchunk, const size_t ngbxs) {
+  const CollectDataForDataset<Dataset> auto thermo = CollectThermo(dataset, maxchunk, ngbxs);
+  const CollectDataForDataset<Dataset> auto wvel =
+      CollectWindVariable<Dataset, WvelFunc>(dataset, WvelFunc{}, "wvel", maxchunk, ngbxs);
 
-  const CollectDataForDataset<Store> auto nsupers = CollectNsupers(dataset, maxchunk, ngbxs);
+  const CollectDataForDataset<Dataset> auto nsupers = CollectNsupers(dataset, maxchunk, ngbxs);
 
-  const CollectDataForDataset<Store> auto collect_gbxdata = nsupers >> wvel >> thermo;
+  const CollectDataForDataset<Dataset> auto collect_gbxdata = nsupers >> wvel >> thermo;
   return WriteToDatasetObserver(interval, dataset, collect_gbxdata);
 }
 
-template <typename Store>
+template <typename Dataset, typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     SimpleDataset<Store> &dataset) {
+                                     Dataset &dataset, Store &store) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
   const auto ngbxs = config.get_ngbxs();
 
   const Observer auto obs0 = StreamOutObserver(realtime2step(240), &step2realtime);
 
-  const Observer auto obs1 = TimeObserver(obsstep, dataset, maxchunk, &step2dimlesstime);
+  const Observer auto obs1 = TimeObserver(obsstep, dataset, store, maxchunk, &step2dimlesstime);
 
-  const Observer auto obs2 = GbxindexObserver(dataset, maxchunk, ngbxs);
+  const Observer auto obs2 = GbxindexObserver(dataset, store, maxchunk, ngbxs);
 
-  const Observer auto obs3 = MassMomentsObserver(obsstep, dataset, maxchunk, ngbxs);
+  const Observer auto obs3 = MassMomentsObserver(obsstep, dataset, store, maxchunk, ngbxs);
 
-  const Observer auto obs4 = MassMomentsRaindropsObserver(obsstep, dataset, maxchunk, ngbxs);
+  const Observer auto obs4 = MassMomentsRaindropsObserver(obsstep, dataset, store, maxchunk, ngbxs);
 
   const Observer auto obsgbx = create_gridboxes_observer(obsstep, dataset, maxchunk, ngbxs);
 
-  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, maxchunk);
+  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, store, maxchunk);
 
-  const Observer auto obs_cond = MonitorCondensationObserver(obsstep, dataset, maxchunk, ngbxs);
+  const Observer auto obs_cond =
+      MonitorCondensationObserver(obsstep, dataset, store, maxchunk, ngbxs);
 
   return obs_cond >> obssd >> obsgbx >> obs4 >> obs3 >> obs2 >> obs1 >> obs0;
 }
 
-template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps,
-                       SimpleDataset<Store> &dataset) {
+template <typename Dataset, typename Store>
+inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset &dataset,
+                       Store &store) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
   const MoveSupersInDomain movesupers(create_movement(config, tsteps, gbxmaps));
-  const Observer auto obs(create_observer(config, tsteps, dataset));
+  const Observer auto obs = create_observer(config, tsteps, dataset, store);
 
   return SDMMethods(couplstep, gbxmaps, microphys, movesupers, obs);
 }
@@ -218,7 +218,7 @@ int main(int argc, char *argv[]) {
     auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
-    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+    const SDMMethods sdm = create_sdm(config, tsteps, dataset, store);
 
     /* Solver of dynamics coupled to CLEO SDM */
     CoupledDynamics auto coupldyn(

--- a/examples/fromfile/src/main_fromfile.cpp
+++ b/examples/fromfile/src/main_fromfile.cpp
@@ -166,7 +166,7 @@ int main(int argc, char *argv[]) {
 
     /* Create Xarray dataset wit Zarr backend for writing output data to a store */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = CollectiveDataset(store);
+    auto dataset = CollectiveDataset<FSStore, CartesianDecomposition>(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm = create_sdm(config, tsteps, dataset, store);

--- a/examples/fromfile/src/main_fromfile.cpp
+++ b/examples/fromfile/src/main_fromfile.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 28th May 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -100,7 +100,8 @@ inline auto create_movement(const unsigned int motionstep, const CartesianMaps &
 
 template <typename Store>
 inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                Dataset<Store> &dataset, const int maxchunk) {
+                                                CollectiveDataset<Store> &dataset,
+                                                const int maxchunk) {
   CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
   CollectDataForDataset<Store> auto coord3 = CollectCoord3(dataset, maxchunk);
   CollectDataForDataset<Store> auto coord1 = CollectCoord1(dataset, maxchunk);
@@ -112,7 +113,8 @@ inline Observer auto create_superdrops_observer(const unsigned int interval,
 
 template <typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset<Store> &dataset, const CartesianMaps &gbxmaps) {
+                                     CollectiveDataset<Store> &dataset,
+                                     const CartesianMaps &gbxmaps) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
   const auto ngbxs = gbxmaps.get_local_ngridboxes();
@@ -132,7 +134,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 }
 
 template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       CollectiveDataset<Store> &dataset) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
@@ -165,7 +168,7 @@ int main(int argc, char *argv[]) {
 
     /* Create Xarray dataset wit Zarr backend for writing output data to a store */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = Dataset(store);
+    auto dataset = CollectiveDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));

--- a/examples/fromfile_irreg/src/main_fromfile_irreg.cpp
+++ b/examples/fromfile_irreg/src/main_fromfile_irreg.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 28th May 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,7 +28,7 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_motion.hpp"
@@ -98,7 +98,7 @@ inline auto create_movement(const unsigned int motionstep, const CartesianMaps &
 
 template <typename Store>
 inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                Dataset<Store> &dataset, const int maxchunk) {
+                                                SimpleDataset<Store> &dataset, const int maxchunk) {
   CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
   CollectDataForDataset<Store> auto coord3 = CollectCoord3(dataset, maxchunk);
   CollectDataForDataset<Store> auto coord1 = CollectCoord1(dataset, maxchunk);
@@ -110,7 +110,7 @@ inline Observer auto create_superdrops_observer(const unsigned int interval,
 
 template <typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset<Store> &dataset) {
+                                     SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
   const auto ngbxs = config.get_ngbxs();
@@ -129,7 +129,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 }
 
 template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       SimpleDataset<Store> &dataset) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
@@ -170,7 +171,7 @@ int main(int argc, char *argv[]) {
 
     /* Create Xarray dataset wit Zarr backend for writing output data to a store */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = Dataset(store);
+    auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));

--- a/examples/rainshaft1d/src/main_rshaft1d.cpp
+++ b/examples/rainshaft1d/src/main_rshaft1d.cpp
@@ -28,7 +28,6 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_motion.hpp"
@@ -60,6 +59,7 @@
 #include "superdrops/motion.hpp"
 #include "superdrops/terminalvelocity.hpp"
 #include "zarr/fsstore.hpp"
+#include "zarr/simple_dataset.hpp"
 
 inline CoupledDynamics auto create_coupldyn(const Config &config, const CartesianMaps &gbxmaps,
                                             const unsigned int couplstep,
@@ -108,50 +108,50 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
   return cond >> colls;
 }
 
-template <typename Store>
-inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                SimpleDataset<Store> &dataset, const int maxchunk) {
-  CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
-  CollectDataForDataset<Store> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
-  CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
-  CollectDataForDataset<Store> auto radius = CollectRadius(dataset, maxchunk);
-  CollectDataForDataset<Store> auto msol = CollectMsol(dataset, maxchunk);
-  CollectDataForDataset<Store> auto coord3 = CollectCoord3(dataset, maxchunk);
+template <typename Dataset, typename Store>
+inline Observer auto create_superdrops_observer(const unsigned int interval, Dataset &dataset,
+                                                Store &store, const int maxchunk) {
+  CollectDataForDataset<Dataset> auto sdid = CollectSdId(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto xi = CollectXi(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto radius = CollectRadius(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto msol = CollectMsol(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto coord3 = CollectCoord3(dataset, maxchunk);
 
   const auto collect_sddata = coord3 >> msol >> radius >> xi >> sdgbxindex >> sdid;
-  return SuperdropsObserver(interval, dataset, maxchunk, collect_sddata);
+  return SuperdropsObserver(interval, dataset, store, maxchunk, collect_sddata);
 }
 
-template <typename Store>
+template <typename Dataset, typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     SimpleDataset<Store> &dataset) {
+                                     Dataset &dataset, Store &store) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
   const auto ngbxs = config.get_ngbxs();
 
   const Observer auto obs0 = StreamOutObserver(obsstep * 10, &step2realtime);
 
-  const Observer auto obs1 = TimeObserver(obsstep, dataset, maxchunk, &step2dimlesstime);
+  const Observer auto obs1 = TimeObserver(obsstep, dataset, store, maxchunk, &step2dimlesstime);
 
-  const Observer auto obs2 = GbxindexObserver(dataset, maxchunk, ngbxs);
+  const Observer auto obs2 = GbxindexObserver(dataset, store, maxchunk, ngbxs);
 
   const Observer auto obs3 = NsupersObserver(obsstep, dataset, maxchunk, ngbxs);
 
-  const Observer auto obs4 = MassMomentsObserver(obsstep, dataset, maxchunk, ngbxs);
+  const Observer auto obs4 = MassMomentsObserver(obsstep, dataset, store, maxchunk, ngbxs);
 
-  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, maxchunk);
+  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, store, maxchunk);
 
   return obssd >> obs4 >> obs3 >> obs2 >> obs1 >> obs0;
 }
 
-template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps,
-                       SimpleDataset<Store> &dataset) {
+template <typename Dataset, typename Store>
+inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset &dataset,
+                       Store &store) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
   const MoveSupersInDomain movesupers(create_movement(tsteps.get_motionstep(), gbxmaps));
-  const Observer auto obs(create_observer(config, tsteps, dataset));
+  const Observer auto obs = create_observer(config, tsteps, dataset, store);
 
   return SDMMethods(couplstep, gbxmaps, microphys, movesupers, obs);
 }
@@ -190,7 +190,7 @@ int main(int argc, char *argv[]) {
     auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
-    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+    const SDMMethods sdm = create_sdm(config, tsteps, dataset, store);
 
     /* Solver of dynamics coupled to CLEO SDM */
     CoupledDynamics auto coupldyn(

--- a/examples/rainshaft1d/src/main_rshaft1d.cpp
+++ b/examples/rainshaft1d/src/main_rshaft1d.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 28th May 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,7 +28,7 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_motion.hpp"
@@ -110,7 +110,7 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
 
 template <typename Store>
 inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                Dataset<Store> &dataset, const int maxchunk) {
+                                                SimpleDataset<Store> &dataset, const int maxchunk) {
   CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
   CollectDataForDataset<Store> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
   CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
@@ -124,7 +124,7 @@ inline Observer auto create_superdrops_observer(const unsigned int interval,
 
 template <typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset<Store> &dataset) {
+                                     SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
   const auto ngbxs = config.get_ngbxs();
@@ -145,7 +145,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 }
 
 template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       SimpleDataset<Store> &dataset) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
@@ -186,7 +187,7 @@ int main(int argc, char *argv[]) {
 
     /* Create Xarray dataset wit Zarr backend for writing output data to a store */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = Dataset(store);
+    auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));

--- a/examples/speedtest/src/main_spdtest.cpp
+++ b/examples/speedtest/src/main_spdtest.cpp
@@ -28,7 +28,6 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_motion.hpp"
@@ -62,6 +61,7 @@
 #include "superdrops/motion.hpp"
 #include "superdrops/terminalvelocity.hpp"
 #include "zarr/fsstore.hpp"
+#include "zarr/simple_dataset.hpp"
 
 inline CoupledDynamics auto create_coupldyn(const Config &config, const CartesianMaps &gbxmaps,
                                             const unsigned int couplstep,
@@ -122,77 +122,77 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
   return colls >> cond;
 }
 
-template <typename Store>
-inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                SimpleDataset<Store> &dataset, const int maxchunk) {
-  CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
-  CollectDataForDataset<Store> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
-  CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
-  CollectDataForDataset<Store> auto radius = CollectRadius(dataset, maxchunk);
-  CollectDataForDataset<Store> auto msol = CollectMsol(dataset, maxchunk);
-  CollectDataForDataset<Store> auto coord3 = CollectCoord3(dataset, maxchunk);
-  CollectDataForDataset<Store> auto coord1 = CollectCoord1(dataset, maxchunk);
-  CollectDataForDataset<Store> auto coord2 = CollectCoord2(dataset, maxchunk);
+template <typename Dataset, typename Store>
+inline Observer auto create_superdrops_observer(const unsigned int interval, Dataset &dataset,
+                                                Store &store, const int maxchunk) {
+  CollectDataForDataset<Dataset> auto sdid = CollectSdId(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto xi = CollectXi(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto radius = CollectRadius(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto msol = CollectMsol(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto coord3 = CollectCoord3(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto coord1 = CollectCoord1(dataset, maxchunk);
+  CollectDataForDataset<Dataset> auto coord2 = CollectCoord2(dataset, maxchunk);
 
   const auto collect_sddata =
       coord2 >> coord1 >> coord3 >> msol >> radius >> xi >> sdgbxindex >> sdid;
-  return SuperdropsObserver(interval, dataset, maxchunk, collect_sddata);
+  return SuperdropsObserver(interval, dataset, store, maxchunk, collect_sddata);
 }
 
-template <typename Store>
-inline Observer auto create_gridboxes_observer(const unsigned int interval,
-                                               SimpleDataset<Store> &dataset, const int maxchunk,
-                                               const size_t ngbxs) {
-  const CollectDataForDataset<Store> auto thermo = CollectThermo(dataset, maxchunk, ngbxs);
-  const CollectDataForDataset<Store> auto windvel = CollectWindVel(dataset, maxchunk, ngbxs);
-  const CollectDataForDataset<Store> auto nsupers = CollectNsupers(dataset, maxchunk, ngbxs);
+template <typename Dataset>
+inline Observer auto create_gridboxes_observer(const unsigned int interval, Dataset &dataset,
+                                               const int maxchunk, const size_t ngbxs) {
+  const CollectDataForDataset<Dataset> auto thermo = CollectThermo(dataset, maxchunk, ngbxs);
+  const CollectDataForDataset<Dataset> auto windvel = CollectWindVel(dataset, maxchunk, ngbxs);
+  const CollectDataForDataset<Dataset> auto nsupers = CollectNsupers(dataset, maxchunk, ngbxs);
 
-  const CollectDataForDataset<Store> auto collect_gbxdata = nsupers >> windvel >> thermo;
+  const CollectDataForDataset<Dataset> auto collect_gbxdata = nsupers >> windvel >> thermo;
   return WriteToDatasetObserver(interval, dataset, collect_gbxdata);
 }
 
-template <typename Store>
-inline Observer auto create_bulk_observer(const unsigned int interval,
-                                          SimpleDataset<Store> &dataset, const int maxchunk,
-                                          const size_t ngbxs) {
-  const Observer auto obs2 = TimeObserver(interval, dataset, maxchunk, &step2dimlesstime);
+template <typename Dataset, typename Store>
+inline Observer auto create_bulk_observer(const unsigned int interval, Dataset &dataset,
+                                          Store &store, const int maxchunk, const size_t ngbxs) {
+  const Observer auto obs2 = TimeObserver(interval, dataset, store, maxchunk, &step2dimlesstime);
 
-  const Observer auto obs3 = GbxindexObserver(dataset, maxchunk, ngbxs);
+  const Observer auto obs3 = GbxindexObserver(dataset, store, maxchunk, ngbxs);
 
-  const Observer auto obs4 = TotNsupersObserver(interval, dataset, maxchunk);
+  const Observer auto obs4 = TotNsupersObserver(interval, dataset, store, maxchunk);
 
-  const Observer auto obs5 = MassMomentsObserver(interval, dataset, maxchunk, ngbxs);
+  const Observer auto obs5 = MassMomentsObserver(interval, dataset, store, maxchunk, ngbxs);
 
-  const Observer auto obs6 = MassMomentsRaindropsObserver(interval, dataset, maxchunk, ngbxs);
+  const Observer auto obs6 =
+      MassMomentsRaindropsObserver(interval, dataset, store, maxchunk, ngbxs);
 
   const Observer auto obsgbx = create_gridboxes_observer(interval, dataset, maxchunk, ngbxs);
 
   return obsgbx >> obs6 >> obs5 >> obs4 >> obs3 >> obs2;
 }
 
-template <typename Store>
+template <typename Dataset, typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     SimpleDataset<Store> &dataset) {
+                                     Dataset &dataset, Store &store) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
 
   const Observer auto obs0 = StreamOutObserver(obsstep * 10, &step2realtime);
 
-  const Observer auto obsblk = create_bulk_observer(obsstep, dataset, maxchunk, config.get_ngbxs());
+  const Observer auto obsblk =
+      create_bulk_observer(obsstep, dataset, store, maxchunk, config.get_ngbxs());
 
-  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, maxchunk);
+  const Observer auto obssd = create_superdrops_observer(obsstep, dataset, store, maxchunk);
 
   return obssd >> obsblk >> obs0;
 }
 
-template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps,
-                       SimpleDataset<Store> &dataset) {
+template <typename Dataset, typename Store>
+inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset &dataset,
+                       Store &store) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
   const MoveSupersInDomain movesupers(create_movement(tsteps.get_motionstep(), gbxmaps));
-  const Observer auto obs(create_observer(config, tsteps, dataset));
+  const Observer auto obs = create_observer(config, tsteps, dataset, store);
 
   return SDMMethods(couplstep, gbxmaps, microphys, movesupers, obs);
 }
@@ -231,7 +231,7 @@ int main(int argc, char *argv[]) {
     auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
-    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+    const SDMMethods sdm = create_sdm(config, tsteps, dataset, store);
 
     /* Solver of dynamics coupled to CLEO SDM */
     CoupledDynamics auto coupldyn(

--- a/examples/speedtest/src/main_spdtest.cpp
+++ b/examples/speedtest/src/main_spdtest.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 28th May 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,7 +28,7 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_motion.hpp"
@@ -124,7 +124,7 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
 
 template <typename Store>
 inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                Dataset<Store> &dataset, const int maxchunk) {
+                                                SimpleDataset<Store> &dataset, const int maxchunk) {
   CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
   CollectDataForDataset<Store> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
   CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
@@ -140,8 +140,9 @@ inline Observer auto create_superdrops_observer(const unsigned int interval,
 }
 
 template <typename Store>
-inline Observer auto create_gridboxes_observer(const unsigned int interval, Dataset<Store> &dataset,
-                                               const int maxchunk, const size_t ngbxs) {
+inline Observer auto create_gridboxes_observer(const unsigned int interval,
+                                               SimpleDataset<Store> &dataset, const int maxchunk,
+                                               const size_t ngbxs) {
   const CollectDataForDataset<Store> auto thermo = CollectThermo(dataset, maxchunk, ngbxs);
   const CollectDataForDataset<Store> auto windvel = CollectWindVel(dataset, maxchunk, ngbxs);
   const CollectDataForDataset<Store> auto nsupers = CollectNsupers(dataset, maxchunk, ngbxs);
@@ -151,8 +152,9 @@ inline Observer auto create_gridboxes_observer(const unsigned int interval, Data
 }
 
 template <typename Store>
-inline Observer auto create_bulk_observer(const unsigned int interval, Dataset<Store> &dataset,
-                                          const int maxchunk, const size_t ngbxs) {
+inline Observer auto create_bulk_observer(const unsigned int interval,
+                                          SimpleDataset<Store> &dataset, const int maxchunk,
+                                          const size_t ngbxs) {
   const Observer auto obs2 = TimeObserver(interval, dataset, maxchunk, &step2dimlesstime);
 
   const Observer auto obs3 = GbxindexObserver(dataset, maxchunk, ngbxs);
@@ -170,7 +172,7 @@ inline Observer auto create_bulk_observer(const unsigned int interval, Dataset<S
 
 template <typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset<Store> &dataset) {
+                                     SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
 
@@ -184,7 +186,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 }
 
 template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       SimpleDataset<Store> &dataset) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
@@ -225,7 +228,7 @@ int main(int argc, char *argv[]) {
 
     /* Create zarr store for writing output to storage */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = Dataset(store);
+    auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));

--- a/libs/observers/collect_data_for_dataset.hpp
+++ b/libs/observers/collect_data_for_dataset.hpp
@@ -28,8 +28,9 @@
 #include <concepts>
 
 #include "../kokkosaliases.hpp"
-#include "zarr/collective_dataset.hpp"
 #include "zarr/fsstore.hpp"
+// #include "zarr/collective_dataset.hpp" # WIP to >> operator for colective dataset
+#include "zarr/simple_dataset.hpp"
 
 /**
  * @brief Concept for CollectDataForDataset is all types that have functions for creating a functor
@@ -38,28 +39,27 @@
  *
  * @tparam CDD The type that satisfies the CollectDataForDataset concept.
  */
-template <typename CDD, typename Store>
-concept CollectDataForDataset =
-    requires(CDD cdd, const SimpleDataset<Store> &ds, const viewd_constgbx d_gbxs,
-             const subviewd_constsupers d_supers, const size_t sz) {
-      { cdd.get_functor(d_gbxs, d_supers) };
-      { cdd.reallocate_views(sz) } -> std::same_as<void>;
-      { cdd.write_to_arrays(ds) } -> std::same_as<void>;
-      { cdd.write_to_ragged_arrays(ds) } -> std::same_as<void>;
-      { cdd.write_arrayshapes(ds) } -> std::same_as<void>;
-      { cdd.write_ragged_arrayshapes(ds) } -> std::same_as<void>;
-    };
+template <typename CDD, typename Dataset>
+concept CollectDataForDataset = requires(CDD cdd, const Dataset &ds, const viewd_constgbx d_gbxs,
+                                         const subviewd_constsupers d_supers, const size_t sz) {
+  { cdd.get_functor(d_gbxs, d_supers) };
+  { cdd.reallocate_views(sz) } -> std::same_as<void>;
+  { cdd.template write_to_arrays<Dataset>(ds) } -> std::same_as<void>;
+  { cdd.template write_to_ragged_arrays<Dataset>(ds) } -> std::same_as<void>;
+  { cdd.template write_arrayshapes<Dataset>(ds) } -> std::same_as<void>;
+  { cdd.template write_ragged_arrayshapes<Dataset>(ds) } -> std::same_as<void>;
+};
 
 /**
  * @brief struct is a new CollectDataForDataset formed from the combination of two structs that
- * also satisfy the CollectDataForDataset concept given the same Store type. Struct that does the
+ * also satisfy the CollectDataForDataset concept given the same Dataset type. Struct that does the
  * actions of the original structs in sequence.
  *
  * @tparam CollectData1 The type of the first CollectDataForDataset.
  * @tparam CollectData2 The type of the second CollectDataForDataset.
  */
-template <typename Store, CollectDataForDataset<Store> CollectData1,
-          CollectDataForDataset<Store> CollectData2>
+template <typename Dataset, CollectDataForDataset<Dataset> CollectData1,
+          CollectDataForDataset<Dataset> CollectData2>
 struct CombinedCollectDataForDataset {
  private:
   CollectData1 a; /**< The first instance of type of CollectDataForDataset. */
@@ -101,22 +101,26 @@ struct CombinedCollectDataForDataset {
     return Functor(a, b, d_gbxs, d_supers);
   }
 
-  void write_to_arrays(const SimpleDataset<Store> &dataset) const {
+  template <typename D = Dataset>
+  void write_to_arrays(const D &dataset) const {
     a.write_to_arrays(dataset);
     b.write_to_arrays(dataset);
   }
 
-  void write_to_ragged_arrays(const SimpleDataset<Store> &dataset) const {
+  template <typename D = Dataset>
+  void write_to_ragged_arrays(const D &dataset) const {
     a.write_to_ragged_arrays(dataset);
     b.write_to_ragged_arrays(dataset);
   }
 
-  void write_arrayshapes(const SimpleDataset<Store> &dataset) const {
+  template <typename D = Dataset>
+  void write_arrayshapes(const D &dataset) const {
     a.write_arrayshapes(dataset);
     b.write_arrayshapes(dataset);
   }
 
-  void write_ragged_arrayshapes(const SimpleDataset<Store> &dataset) const {
+  template <typename D = Dataset>
+  void write_ragged_arrayshapes(const D &dataset) const {
     a.write_ragged_arrayshapes(dataset);
     b.write_ragged_arrayshapes(dataset);
   }
@@ -130,18 +134,17 @@ struct CombinedCollectDataForDataset {
 /**
  * @brief Overloaded operator >> to combine two CollectDataForDataset instances into a new one.
  *
- * @param a First CollectDataForDataset with Store=FSStore.
- * @param b Second CollectDataForDataset with Store=FSStore.
+ * @param a First CollectDataForDataset with Dataset=SimpleDataset<FSStore>.
+ * @param b Second CollectDataForDataset with Dataset=SimpleDataset<FSStore>.
  * @return CombinedCollectDataForDataset<Obs1, Obs2> Combined CollectDataForDataset.
  */
-
-template <CollectDataForDataset<FSStore> CollectData1, CollectDataForDataset<FSStore> CollectData2>
+template <CollectDataForDataset<SimpleDataset<FSStore>> CollectData1,
+          CollectDataForDataset<SimpleDataset<FSStore>> CollectData2>
 auto operator>>(const CollectData1 a, const CollectData2 b) {
-  return CombinedCollectDataForDataset<FSStore, CollectData1, CollectData2>(a, b);
+  return CombinedCollectDataForDataset<SimpleDataset<FSStore>, CollectData1, CollectData2>(a, b);
 }
 
 /* struct satifying CollectDataForDataset and does nothing */
-template <typename Store>
 struct NullCollectDataForDataset {
  public:
   struct Functor {
@@ -156,13 +159,17 @@ struct NullCollectDataForDataset {
     return Functor{};
   }
 
-  void write_to_arrays(const SimpleDataset<Store> &dataset) const {}
+  template <typename Dataset>
+  void write_to_arrays(const Dataset &dataset) const {}
 
-  void write_to_ragged_arrays(const SimpleDataset<Store> &dataset) const {}
+  template <typename Dataset>
+  void write_to_ragged_arrays(const Dataset &dataset) const {}
 
-  void write_arrayshapes(const SimpleDataset<Store> &dataset) const {}
+  template <typename Dataset>
+  void write_arrayshapes(const Dataset &dataset) const {}
 
-  void write_ragged_arrayshapes(const SimpleDataset<Store> &dataset) const {}
+  template <typename Dataset>
+  void write_ragged_arrayshapes(const Dataset &dataset) const {}
 
   void reallocate_views(const size_t sz) const {}
 };

--- a/libs/observers/collect_data_for_dataset.hpp
+++ b/libs/observers/collect_data_for_dataset.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Tuesday 21st May 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -40,7 +40,7 @@
  */
 template <typename CDD, typename Store>
 concept CollectDataForDataset =
-    requires(CDD cdd, const Dataset<Store> &ds, const viewd_constgbx d_gbxs,
+    requires(CDD cdd, const SimpleDataset<Store> &ds, const viewd_constgbx d_gbxs,
              const subviewd_constsupers d_supers, const size_t sz) {
       { cdd.get_functor(d_gbxs, d_supers) };
       { cdd.reallocate_views(sz) } -> std::same_as<void>;
@@ -101,22 +101,22 @@ struct CombinedCollectDataForDataset {
     return Functor(a, b, d_gbxs, d_supers);
   }
 
-  void write_to_arrays(const Dataset<Store> &dataset) const {
+  void write_to_arrays(const SimpleDataset<Store> &dataset) const {
     a.write_to_arrays(dataset);
     b.write_to_arrays(dataset);
   }
 
-  void write_to_ragged_arrays(const Dataset<Store> &dataset) const {
+  void write_to_ragged_arrays(const SimpleDataset<Store> &dataset) const {
     a.write_to_ragged_arrays(dataset);
     b.write_to_ragged_arrays(dataset);
   }
 
-  void write_arrayshapes(const Dataset<Store> &dataset) const {
+  void write_arrayshapes(const SimpleDataset<Store> &dataset) const {
     a.write_arrayshapes(dataset);
     b.write_arrayshapes(dataset);
   }
 
-  void write_ragged_arrayshapes(const Dataset<Store> &dataset) const {
+  void write_ragged_arrayshapes(const SimpleDataset<Store> &dataset) const {
     a.write_ragged_arrayshapes(dataset);
     b.write_ragged_arrayshapes(dataset);
   }
@@ -156,13 +156,13 @@ struct NullCollectDataForDataset {
     return Functor{};
   }
 
-  void write_to_arrays(const Dataset<Store> &dataset) const {}
+  void write_to_arrays(const SimpleDataset<Store> &dataset) const {}
 
-  void write_to_ragged_arrays(const Dataset<Store> &dataset) const {}
+  void write_to_ragged_arrays(const SimpleDataset<Store> &dataset) const {}
 
-  void write_arrayshapes(const Dataset<Store> &dataset) const {}
+  void write_arrayshapes(const SimpleDataset<Store> &dataset) const {}
 
-  void write_ragged_arrayshapes(const Dataset<Store> &dataset) const {}
+  void write_ragged_arrayshapes(const SimpleDataset<Store> &dataset) const {}
 
   void reallocate_views(const size_t sz) const {}
 };

--- a/libs/observers/create_massmoments_arrays.hpp
+++ b/libs/observers/create_massmoments_arrays.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 21st June 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -52,7 +52,7 @@
  * @return XarrayZarrArray<Store, T> The created XarrayZarrArray.
  */
 template <typename Store, typename T>
-XarrayZarrArray<Store, T> create_massmoment_xarray(const Dataset<Store> &dataset,
+XarrayZarrArray<Store, T> create_massmoment_xarray(const SimpleDataset<Store> &dataset,
                                                    const std::string_view name,
                                                    const std::string_view units,
                                                    const double scale_factor, const size_t maxchunk,
@@ -76,7 +76,7 @@ XarrayZarrArray<Store, T> create_massmoment_xarray(const Dataset<Store> &dataset
  * @return XarrayZarrArray<Store, uint64_t> The created XarrayZarrArray (for the 0th mass moment).
  */
 template <typename Store>
-XarrayZarrArray<Store, uint64_t> create_massmom0_xarray(const Dataset<Store> &dataset,
+XarrayZarrArray<Store, uint64_t> create_massmom0_xarray(const SimpleDataset<Store> &dataset,
                                                         const std::string_view name,
                                                         const size_t maxchunk, const size_t ngbxs) {
   const auto units = std::string_view("");
@@ -97,7 +97,7 @@ XarrayZarrArray<Store, uint64_t> create_massmom0_xarray(const Dataset<Store> &da
  * @return XarrayZarrArray<Store, uint64_t> The created XarrayZarrArray (for the 1st mass moment).
  */
 template <typename Store>
-XarrayZarrArray<Store, float> create_massmom1_xarray(const Dataset<Store> &dataset,
+XarrayZarrArray<Store, float> create_massmom1_xarray(const SimpleDataset<Store> &dataset,
                                                      const std::string_view name,
                                                      const size_t maxchunk, const size_t ngbxs) {
   const auto units = std::string_view("g");
@@ -120,7 +120,7 @@ XarrayZarrArray<Store, float> create_massmom1_xarray(const Dataset<Store> &datas
  * @return XarrayZarrArray<Store, uint64_t> The created XarrayZarrArray (for the 2nd mass moment).
  */
 template <typename Store>
-XarrayZarrArray<Store, float> create_massmom2_xarray(const Dataset<Store> &dataset,
+XarrayZarrArray<Store, float> create_massmom2_xarray(const SimpleDataset<Store> &dataset,
                                                      const std::string_view name,
                                                      const size_t maxchunk, const size_t ngbxs) {
   const auto units = std::string_view("g^2");

--- a/libs/observers/create_massmoments_arrays.hpp
+++ b/libs/observers/create_massmoments_arrays.hpp
@@ -36,14 +36,15 @@
 #include "observers/observers.hpp"
 #include "observers/write_to_dataset_observer.hpp"
 #include "superdrops/superdrop.hpp"
-#include "zarr/collective_dataset.hpp"
 
 /**
  * @brief Creates an XarrayZarrArray for storing the mass moments of each gridbox in a dataset.
  *
+ * @tparam Dataset The type of dataset.
  * @tparam Store The type of data store in the dataset.
  * @tparam T The type of the mass moment data to store in the XarrayZarrArray.
  * @param dataset The dataset where the XarrayZarrArray will be created.
+ * @param store The store the dataset writes to.
  * @param name The name of the Xarray.
  * @param units The units of the mass moment data.
  * @param scale_factor The scale factor for the data.
@@ -51,8 +52,8 @@
  * @param ngbxs The number of gridboxes.
  * @return XarrayZarrArray<Store, T> The created XarrayZarrArray.
  */
-template <typename Store, typename T>
-XarrayZarrArray<Store, T> create_massmoment_xarray(const SimpleDataset<Store> &dataset,
+template <typename Dataset, typename Store, typename T>
+XarrayZarrArray<Store, T> create_massmoment_xarray(const Dataset &dataset, Store &store,
                                                    const std::string_view name,
                                                    const std::string_view units,
                                                    const double scale_factor, const size_t maxchunk,
@@ -68,19 +69,22 @@ XarrayZarrArray<Store, T> create_massmoment_xarray(const SimpleDataset<Store> &d
  * Calls create_massmoment_xarray for data that is represented by 8 byte unsigned integers with
  * no units and is called "name" - e.g. the 0th mass moment of a droplet distribution.
  *
+ * @tparam Dataset The type of dataset.
  * @tparam Store The type of data store in the dataset.
  * @param dataset The dataset where the XarrayZarrArray will be created.
+ * @param store The store the dataset writes to.
  * @param name The name of the (0th mass moment) Xarray.
  * @param maxchunk The maximum chunk size for the Xarray (number of elements).
  * @param ngbxs The number of gridboxes.
  * @return XarrayZarrArray<Store, uint64_t> The created XarrayZarrArray (for the 0th mass moment).
  */
-template <typename Store>
-XarrayZarrArray<Store, uint64_t> create_massmom0_xarray(const SimpleDataset<Store> &dataset,
+template <typename Dataset, typename Store>
+XarrayZarrArray<Store, uint64_t> create_massmom0_xarray(const Dataset &dataset, Store &store,
                                                         const std::string_view name,
                                                         const size_t maxchunk, const size_t ngbxs) {
   const auto units = std::string_view("");
-  return create_massmoment_xarray<Store, uint64_t>(dataset, name, units, 1, maxchunk, ngbxs);
+  return create_massmoment_xarray<Dataset, Store, uint64_t>(dataset, store, name, units, 1,
+                                                            maxchunk, ngbxs);
 }
 
 /**
@@ -89,21 +93,23 @@ XarrayZarrArray<Store, uint64_t> create_massmom0_xarray(const SimpleDataset<Stor
  * Calls create_massmoment_xarray for data that is represented by 4 byte float with
  * units "g" and is called "name" - e.g. the 1st mass moment of a droplet distribution.
  *
+ * @tparam Dataset The type of dataset.
  * @tparam Store The type of data store in the dataset.
  * @param dataset The dataset where the XarrayZarrArray will be created.
+ * @param store The store the dataset writes to.
  * @param name The name of the (1st mass moment) Xarray.
  * @param maxchunk The maximum chunk size for the Xarray (number of elements).
  * @param ngbxs The number of gridboxes.
  * @return XarrayZarrArray<Store, uint64_t> The created XarrayZarrArray (for the 1st mass moment).
  */
-template <typename Store>
-XarrayZarrArray<Store, float> create_massmom1_xarray(const SimpleDataset<Store> &dataset,
+template <typename Dataset, typename Store>
+XarrayZarrArray<Store, float> create_massmom1_xarray(const Dataset &dataset, Store &store,
                                                      const std::string_view name,
                                                      const size_t maxchunk, const size_t ngbxs) {
   const auto units = std::string_view("g");
   constexpr auto scale_factor = dlc::MASS0grams;
-  return create_massmoment_xarray<Store, float>(dataset, name, units, scale_factor, maxchunk,
-                                                ngbxs);
+  return create_massmoment_xarray<Dataset, Store, float>(dataset, store, name, units, scale_factor,
+                                                         maxchunk, ngbxs);
 }
 
 /**
@@ -112,21 +118,23 @@ XarrayZarrArray<Store, float> create_massmom1_xarray(const SimpleDataset<Store> 
  * Calls create_massmoment_xarray for data that is represented by 4 byte float with
  * units "g^2" and is called "name" - e.g. the 2nd mass moment of a droplet distribution.
  *
+ * @tparam Dataset The type of dataset.
  * @tparam Store The type of data store in the dataset.
  * @param dataset The dataset where the XarrayZarrArray will be created.
+ * @param store The store the dataset writes to.
  * @param name The name of the (2nd mass moment) Xarray.
  * @param maxchunk The maximum chunk size for the Xarray (number of elements).
  * @param ngbxs The number of gridboxes.
  * @return XarrayZarrArray<Store, uint64_t> The created XarrayZarrArray (for the 2nd mass moment).
  */
-template <typename Store>
-XarrayZarrArray<Store, float> create_massmom2_xarray(const SimpleDataset<Store> &dataset,
+template <typename Dataset, typename Store>
+XarrayZarrArray<Store, float> create_massmom2_xarray(const Dataset &dataset, Store &store,
                                                      const std::string_view name,
                                                      const size_t maxchunk, const size_t ngbxs) {
   const auto units = std::string_view("g^2");
   constexpr auto scale_factor = dlc::MASS0grams * dlc::MASS0grams;
-  return create_massmoment_xarray<Store, float>(dataset, name, units, scale_factor, maxchunk,
-                                                ngbxs);
+  return create_massmoment_xarray<Dataset, Store, float>(dataset, store, name, units, scale_factor,
+                                                         maxchunk, ngbxs);
 }
 
 #endif  // LIBS_OBSERVERS_CREATE_MASSMOMENTS_ARRAYS_HPP_

--- a/libs/observers/gbxindex_observer.hpp
+++ b/libs/observers/gbxindex_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 21st June 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -70,7 +70,7 @@ struct GbxIndexFunctor {
 template <typename Store>
 class GbxindexObserver {
  private:
-  Dataset<Store> &dataset; /**< Dataset to write gridbox index data to. */
+  SimpleDataset<Store> &dataset; /**< Dataset to write gridbox index data to. */
   std::shared_ptr<XarrayZarrArray<Store, uint32_t>>
       xzarr_ptr; /**< Pointer to gridbox index array in dataset. */
 
@@ -97,7 +97,7 @@ class GbxindexObserver {
    * @param maxchunk Maximum number of elements in a chunk (1-D vector size).
    * @param ngbxs Number of gridboxes in final array.
    */
-  GbxindexObserver(Dataset<Store> &dataset, const size_t maxchunk, const size_t ngbxs)
+  GbxindexObserver(SimpleDataset<Store> &dataset, const size_t maxchunk, const size_t ngbxs)
       : dataset(dataset),
         xzarr_ptr(std::make_shared<XarrayZarrArray<Store, uint32_t>>(
             dataset.template create_coordinate_array<uint32_t>("gbxindex", "", 1, maxchunk,

--- a/libs/observers/gbxindex_observer.hpp
+++ b/libs/observers/gbxindex_observer.hpp
@@ -33,7 +33,6 @@
 #include "observers/observers.hpp"
 #include "superdrops/sdmmonitor.hpp"
 #include "zarr/buffer.hpp"
-#include "zarr/collective_dataset.hpp"
 #include "zarr/xarray_zarr_array.hpp"
 
 /**
@@ -65,12 +64,13 @@ struct GbxIndexFunctor {
 
 /* @class GbxindexObserver
  * @brief Observer to output gridbox indexes to a 1-D array as coordinate of an xarray dataset.
+ * @tparam Dataset Type of dataset.
  * @tparam Store Type of store for the dataset.
  */
-template <typename Store>
+template <typename Dataset, typename Store>
 class GbxindexObserver {
  private:
-  SimpleDataset<Store> &dataset; /**< Dataset to write gridbox index data to. */
+  Dataset &dataset; /**< Dataset to write gridbox index data to. */
   std::shared_ptr<XarrayZarrArray<Store, uint32_t>>
       xzarr_ptr; /**< Pointer to gridbox index array in dataset. */
 
@@ -94,10 +94,11 @@ class GbxindexObserver {
   /**
    * @brief Constructor for GbxindexObserver.
    * @param dataset Dataset to write gridbox index data to.
+   * @param store Store which dataset writes to.
    * @param maxchunk Maximum number of elements in a chunk (1-D vector size).
    * @param ngbxs Number of gridboxes in final array.
    */
-  GbxindexObserver(SimpleDataset<Store> &dataset, const size_t maxchunk, const size_t ngbxs)
+  GbxindexObserver(Dataset &dataset, Store &store, const size_t maxchunk, const size_t ngbxs)
       : dataset(dataset),
         xzarr_ptr(std::make_shared<XarrayZarrArray<Store, uint32_t>>(
             dataset.template create_coordinate_array<uint32_t>("gbxindex", "", 1, maxchunk,

--- a/libs/observers/generic_collect_data.hpp
+++ b/libs/observers/generic_collect_data.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Thursday 11th April 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -160,7 +160,7 @@ class GenericCollectData {
    *
    * @param dataset The dataset to write data to.
    */
-  void write_to_arrays(const Dataset<Store> &dataset) const {
+  void write_to_arrays(const SimpleDataset<Store> &dataset) const {
     Kokkos::deep_copy(ptr->h_data, ptr->d_data);
     dataset.write_to_array(ptr->xzarr, ptr->h_data);
   }
@@ -171,7 +171,7 @@ class GenericCollectData {
    *
    * @param dataset The dataset to write data to.
    */
-  void write_to_ragged_arrays(const Dataset<Store> &dataset) const {
+  void write_to_ragged_arrays(const SimpleDataset<Store> &dataset) const {
     Kokkos::deep_copy(ptr->h_data, ptr->d_data);
     dataset.write_to_ragged_array(ptr->xzarr, ptr->h_data);
   }
@@ -181,7 +181,7 @@ class GenericCollectData {
    *
    * @param dataset The dataset to write array shape to.
    */
-  void write_arrayshapes(const Dataset<Store> &dataset) const {
+  void write_arrayshapes(const SimpleDataset<Store> &dataset) const {
     dataset.write_arrayshape(ptr->xzarr);
   }
 
@@ -190,7 +190,7 @@ class GenericCollectData {
    *
    * @param dataset The dataset to write array shape to.
    */
-  void write_ragged_arrayshapes(const Dataset<Store> &dataset) const {
+  void write_ragged_arrayshapes(const SimpleDataset<Store> &dataset) const {
     dataset.write_ragged_arrayshape(ptr->xzarr);
   }
 };

--- a/libs/observers/generic_collect_data.hpp
+++ b/libs/observers/generic_collect_data.hpp
@@ -28,7 +28,6 @@
 
 #include "../kokkosaliases.hpp"
 #include "zarr/buffer.hpp"
-#include "zarr/collective_dataset.hpp"
 #include "zarr/xarray_zarr_array.hpp"
 
 /**
@@ -160,7 +159,8 @@ class GenericCollectData {
    *
    * @param dataset The dataset to write data to.
    */
-  void write_to_arrays(const SimpleDataset<Store> &dataset) const {
+  template <typename Dataset>
+  void write_to_arrays(const Dataset &dataset) const {
     Kokkos::deep_copy(ptr->h_data, ptr->d_data);
     dataset.write_to_array(ptr->xzarr, ptr->h_data);
   }
@@ -171,7 +171,8 @@ class GenericCollectData {
    *
    * @param dataset The dataset to write data to.
    */
-  void write_to_ragged_arrays(const SimpleDataset<Store> &dataset) const {
+  template <typename Dataset>
+  void write_to_ragged_arrays(const Dataset &dataset) const {
     Kokkos::deep_copy(ptr->h_data, ptr->d_data);
     dataset.write_to_ragged_array(ptr->xzarr, ptr->h_data);
   }
@@ -181,7 +182,8 @@ class GenericCollectData {
    *
    * @param dataset The dataset to write array shape to.
    */
-  void write_arrayshapes(const SimpleDataset<Store> &dataset) const {
+  template <typename Dataset>
+  void write_arrayshapes(const Dataset &dataset) const {
     dataset.write_arrayshape(ptr->xzarr);
   }
 
@@ -190,7 +192,8 @@ class GenericCollectData {
    *
    * @param dataset The dataset to write array shape to.
    */
-  void write_ragged_arrayshapes(const SimpleDataset<Store> &dataset) const {
+  template <typename Dataset>
+  void write_ragged_arrayshapes(const Dataset &dataset) const {
     dataset.write_ragged_arrayshape(ptr->xzarr);
   }
 };

--- a/libs/observers/massmoments_observer.hpp
+++ b/libs/observers/massmoments_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 24th March 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -210,7 +210,7 @@ struct CollectMassMoments {
    */
   template <typename T>
   void write_one_array(std::shared_ptr<XarrayAndViews<Store, T>> ptr,
-                       const Dataset<Store> &dataset) const {
+                       const SimpleDataset<Store> &dataset) const {
     Kokkos::deep_copy(ptr->h_data, ptr->d_data);
     dataset.write_to_array(ptr->xzarr, ptr->h_data);
   }
@@ -224,7 +224,7 @@ struct CollectMassMoments {
    */
   template <typename T>
   void write_one_arrayshape(std::shared_ptr<XarrayAndViews<Store, T>> ptr,
-                            const Dataset<Store> &dataset) const {
+                            const SimpleDataset<Store> &dataset) const {
     dataset.write_arrayshape(ptr->xzarr);
   }
 
@@ -312,7 +312,7 @@ struct CollectMassMoments {
    *
    * @param dataset The dataset to write data to.
    */
-  void write_to_arrays(const Dataset<Store> &dataset) const {
+  void write_to_arrays(const SimpleDataset<Store> &dataset) const {
     write_one_array(mom0_ptr, dataset);
     write_one_array(mom1_ptr, dataset);
     write_one_array(mom2_ptr, dataset);
@@ -323,7 +323,7 @@ struct CollectMassMoments {
    *
    * @param dataset The dataset to write data to.
    */
-  void write_arrayshapes(const Dataset<Store> &dataset) const {
+  void write_arrayshapes(const SimpleDataset<Store> &dataset) const {
     write_one_arrayshape(mom0_ptr, dataset);
     write_one_arrayshape(mom1_ptr, dataset);
     write_one_arrayshape(mom2_ptr, dataset);
@@ -334,14 +334,14 @@ struct CollectMassMoments {
    *
    * @param dataset The dataset to write data to.
    */
-  void write_to_ragged_arrays(const Dataset<Store> &dataset) const {}
+  void write_to_ragged_arrays(const SimpleDataset<Store> &dataset) const {}
 
   /**
    * @brief Null function to satisfy CollectDataForDataset concept.
    *
    * @param dataset The dataset to write data to.
    */
-  void write_ragged_arrayshapes(const Dataset<Store> &dataset) const {}
+  void write_ragged_arrayshapes(const SimpleDataset<Store> &dataset) const {}
 
   /**
    * @brief Null function to satisfy CollectDataForDataset concept.
@@ -364,8 +364,9 @@ struct CollectMassMoments {
  * observer concept.
  */
 template <typename Store>
-inline Observer auto MassMomentsObserver(const unsigned int interval, const Dataset<Store> &dataset,
-                                         const size_t maxchunk, const size_t ngbxs) {
+inline Observer auto MassMomentsObserver(const unsigned int interval,
+                                         const SimpleDataset<Store> &dataset, const size_t maxchunk,
+                                         const size_t ngbxs) {
   const auto xzarr_mom0 = create_massmom0_xarray(dataset, "massmom0", maxchunk, ngbxs);
   const auto xzarr_mom1 = create_massmom1_xarray(dataset, "massmom1", maxchunk, ngbxs);
   const auto xzarr_mom2 = create_massmom2_xarray(dataset, "massmom2", maxchunk, ngbxs);
@@ -393,7 +394,7 @@ inline Observer auto MassMomentsObserver(const unsigned int interval, const Data
  */
 template <typename Store>
 inline Observer auto MassMomentsRaindropsObserver(const unsigned int interval,
-                                                  const Dataset<Store> &dataset,
+                                                  const SimpleDataset<Store> &dataset,
                                                   const size_t maxchunk, const size_t ngbxs) {
   const auto xzarr_mom0 = create_massmom0_xarray(dataset, "massmom0_raindrops", maxchunk, ngbxs);
   const auto xzarr_mom1 = create_massmom1_xarray(dataset, "massmom1_raindrops", maxchunk, ngbxs);

--- a/libs/observers/nsupers_observer.hpp
+++ b/libs/observers/nsupers_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 21st June 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -74,7 +74,7 @@ struct NsupersFunc {
  * collecting the number of superdroplets in each gridbox.
  */
 template <typename Store>
-inline CollectDataForDataset<Store> auto CollectNsupers(const Dataset<Store> &dataset,
+inline CollectDataForDataset<Store> auto CollectNsupers(const SimpleDataset<Store> &dataset,
                                                         const size_t maxchunk, const size_t ngbxs) {
   const auto chunkshape = good2Dchunkshape(maxchunk, ngbxs);
   const auto dimnames = std::vector<std::string>{"time", "gbxindex"};
@@ -96,8 +96,9 @@ inline CollectDataForDataset<Store> auto CollectNsupers(const Dataset<Store> &da
  * @return Observer An observer instance for writing the number of superdroplets.
  */
 template <typename Store>
-inline Observer auto NsupersObserver(const unsigned int interval, const Dataset<Store> &dataset,
-                                     const size_t maxchunk, const size_t ngbxs) {
+inline Observer auto NsupersObserver(const unsigned int interval,
+                                     const SimpleDataset<Store> &dataset, const size_t maxchunk,
+                                     const size_t ngbxs) {
   return WriteToDatasetObserver(interval, dataset, CollectNsupers(dataset, maxchunk, ngbxs));
 }
 

--- a/libs/observers/nsupers_observer.hpp
+++ b/libs/observers/nsupers_observer.hpp
@@ -37,7 +37,6 @@
 #include "observers/collect_data_for_dataset.hpp"
 #include "observers/generic_collect_data.hpp"
 #include "observers/write_to_dataset_observer.hpp"
-#include "zarr/collective_dataset.hpp"
 
 /**
  * @brief Functor operator to perform a copy of the number of superdroplets in each gridbox
@@ -63,19 +62,21 @@ struct NsupersFunc {
 };
 
 /**
- * @brief Constructs type sastifying the CollectDataForDataset concept for a given Store (using an
+ * @brief Constructs type sastifying the CollectDataForDataset concept for a given Dataset (using an
  * instance of the GenericCollectData class) which writes the number of superdroplets in each
  * gridbox "nsupers" during the functor call.
  *
+ * @tparam Dataset Type of dataset
  * @param dataset The dataset to write nsupers to.
  * @param maxchunk The maximum chunk size (number of elements).
  * @param ngbxs The number of gridboxes.
- * @return CollectDataForDataset<Store> An instance satisfying the CollectDataForDataset concept for
- * collecting the number of superdroplets in each gridbox.
+ * @return CollectDataForDataset<Dataset> An instance satisfying the CollectDataForDataset concept
+ * for collecting the number of superdroplets in each gridbox.
  */
-template <typename Store>
-inline CollectDataForDataset<Store> auto CollectNsupers(const SimpleDataset<Store> &dataset,
-                                                        const size_t maxchunk, const size_t ngbxs) {
+template <typename Dataset>
+inline CollectDataForDataset<Dataset> auto CollectNsupers(const Dataset &dataset,
+                                                          const size_t maxchunk,
+                                                          const size_t ngbxs) {
   const auto chunkshape = good2Dchunkshape(maxchunk, ngbxs);
   const auto dimnames = std::vector<std::string>{"time", "gbxindex"};
   const auto xzarr =
@@ -88,17 +89,15 @@ inline CollectDataForDataset<Store> auto CollectNsupers(const SimpleDataset<Stor
  * at start of each observation timestep to an array with a constant observation timestep
  * "interval".
  *
- * @tparam Store Type of store for dataset.
  * @param interval Observation timestep.
  * @param dataset Dataset to write time data to.
  * @param maxchunk Maximum number of elements in a chunk (1-D vector size).
  * @param ngbxs The number of gridboxes.
  * @return Observer An observer instance for writing the number of superdroplets.
  */
-template <typename Store>
-inline Observer auto NsupersObserver(const unsigned int interval,
-                                     const SimpleDataset<Store> &dataset, const size_t maxchunk,
-                                     const size_t ngbxs) {
+template <typename Dataset>
+inline Observer auto NsupersObserver(const unsigned int interval, const Dataset &dataset,
+                                     const size_t maxchunk, const size_t ngbxs) {
   return WriteToDatasetObserver(interval, dataset, CollectNsupers(dataset, maxchunk, ngbxs));
 }
 

--- a/libs/observers/parallel_write_data.hpp
+++ b/libs/observers/parallel_write_data.hpp
@@ -27,7 +27,6 @@
 #include <concepts>
 
 #include "../kokkosaliases.hpp"
-#include "zarr/collective_dataset.hpp"
 
 namespace KCS = KokkosCleoSettings;
 
@@ -94,7 +93,7 @@ struct ParallelGridboxesTeamPolicyFunc {
  * that data to arrays in a dataset.
  *
  * This struct is responsible for collecting data from gridboxes and writing it to arrays in a
- * dataset with a given store.
+ * dataset.
  *
  * The ParallelGridboxesFunc type is a function-like object responsible for looping over
  * gridboxes in parallel (see ParallelGridboxesRangePolicyFunc or ParallelGridboxesTeamPolicyFunc).
@@ -102,17 +101,18 @@ struct ParallelGridboxesTeamPolicyFunc {
  * operator of the type it returns from its get_functor() call should be compatible with the
  * signature of the functor required by the ParallelGridboxesFunc type.
  *
- * @tparam Store The type of the data store in the dataset.
+ * @tparam Dataset The type dataset used to write data to a store.
  * @tparam ParallelGridboxesFunc Function-like object for call to loop over gridboxes.
  * @tparam CollectData Object satisfying the CollectDataForDataset concept for the given
- * store.
+ * dataset.
  */
-template <typename Store, typename ParallelGridboxesFunc, CollectDataForDataset<Store> CollectData>
+template <typename Dataset, typename ParallelGridboxesFunc,
+          CollectDataForDataset<Dataset> CollectData>
 class ParallelWriteGridboxes {
  private:
   ParallelGridboxesFunc
-      parallel_gridboxes_func;   /**< Function-like object for call to loop over gridboxes.*/
-  const SimpleDataset<Store> &dataset; /**< Dataset to write data to. */
+      parallel_gridboxes_func; /**< Function-like object for call to loop over gridboxes.*/
+  const Dataset &dataset;      /**< Dataset to write data to. */
   CollectData collect_data; /**< CollectData Object satisfying the CollectDataForDataset concept. */
 
  public:
@@ -123,8 +123,8 @@ class ParallelWriteGridboxes {
    * @param dataset The dataset to write data to.
    * @param collect_data The object satisfying the CollectDataForDataset concept to collect data.
    */
-  ParallelWriteGridboxes(ParallelGridboxesFunc parallel_gridboxes_func,
-                         const SimpleDataset<Store> &dataset, CollectData collect_data)
+  ParallelWriteGridboxes(ParallelGridboxesFunc parallel_gridboxes_func, const Dataset &dataset,
+                         CollectData collect_data)
       : parallel_gridboxes_func(parallel_gridboxes_func),
         dataset(dataset),
         collect_data(collect_data) {}
@@ -160,9 +160,9 @@ class ParallelWriteGridboxes {
  *
  * @tparam CRC The type that satisfies the CollectRaggedCount concept.
  */
-template <typename CRC, typename Store>
+template <typename CRC, typename Dataset>
 concept CollectRaggedCount =
-    requires(CRC crc, const SimpleDataset<Store> &ds, const subviewd_constsupers d_supers) {
+    requires(CRC crc, const Dataset &ds, const subviewd_constsupers d_supers) {
       { crc.write_to_array(ds, d_supers) } -> std::same_as<void>;
       { crc.write_arrayshape(ds) } -> std::same_as<void>;
     };
@@ -178,16 +178,16 @@ concept CollectRaggedCount =
  * the operator of the type it returns from its get_functor() call should be compatible with the
  * signature of the functor required by the Kokkos::parallel_for loop over superdroplets.
  *
- * @tparam Store The type of data store in the dataset.
+ * @tparam Dataset The type dataset used to write data to a store.
  * @tparam CollectData The object for collecting data satsifying the CollectDataForDataset concept.
  * @tparam RaggedCount The type of the function object for writing the ragged count variable in the
  * dataset satisfying the CollectRaggedCount concept.
  */
-template <typename Store, CollectDataForDataset<Store> CollectData,
-          CollectRaggedCount<Store> RaggedCount>
+template <typename Dataset, CollectDataForDataset<Dataset> CollectData,
+          CollectRaggedCount<Dataset> RaggedCount>
 class ParallelWriteSupers {
  private:
-  const SimpleDataset<Store> &dataset; /**< dataset to write data to */
+  const Dataset &dataset; /**< dataset to write data to */
   CollectData collect_data;
   /**< functions to collect data within loop over superdroplets and write to ragged array(s) */
   RaggedCount ragged_count; /**< functions to write ragged count variable to a dataset */
@@ -220,8 +220,7 @@ class ParallelWriteSupers {
    * @param ragged_count Object for writing the ragged count variable in the dataset satisfying the
    * CollectRaggedCount concept.
    */
-  ParallelWriteSupers(const SimpleDataset<Store> &dataset, CollectData collect_data,
-                      RaggedCount ragged_count)
+  ParallelWriteSupers(const Dataset &dataset, CollectData collect_data, RaggedCount ragged_count)
       : dataset(dataset), collect_data(collect_data), ragged_count(ragged_count) {}
 
   /**

--- a/libs/observers/parallel_write_data.hpp
+++ b/libs/observers/parallel_write_data.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Thursday 11th April 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -112,7 +112,7 @@ class ParallelWriteGridboxes {
  private:
   ParallelGridboxesFunc
       parallel_gridboxes_func;   /**< Function-like object for call to loop over gridboxes.*/
-  const Dataset<Store> &dataset; /**< Dataset to write data to. */
+  const SimpleDataset<Store> &dataset; /**< Dataset to write data to. */
   CollectData collect_data; /**< CollectData Object satisfying the CollectDataForDataset concept. */
 
  public:
@@ -124,7 +124,7 @@ class ParallelWriteGridboxes {
    * @param collect_data The object satisfying the CollectDataForDataset concept to collect data.
    */
   ParallelWriteGridboxes(ParallelGridboxesFunc parallel_gridboxes_func,
-                         const Dataset<Store> &dataset, CollectData collect_data)
+                         const SimpleDataset<Store> &dataset, CollectData collect_data)
       : parallel_gridboxes_func(parallel_gridboxes_func),
         dataset(dataset),
         collect_data(collect_data) {}
@@ -162,7 +162,7 @@ class ParallelWriteGridboxes {
  */
 template <typename CRC, typename Store>
 concept CollectRaggedCount =
-    requires(CRC crc, const Dataset<Store> &ds, const subviewd_constsupers d_supers) {
+    requires(CRC crc, const SimpleDataset<Store> &ds, const subviewd_constsupers d_supers) {
       { crc.write_to_array(ds, d_supers) } -> std::same_as<void>;
       { crc.write_arrayshape(ds) } -> std::same_as<void>;
     };
@@ -187,7 +187,7 @@ template <typename Store, CollectDataForDataset<Store> CollectData,
           CollectRaggedCount<Store> RaggedCount>
 class ParallelWriteSupers {
  private:
-  const Dataset<Store> &dataset; /**< dataset to write data to */
+  const SimpleDataset<Store> &dataset; /**< dataset to write data to */
   CollectData collect_data;
   /**< functions to collect data within loop over superdroplets and write to ragged array(s) */
   RaggedCount ragged_count; /**< functions to write ragged count variable to a dataset */
@@ -220,7 +220,7 @@ class ParallelWriteSupers {
    * @param ragged_count Object for writing the ragged count variable in the dataset satisfying the
    * CollectRaggedCount concept.
    */
-  ParallelWriteSupers(const Dataset<Store> &dataset, CollectData collect_data,
+  ParallelWriteSupers(const SimpleDataset<Store> &dataset, CollectData collect_data,
                       RaggedCount ragged_count)
       : dataset(dataset), collect_data(collect_data), ragged_count(ragged_count) {}
 

--- a/libs/observers/sdmmonitor/do_sdmmonitor_obs.hpp
+++ b/libs/observers/sdmmonitor/do_sdmmonitor_obs.hpp
@@ -31,7 +31,6 @@
 #include "../../kokkosaliases.hpp"
 #include "superdrops/sdmmonitor.hpp"
 #include "zarr/buffer.hpp"
-#include "zarr/simple_dataset.hpp"
 #include "zarr/xarray_zarr_array.hpp"
 
 /**
@@ -40,11 +39,11 @@
  * start of each timestep and write it to a Zarr array in an Xarray dataset.
  * @tparam Store Type of store for dataset.
  */
-template <typename Store, SDMMonitor SDMMo, typename T>
+template <typename Dataset, typename Store, SDMMonitor SDMMo, typename T>
 class DoSDMMonitorObs {
  private:
   using viewh_buffer = Buffer<T>::viewh_buffer;
-  SimpleDataset<Store> &dataset;                              /**< Dataset to write time data to. */
+  Dataset &dataset;                                     /**< Dataset to write time data to. */
   std::shared_ptr<XarrayZarrArray<Store, T>> xzarr_ptr; /**< Pointer to array in dataset. */
   SDMMo monitor;
 
@@ -66,7 +65,7 @@ class DoSDMMonitorObs {
    * @param xzarr_ptr Pointer to zarr array in xarray dataset.
    * @param monitor SDMMonitor to use.
    */
-  DoSDMMonitorObs(SimpleDataset<Store> &dataset,
+  DoSDMMonitorObs(Dataset &dataset, Store &store,
                   const std::shared_ptr<XarrayZarrArray<Store, T>> xzarr_ptr, const SDMMo monitor)
       : dataset(dataset), xzarr_ptr(xzarr_ptr), monitor(monitor) {}
 

--- a/libs/observers/sdmmonitor/do_sdmmonitor_obs.hpp
+++ b/libs/observers/sdmmonitor/do_sdmmonitor_obs.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Saturday 15th June 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -31,7 +31,7 @@
 #include "../../kokkosaliases.hpp"
 #include "superdrops/sdmmonitor.hpp"
 #include "zarr/buffer.hpp"
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "zarr/xarray_zarr_array.hpp"
 
 /**
@@ -44,7 +44,7 @@ template <typename Store, SDMMonitor SDMMo, typename T>
 class DoSDMMonitorObs {
  private:
   using viewh_buffer = Buffer<T>::viewh_buffer;
-  Dataset<Store> &dataset;                              /**< Dataset to write time data to. */
+  SimpleDataset<Store> &dataset;                              /**< Dataset to write time data to. */
   std::shared_ptr<XarrayZarrArray<Store, T>> xzarr_ptr; /**< Pointer to array in dataset. */
   SDMMo monitor;
 
@@ -66,7 +66,7 @@ class DoSDMMonitorObs {
    * @param xzarr_ptr Pointer to zarr array in xarray dataset.
    * @param monitor SDMMonitor to use.
    */
-  DoSDMMonitorObs(Dataset<Store> &dataset,
+  DoSDMMonitorObs(SimpleDataset<Store> &dataset,
                   const std::shared_ptr<XarrayZarrArray<Store, T>> xzarr_ptr, const SDMMo monitor)
       : dataset(dataset), xzarr_ptr(xzarr_ptr), monitor(monitor) {}
 

--- a/libs/observers/sdmmonitor/monitor_condensation_observer.hpp
+++ b/libs/observers/sdmmonitor/monitor_condensation_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 24th March 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -96,8 +96,8 @@ struct MonitorCondensation {
  */
 template <typename Store>
 inline Observer auto MonitorCondensationObserver(const unsigned int interval,
-                                                 Dataset<Store>& dataset, const size_t maxchunk,
-                                                 const size_t ngbxs) {
+                                                 SimpleDataset<Store>& dataset,
+                                                 const size_t maxchunk, const size_t ngbxs) {
   using Mo = MonitorCondensation;
   const auto name = std::string_view("massdelta_cond");
   const auto units = std::string_view("g");

--- a/libs/observers/sdmmonitor/monitor_condensation_observer.hpp
+++ b/libs/observers/sdmmonitor/monitor_condensation_observer.hpp
@@ -94,10 +94,10 @@ struct MonitorCondensation {
  * @param ngbxs The number of gridboxes.
  * @return Constructed type satisfying observer concept.
  */
-template <typename Store>
-inline Observer auto MonitorCondensationObserver(const unsigned int interval,
-                                                 SimpleDataset<Store>& dataset,
-                                                 const size_t maxchunk, const size_t ngbxs) {
+template <typename Dataset, typename Store>
+inline Observer auto MonitorCondensationObserver(const unsigned int interval, Dataset& dataset,
+                                                 Store& store, const size_t maxchunk,
+                                                 const size_t ngbxs) {
   using Mo = MonitorCondensation;
   const auto name = std::string_view("massdelta_cond");
   const auto units = std::string_view("g");
@@ -107,7 +107,8 @@ inline Observer auto MonitorCondensationObserver(const unsigned int interval,
   const auto xzarr_ptr = std::make_shared<XarrayZarrArray<Store, Mo::datatype>>(
       dataset.template create_array<Mo::datatype>(name, units, scale_factor, chunkshape, dimnames));
 
-  const auto do_obs = DoSDMMonitorObs<Store, Mo, Mo::datatype>(dataset, xzarr_ptr, Mo(ngbxs));
+  const auto do_obs =
+      DoSDMMonitorObs<Dataset, Store, Mo, Mo::datatype>(dataset, store, xzarr_ptr, Mo(ngbxs));
   return ConstTstepObserver(interval, do_obs);
 }
 

--- a/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
+++ b/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 24th July 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -36,7 +36,7 @@
 #include "observers/sdmmonitor/monitor_massmoments.hpp"
 #include "superdrops/sdmmonitor.hpp"
 #include "zarr/buffer.hpp"
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "zarr/xarray_zarr_array.hpp"
 
 template <typename Store>
@@ -48,7 +48,8 @@ struct MonitorMassMomentXarrays {
   XarrayZarrArray<Store, float> mom1_motion;       /**< 1st mass moment from motion Xarray */
   XarrayZarrArray<Store, float> mom2_motion;       /**< 2nd mass moment from motion Xarray */
 
-  MonitorMassMomentXarrays(const Dataset<Store> &dataset, const size_t maxchunk, const size_t ngbxs)
+  MonitorMassMomentXarrays(const SimpleDataset<Store> &dataset, const size_t maxchunk,
+                           const size_t ngbxs)
       : mom0_microphys(create_massmom0_xarray(dataset, "massmom0_microphys", maxchunk, ngbxs)),
         mom1_microphys(create_massmom1_xarray(dataset, "massmom1_microphys", maxchunk, ngbxs)),
         mom2_microphys(create_massmom2_xarray(dataset, "massmom2_microphys", maxchunk, ngbxs)),
@@ -66,7 +67,7 @@ struct MonitorRainMassMomentXarrays {
   XarrayZarrArray<Store, float> mom1_motion;       /**< 1st mass moment from motion Xarray */
   XarrayZarrArray<Store, float> mom2_motion;       /**< 2nd mass moment from motion Xarray */
 
-  MonitorRainMassMomentXarrays(const Dataset<Store> &dataset, const size_t maxchunk,
+  MonitorRainMassMomentXarrays(const SimpleDataset<Store> &dataset, const size_t maxchunk,
                                const size_t ngbxs)
       : mom0_microphys(
             create_massmom0_xarray(dataset, "massmom0_raindrops_microphys", maxchunk, ngbxs)),
@@ -91,7 +92,7 @@ struct MonitorRainMassMomentXarrays {
 template <typename Store, typename MonitorXarraysType, typename MonitorViewsType>
 class DoMonitorMassMomentsObs {
  private:
-  Dataset<Store> &dataset;                        /**< Dataset to write time data to. */
+  SimpleDataset<Store> &dataset;                  /**< Dataset to write time data to. */
   std::shared_ptr<MonitorXarraysType> xzarrs_ptr; /**< Pointer to arrays in dataset. */
   MonitorMassMoments<MonitorViewsType> monitor;
 
@@ -130,7 +131,7 @@ class DoMonitorMassMomentsObs {
    * @param maxchunk The maximum chunk size (number of elements) for Xarrays.
    * @param ngbxs The number of gridboxes.
    */
-  DoMonitorMassMomentsObs(Dataset<Store> &dataset, const size_t maxchunk, const size_t ngbxs)
+  DoMonitorMassMomentsObs(SimpleDataset<Store> &dataset, const size_t maxchunk, const size_t ngbxs)
       : dataset(dataset),
         xzarrs_ptr(std::make_shared<MonitorXarraysType>(dataset, maxchunk, ngbxs)),
         monitor(ngbxs) {}
@@ -195,8 +196,8 @@ class DoMonitorMassMomentsObs {
  */
 template <typename Store>
 inline Observer auto MonitorMassMomentsObserver(const unsigned int interval,
-                                                Dataset<Store> &dataset, const size_t maxchunk,
-                                                const size_t ngbxs) {
+                                                SimpleDataset<Store> &dataset,
+                                                const size_t maxchunk, const size_t ngbxs) {
   const auto do_obs =
       DoMonitorMassMomentsObs<Store, MonitorMassMomentXarrays<Store>, MonitorMassMomentViews>(
           dataset, maxchunk, ngbxs);
@@ -217,8 +218,8 @@ inline Observer auto MonitorMassMomentsObserver(const unsigned int interval,
  */
 template <typename Store>
 inline Observer auto MonitorRainMassMomentsObserver(const unsigned int interval,
-                                                    Dataset<Store> &dataset, const size_t maxchunk,
-                                                    const size_t ngbxs) {
+                                                    SimpleDataset<Store> &dataset,
+                                                    const size_t maxchunk, const size_t ngbxs) {
   const auto do_obs = DoMonitorMassMomentsObs<Store, MonitorRainMassMomentXarrays<Store>,
                                               MonitorRainMassMomentViews>(dataset, maxchunk, ngbxs);
   return ConstTstepObserver(interval, do_obs);

--- a/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
+++ b/libs/observers/sdmmonitor/monitor_massmoments_observer.hpp
@@ -36,10 +36,9 @@
 #include "observers/sdmmonitor/monitor_massmoments.hpp"
 #include "superdrops/sdmmonitor.hpp"
 #include "zarr/buffer.hpp"
-#include "zarr/simple_dataset.hpp"
 #include "zarr/xarray_zarr_array.hpp"
 
-template <typename Store>
+template <typename Dataset, typename Store>
 struct MonitorMassMomentXarrays {
   XarrayZarrArray<Store, uint64_t> mom0_microphys; /**< 0th mass moment from microphysics Xarray */
   XarrayZarrArray<Store, float> mom1_microphys;    /**< 1st mass moment from microphysics Xarray */
@@ -48,17 +47,20 @@ struct MonitorMassMomentXarrays {
   XarrayZarrArray<Store, float> mom1_motion;       /**< 1st mass moment from motion Xarray */
   XarrayZarrArray<Store, float> mom2_motion;       /**< 2nd mass moment from motion Xarray */
 
-  MonitorMassMomentXarrays(const SimpleDataset<Store> &dataset, const size_t maxchunk,
+  MonitorMassMomentXarrays(const Dataset &dataset, Store &store, const size_t maxchunk,
                            const size_t ngbxs)
-      : mom0_microphys(create_massmom0_xarray(dataset, "massmom0_microphys", maxchunk, ngbxs)),
-        mom1_microphys(create_massmom1_xarray(dataset, "massmom1_microphys", maxchunk, ngbxs)),
-        mom2_microphys(create_massmom2_xarray(dataset, "massmom2_microphys", maxchunk, ngbxs)),
-        mom0_motion(create_massmom0_xarray(dataset, "massmom0_motion", maxchunk, ngbxs)),
-        mom1_motion(create_massmom1_xarray(dataset, "massmom1_motion", maxchunk, ngbxs)),
-        mom2_motion(create_massmom2_xarray(dataset, "massmom2_motion", maxchunk, ngbxs)) {}
+      : mom0_microphys(
+            create_massmom0_xarray(dataset, store, "massmom0_microphys", maxchunk, ngbxs)),
+        mom1_microphys(
+            create_massmom1_xarray(dataset, store, "massmom1_microphys", maxchunk, ngbxs)),
+        mom2_microphys(
+            create_massmom2_xarray(dataset, store, "massmom2_microphys", maxchunk, ngbxs)),
+        mom0_motion(create_massmom0_xarray(dataset, store, "massmom0_motion", maxchunk, ngbxs)),
+        mom1_motion(create_massmom1_xarray(dataset, store, "massmom1_motion", maxchunk, ngbxs)),
+        mom2_motion(create_massmom2_xarray(dataset, store, "massmom2_motion", maxchunk, ngbxs)) {}
 };
 
-template <typename Store>
+template <typename Dataset, typename Store>
 struct MonitorRainMassMomentXarrays {
   XarrayZarrArray<Store, uint64_t> mom0_microphys; /**< 0th mass moment from microphysics Xarray */
   XarrayZarrArray<Store, float> mom1_microphys;    /**< 1st mass moment from microphysics Xarray */
@@ -67,18 +69,20 @@ struct MonitorRainMassMomentXarrays {
   XarrayZarrArray<Store, float> mom1_motion;       /**< 1st mass moment from motion Xarray */
   XarrayZarrArray<Store, float> mom2_motion;       /**< 2nd mass moment from motion Xarray */
 
-  MonitorRainMassMomentXarrays(const SimpleDataset<Store> &dataset, const size_t maxchunk,
+  MonitorRainMassMomentXarrays(const Dataset &dataset, Store &store, const size_t maxchunk,
                                const size_t ngbxs)
-      : mom0_microphys(
-            create_massmom0_xarray(dataset, "massmom0_raindrops_microphys", maxchunk, ngbxs)),
-        mom1_microphys(
-            create_massmom1_xarray(dataset, "massmom1_raindrops_microphys", maxchunk, ngbxs)),
-        mom2_microphys(
-            create_massmom2_xarray(dataset, "massmom2_raindrops_microphys", maxchunk, ngbxs)),
-        mom0_motion(create_massmom0_xarray(dataset, "massmom0_raindrops_motion", maxchunk, ngbxs)),
-        mom1_motion(create_massmom1_xarray(dataset, "massmom1_raindrops_motion", maxchunk, ngbxs)),
-        mom2_motion(create_massmom2_xarray(dataset, "massmom2_raindrops_motion", maxchunk, ngbxs)) {
-  }
+      : mom0_microphys(create_massmom0_xarray(dataset, store, "massmom0_raindrops_microphys",
+                                              maxchunk, ngbxs)),
+        mom1_microphys(create_massmom1_xarray(dataset, store, "massmom1_raindrops_microphys",
+                                              maxchunk, ngbxs)),
+        mom2_microphys(create_massmom2_xarray(dataset, store, "massmom2_raindrops_microphys",
+                                              maxchunk, ngbxs)),
+        mom0_motion(
+            create_massmom0_xarray(dataset, store, "massmom0_raindrops_motion", maxchunk, ngbxs)),
+        mom1_motion(
+            create_massmom1_xarray(dataset, store, "massmom1_raindrops_motion", maxchunk, ngbxs)),
+        mom2_motion(
+            create_massmom2_xarray(dataset, store, "massmom2_raindrops_motion", maxchunk, ngbxs)) {}
 };
 
 /**
@@ -89,10 +93,10 @@ struct MonitorRainMassMomentXarrays {
  * @tparam MonitorXarraysType Type for xarrays for mass moments in dataset.
  * @tparam MonitorViewsType Type for views which calculate mass moments for xarrays.
  */
-template <typename Store, typename MonitorXarraysType, typename MonitorViewsType>
+template <typename Dataset, typename Store, typename MonitorXarraysType, typename MonitorViewsType>
 class DoMonitorMassMomentsObs {
  private:
-  SimpleDataset<Store> &dataset;                  /**< Dataset to write time data to. */
+  Dataset &dataset;                               /**< Dataset to write time data to. */
   std::shared_ptr<MonitorXarraysType> xzarrs_ptr; /**< Pointer to arrays in dataset. */
   MonitorMassMoments<MonitorViewsType> monitor;
 
@@ -128,12 +132,13 @@ class DoMonitorMassMomentsObs {
   /**
    * @brief Constructor for DoMonitorMassMomentsObs.
    * @param dataset Dataset to write monitored data to.
+   * &param store Store dataset writes into.
    * @param maxchunk The maximum chunk size (number of elements) for Xarrays.
    * @param ngbxs The number of gridboxes.
    */
-  DoMonitorMassMomentsObs(SimpleDataset<Store> &dataset, const size_t maxchunk, const size_t ngbxs)
+  DoMonitorMassMomentsObs(Dataset &dataset, Store &store, const size_t maxchunk, const size_t ngbxs)
       : dataset(dataset),
-        xzarrs_ptr(std::make_shared<MonitorXarraysType>(dataset, maxchunk, ngbxs)),
+        xzarrs_ptr(std::make_shared<MonitorXarraysType>(dataset, store, maxchunk, ngbxs)),
         monitor(ngbxs) {}
 
   /**
@@ -190,17 +195,18 @@ class DoMonitorMassMomentsObs {
  * @tparam Store Type of store for dataset.
  * @param interval Observation timestep.
  * @param dataset Dataset to write time data to.
+ * @param store Store which dataset writes to
  * @param maxchunk Maximum number of elements in a chunk (1-D vector size).
  * @param ngbxs The number of gridboxes.
  * @return Constructed type satisfying observer concept.
  */
-template <typename Store>
-inline Observer auto MonitorMassMomentsObserver(const unsigned int interval,
-                                                SimpleDataset<Store> &dataset,
-                                                const size_t maxchunk, const size_t ngbxs) {
+template <typename Dataset, typename Store>
+inline Observer auto MonitorMassMomentsObserver(const unsigned int interval, Dataset &dataset,
+                                                Store &store, const size_t maxchunk,
+                                                const size_t ngbxs) {
   const auto do_obs =
-      DoMonitorMassMomentsObs<Store, MonitorMassMomentXarrays<Store>, MonitorMassMomentViews>(
-          dataset, maxchunk, ngbxs);
+      DoMonitorMassMomentsObs<Dataset, Store, MonitorMassMomentXarrays<Dataset, Store>,
+                              MonitorMassMomentViews>(dataset, store, maxchunk, ngbxs);
   return ConstTstepObserver(interval, do_obs);
 }
 
@@ -212,16 +218,18 @@ inline Observer auto MonitorMassMomentsObserver(const unsigned int interval,
  * @tparam Store Type of store for dataset.
  * @param interval Observation timestep.
  * @param dataset Dataset to write time data to.
+ * @param store Store which dataset writes to
  * @param maxchunk Maximum number of elements in a chunk (1-D vector size).
  * @param ngbxs The number of gridboxes.
  * @return Constructed type satisfying observer concept.
  */
-template <typename Store>
-inline Observer auto MonitorRainMassMomentsObserver(const unsigned int interval,
-                                                    SimpleDataset<Store> &dataset,
-                                                    const size_t maxchunk, const size_t ngbxs) {
-  const auto do_obs = DoMonitorMassMomentsObs<Store, MonitorRainMassMomentXarrays<Store>,
-                                              MonitorRainMassMomentViews>(dataset, maxchunk, ngbxs);
+template <typename Dataset, typename Store>
+inline Observer auto MonitorRainMassMomentsObserver(const unsigned int interval, Dataset &dataset,
+                                                    Store &store, const size_t maxchunk,
+                                                    const size_t ngbxs) {
+  const auto do_obs =
+      DoMonitorMassMomentsObs<Dataset, Store, MonitorRainMassMomentXarrays<Dataset, Store>,
+                              MonitorRainMassMomentViews>(dataset, store, maxchunk, ngbxs);
   return ConstTstepObserver(interval, do_obs);
 }
 

--- a/libs/observers/state_observer.hpp
+++ b/libs/observers/state_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 21st June 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -56,7 +56,7 @@
  * @return Observer An observer instance for writing the state data.
  */
 template <typename Store>
-inline Observer auto StateObserver(const unsigned int interval, const Dataset<Store> &dataset,
+inline Observer auto StateObserver(const unsigned int interval, const SimpleDataset<Store> &dataset,
                                    const size_t maxchunk, const size_t ngbxs) {
   const CollectDataForDataset<Store> auto thermo = CollectThermo(dataset, maxchunk, ngbxs);
   const CollectDataForDataset<Store> auto windvel = CollectWindVel(dataset, maxchunk, ngbxs);

--- a/libs/observers/state_observer.hpp
+++ b/libs/observers/state_observer.hpp
@@ -38,7 +38,6 @@
 #include "observers/thermo_observer.hpp"
 #include "observers/windvel_observer.hpp"
 #include "observers/write_to_dataset_observer.hpp"
-#include "zarr/collective_dataset.hpp"
 
 /**
  * @brief Constructs an observer which writes the state of a gridbox (thermodynamics and
@@ -48,20 +47,20 @@
  * This function collects thermodynamic properties and wind velocities from the dataset and combines
  * them into a single collection of state data.
  *
- * @tparam Store Type of store for dataset.
+ * @tparam Dataset Type of dataset
  * @param interval Observation timestep.
  * @param dataset Dataset to write time data to.
  * @param maxchunk Maximum number of elements in a chunk (1-D vector size).
  * @param ngbxs The number of gridboxes.
  * @return Observer An observer instance for writing the state data.
  */
-template <typename Store>
-inline Observer auto StateObserver(const unsigned int interval, const SimpleDataset<Store> &dataset,
+template <typename Dataset>
+inline Observer auto StateObserver(const unsigned int interval, const Dataset &dataset,
                                    const size_t maxchunk, const size_t ngbxs) {
-  const CollectDataForDataset<Store> auto thermo = CollectThermo(dataset, maxchunk, ngbxs);
-  const CollectDataForDataset<Store> auto windvel = CollectWindVel(dataset, maxchunk, ngbxs);
+  const CollectDataForDataset<Dataset> auto thermo = CollectThermo(dataset, maxchunk, ngbxs);
+  const CollectDataForDataset<Dataset> auto windvel = CollectWindVel(dataset, maxchunk, ngbxs);
 
-  const CollectDataForDataset<Store> auto collect_data = windvel >> thermo;
+  const CollectDataForDataset<Dataset> auto collect_data = windvel >> thermo;
 
   return WriteToDatasetObserver(interval, dataset, collect_data);
 }

--- a/libs/observers/superdrops_observer.hpp
+++ b/libs/observers/superdrops_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 21st June 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -62,7 +62,7 @@ struct RaggedCount {
    * @param dataset The dataset to collect data from.
    * @param maxchunk The maximum chunk size (number of elements).
    */
-  RaggedCount(const Dataset<Store> &dataset, const size_t maxchunk)
+  RaggedCount(const SimpleDataset<Store> &dataset, const size_t maxchunk)
       : xzarr_ptr(std::make_shared<XarrayZarrArray<Store, uint32_t>>(
             dataset.template create_raggedcount_array<uint32_t>("raggedcount", "", 1, {maxchunk},
                                                                 {"time"}, "superdroplets"))) {}
@@ -76,7 +76,8 @@ struct RaggedCount {
    * @param dataset The dataset to write data to.
    * @param d_supers The view of total super-droplets.
    */
-  void write_to_array(const Dataset<Store> &dataset, const subviewd_constsupers d_supers) const {
+  void write_to_array(const SimpleDataset<Store> &dataset,
+                      const subviewd_constsupers d_supers) const {
     const auto totnsupers = static_cast<uint32_t>(d_supers.extent(0));
     dataset.write_to_array(xzarr_ptr, totnsupers);
   }
@@ -88,7 +89,7 @@ struct RaggedCount {
    *
    * @param dataset The dataset to write data to.
    */
-  void write_arrayshape(const Dataset<Store> &dataset) const {
+  void write_arrayshape(const SimpleDataset<Store> &dataset) const {
     dataset.write_arrayshape(xzarr_ptr);
   }
 };
@@ -116,7 +117,7 @@ struct RaggedCount {
  */
 template <typename Store, typename T, typename FunctorFunc>
 CollectDataForDataset<Store> auto CollectSuperdropVariable(
-    const Dataset<Store> &dataset, const FunctorFunc ffunc, const std::string_view name,
+    const SimpleDataset<Store> &dataset, const FunctorFunc ffunc, const std::string_view name,
     const std::string_view units, const double scale_factor, const size_t maxchunk) {
   const auto chunkshape = std::vector<size_t>{maxchunk};
   const auto dimnames = std::vector<std::string>{"superdroplets"};
@@ -165,7 +166,7 @@ struct SdgbxindexFunc {
  * sdgbxindex data.
  */
 template <typename Store>
-CollectDataForDataset<Store> auto CollectSdgbxindex(const Dataset<Store> &dataset,
+CollectDataForDataset<Store> auto CollectSdgbxindex(const SimpleDataset<Store> &dataset,
                                                     const size_t maxchunk) {
   return CollectSuperdropVariable<Store, uint32_t, SdgbxindexFunc>(dataset, SdgbxindexFunc{},
                                                                    "sdgbxindex", "", 1, maxchunk);
@@ -209,7 +210,7 @@ struct SdIdFunc {
  * sdId data.
  */
 template <typename Store>
-CollectDataForDataset<Store> auto CollectSdId(const Dataset<Store> &dataset,
+CollectDataForDataset<Store> auto CollectSdId(const SimpleDataset<Store> &dataset,
                                               const size_t maxchunk) {
   return CollectSuperdropVariable<Store, uint32_t, SdIdFunc>(dataset, SdIdFunc{}, "sdId", "", 1,
                                                              maxchunk);
@@ -254,7 +255,8 @@ struct XiFunc {
  * @return CollectDataForDataset<Store> An instance of CollectDataForDataset for collecting xi data.
  */
 template <typename Store>
-CollectDataForDataset<Store> auto CollectXi(const Dataset<Store> &dataset, const size_t maxchunk) {
+CollectDataForDataset<Store> auto CollectXi(const SimpleDataset<Store> &dataset,
+                                            const size_t maxchunk) {
   return CollectSuperdropVariable<Store, uint64_t, XiFunc>(dataset, XiFunc{}, "xi", "", 1,
                                                            maxchunk);
 }
@@ -295,7 +297,7 @@ struct RadiusFunc {
  * @return CollectDataForDataset<Store> An instance of CollectDataForDataset for collecting radius.
  */
 template <typename Store>
-CollectDataForDataset<Store> auto CollectRadius(const Dataset<Store> &dataset,
+CollectDataForDataset<Store> auto CollectRadius(const SimpleDataset<Store> &dataset,
                                                 const size_t maxchunk) {
   return CollectSuperdropVariable<Store, float, RadiusFunc>(dataset, RadiusFunc{}, "radius",
                                                             "micro-m", dlc::R0 * 1e6, maxchunk);
@@ -337,7 +339,7 @@ struct MsolFunc {
  * @return CollectDataForDataset<Store> An instance of CollectDataForDataset for collecting msol.
  */
 template <typename Store>
-CollectDataForDataset<Store> auto CollectMsol(const Dataset<Store> &dataset,
+CollectDataForDataset<Store> auto CollectMsol(const SimpleDataset<Store> &dataset,
                                               const size_t maxchunk) {
   return CollectSuperdropVariable<Store, float, MsolFunc>(dataset, MsolFunc{}, "msol", "g",
                                                           dlc::MASS0grams, maxchunk);
@@ -379,7 +381,7 @@ struct Coord3Func {
  * @return CollectDataForDataset<Store> An instance of CollectDataForDataset for collecting coord3.
  */
 template <typename Store>
-CollectDataForDataset<Store> auto CollectCoord3(const Dataset<Store> &dataset,
+CollectDataForDataset<Store> auto CollectCoord3(const SimpleDataset<Store> &dataset,
                                                 const size_t maxchunk) {
   return CollectSuperdropVariable<Store, float, Coord3Func>(dataset, Coord3Func{}, "coord3", "m",
                                                             dlc::COORD0, maxchunk);
@@ -421,7 +423,7 @@ struct Coord1Func {
  * @return CollectDataForDataset<Store> An instance of CollectDataForDataset for collecting coord1.
  */
 template <typename Store>
-CollectDataForDataset<Store> auto CollectCoord1(const Dataset<Store> &dataset,
+CollectDataForDataset<Store> auto CollectCoord1(const SimpleDataset<Store> &dataset,
                                                 const size_t maxchunk) {
   return CollectSuperdropVariable<Store, float, Coord1Func>(dataset, Coord1Func{}, "coord1", "m",
                                                             dlc::COORD0, maxchunk);
@@ -463,7 +465,7 @@ struct Coord2Func {
  * @return CollectDataForDataset<Store> An instance of CollectDataForDataset for collecting coord2.
  */
 template <typename Store>
-CollectDataForDataset<Store> auto CollectCoord2(const Dataset<Store> &dataset,
+CollectDataForDataset<Store> auto CollectCoord2(const SimpleDataset<Store> &dataset,
                                                 const size_t maxchunk) {
   return CollectSuperdropVariable<Store, float, Coord2Func>(dataset, Coord2Func{}, "coord2", "m",
                                                             dlc::COORD0, maxchunk);
@@ -483,8 +485,8 @@ CollectDataForDataset<Store> auto CollectCoord2(const Dataset<Store> &dataset,
  * @return Observer An observer instance for writing thermodynamic variables from each gridbox.
  */
 template <typename Store>
-inline Observer auto SuperdropsObserver(const unsigned int interval, const Dataset<Store> &dataset,
-                                        const size_t maxchunk,
+inline Observer auto SuperdropsObserver(const unsigned int interval,
+                                        const SimpleDataset<Store> &dataset, const size_t maxchunk,
                                         CollectDataForDataset<Store> auto collect_data) {
   const CollectRaggedCount<Store> auto ragged_count = RaggedCount(dataset, maxchunk);
   return WriteToDatasetObserver(interval, dataset, collect_data, ragged_count);

--- a/libs/observers/thermo_observer.hpp
+++ b/libs/observers/thermo_observer.hpp
@@ -36,10 +36,9 @@
 #include "observers/collect_data_for_dataset.hpp"
 #include "observers/generic_collect_data.hpp"
 #include "observers/write_to_dataset_observer.hpp"
-#include "zarr/collective_dataset.hpp"
 
 /**
- * @brief Constructs type sastifying the CollectDataForDataset concept for a given Store (using an
+ * @brief Constructs type sastifying the CollectDataForDataset concept for a given Dataset (using an
  * instance of the GenericCollectData class) which writes a thermodynamic variable to an Xarray in a
  * dataset.
  *
@@ -55,16 +54,14 @@
  * @param scale_factor The scale factor of the coordinate data.
  * @param maxchunk The maximum chunk size (number of elements).
  * @param ngbxs The number of gridboxes.
- * @return CollectDataForDataset<Store> An instance satisfying the CollectDataForDataset concept for
- * collecting a 2-D floating point variable (e.g. a thermodynamic variable) from each gridbox.
+ * @return CollectDataForDataset<Dataset> An instance satisfying the CollectDataForDataset concept
+ * for collecting a 2-D floating point variable (e.g. a thermodynamic variable) from each gridbox.
  */
-template <typename Store, typename FunctorFunc>
-CollectDataForDataset<Store> auto CollectThermoVariable(const SimpleDataset<Store> &dataset,
-                                                        const FunctorFunc ffunc,
-                                                        const std::string_view name,
-                                                        const std::string_view units,
-                                                        const double scale_factor,
-                                                        const size_t maxchunk, const size_t ngbxs) {
+template <typename Dataset, typename FunctorFunc>
+CollectDataForDataset<Dataset> auto CollectThermoVariable(
+    const Dataset &dataset, const FunctorFunc ffunc, const std::string_view name,
+    const std::string_view units, const double scale_factor, const size_t maxchunk,
+    const size_t ngbxs) {
   const auto chunkshape = good2Dchunkshape(maxchunk, ngbxs);
   const auto dimnames = std::vector<std::string>{"time", "gbxindex"};
   const auto xzarr =
@@ -167,26 +164,27 @@ struct QcondFunc {
  * This function combines CollectDataForDataset types for many thermodynamic variables from each
  * gridbox (e.g. press, temp, qvap, qcond, etc.) using instances of the GenericCollectData class.
  *
- * @tparam Store The type of the dataset store.
+ * @tparam Dataset The type of dataset.
  * @param dataset The dataset to write the wind velocity components to.
  * @param maxchunk The maximum chunk size (number of elements).
  * @param ngbxs The number of gridboxes.
- * @return CollectDataForDataset<Store> An instance of CollectDataForDataset for collecting
+ * @return CollectDataForDataset<Dataset> An instance of CollectDataForDataset for collecting
  * thermodynamics from the state of each gridbox.
  */
-template <typename Store>
-inline CollectDataForDataset<Store> auto CollectThermo(const SimpleDataset<Store> &dataset,
-                                                       const size_t maxchunk, const size_t ngbxs) {
-  const CollectDataForDataset<Store> auto press = CollectThermoVariable<Store, PressFunc>(
+template <typename Dataset>
+inline CollectDataForDataset<Dataset> auto CollectThermo(const Dataset &dataset,
+                                                         const size_t maxchunk,
+                                                         const size_t ngbxs) {
+  const CollectDataForDataset<Dataset> auto press = CollectThermoVariable<Dataset, PressFunc>(
       dataset, PressFunc{}, "press", "hPa", dlc::P0 / 100, maxchunk, ngbxs);
 
-  const CollectDataForDataset<Store> auto temp = CollectThermoVariable<Store, TempFunc>(
+  const CollectDataForDataset<Dataset> auto temp = CollectThermoVariable<Dataset, TempFunc>(
       dataset, TempFunc{}, "temp", "K", dlc::TEMP0, maxchunk, ngbxs);
 
-  const CollectDataForDataset<Store> auto qvap = CollectThermoVariable<Store, QvapFunc>(
+  const CollectDataForDataset<Dataset> auto qvap = CollectThermoVariable<Dataset, QvapFunc>(
       dataset, QvapFunc{}, "qvap", "g/Kg", 1000.0, maxchunk, ngbxs);
 
-  const CollectDataForDataset<Store> auto qcond = CollectThermoVariable<Store, QcondFunc>(
+  const CollectDataForDataset<Dataset> auto qcond = CollectThermoVariable<Dataset, QcondFunc>(
       dataset, QcondFunc{}, "qcond", "g/Kg", 1000.0, maxchunk, ngbxs);
 
   return press >> temp >> qvap >> qcond;
@@ -197,18 +195,17 @@ inline CollectDataForDataset<Store> auto CollectThermo(const SimpleDataset<Store
  * qvap, etc.) at start of each observation timestep to a arrays with a constant
  * observation timestep "interval".
  *
- * @tparam Store Type of store for dataset.
+ * @tparam Dataset Type of dataset.
  * @param interval Observation timestep.
  * @param dataset Dataset to write time data to.
  * @param maxchunk Maximum number of elements in a chunk (1-D vector size).
  * @param ngbxs The number of gridboxes.
  * @return Observer An observer instance for writing thermodynamic variables from each gridbox.
  */
-template <typename Store>
-inline Observer auto ThermoObserver(const unsigned int interval,
-                                    const SimpleDataset<Store> &dataset, const size_t maxchunk,
-                                    const size_t ngbxs) {
-  const CollectDataForDataset<Store> auto thermo = CollectThermo(dataset, maxchunk, ngbxs);
+template <typename Dataset>
+inline Observer auto ThermoObserver(const unsigned int interval, const Dataset &dataset,
+                                    const size_t maxchunk, const size_t ngbxs) {
+  const CollectDataForDataset<Dataset> auto thermo = CollectThermo(dataset, maxchunk, ngbxs);
   return WriteToDatasetObserver(interval, dataset, thermo);
 }
 

--- a/libs/observers/thermo_observer.hpp
+++ b/libs/observers/thermo_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 21st June 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -59,7 +59,7 @@
  * collecting a 2-D floating point variable (e.g. a thermodynamic variable) from each gridbox.
  */
 template <typename Store, typename FunctorFunc>
-CollectDataForDataset<Store> auto CollectThermoVariable(const Dataset<Store> &dataset,
+CollectDataForDataset<Store> auto CollectThermoVariable(const SimpleDataset<Store> &dataset,
                                                         const FunctorFunc ffunc,
                                                         const std::string_view name,
                                                         const std::string_view units,
@@ -175,7 +175,7 @@ struct QcondFunc {
  * thermodynamics from the state of each gridbox.
  */
 template <typename Store>
-inline CollectDataForDataset<Store> auto CollectThermo(const Dataset<Store> &dataset,
+inline CollectDataForDataset<Store> auto CollectThermo(const SimpleDataset<Store> &dataset,
                                                        const size_t maxchunk, const size_t ngbxs) {
   const CollectDataForDataset<Store> auto press = CollectThermoVariable<Store, PressFunc>(
       dataset, PressFunc{}, "press", "hPa", dlc::P0 / 100, maxchunk, ngbxs);
@@ -205,8 +205,9 @@ inline CollectDataForDataset<Store> auto CollectThermo(const Dataset<Store> &dat
  * @return Observer An observer instance for writing thermodynamic variables from each gridbox.
  */
 template <typename Store>
-inline Observer auto ThermoObserver(const unsigned int interval, const Dataset<Store> &dataset,
-                                    const size_t maxchunk, const size_t ngbxs) {
+inline Observer auto ThermoObserver(const unsigned int interval,
+                                    const SimpleDataset<Store> &dataset, const size_t maxchunk,
+                                    const size_t ngbxs) {
   const CollectDataForDataset<Store> auto thermo = CollectThermo(dataset, maxchunk, ngbxs);
   return WriteToDatasetObserver(interval, dataset, thermo);
 }

--- a/libs/observers/time_observer.hpp
+++ b/libs/observers/time_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 21st June 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -48,7 +48,7 @@
 template <typename Store>
 class DoTimeObs {
  private:
-  Dataset<Store> &dataset; /**< Dataset to write time data to. */
+  SimpleDataset<Store> &dataset; /**< Dataset to write time data to. */
   std::shared_ptr<XarrayZarrArray<Store, float>>
       xzarr_ptr; /**< Pointer to time array in dataset. */
   std::function<double(unsigned int)>
@@ -79,7 +79,7 @@ class DoTimeObs {
    * @param maxchunk Maximum number of elements in a chunk (1-D vector size).
    * @param step2dimlesstime Function to convert model timesteps to a real time [assumed seconds].
    */
-  DoTimeObs(Dataset<Store> &dataset, const size_t maxchunk,
+  DoTimeObs(SimpleDataset<Store> &dataset, const size_t maxchunk,
             const std::function<double(unsigned int)> step2dimlesstime)
       : dataset(dataset),
         xzarr_ptr(std::make_shared<XarrayZarrArray<Store, float>>(
@@ -138,7 +138,7 @@ class DoTimeObs {
  * @return Constructed type satisfying observer concept.
  */
 template <typename Store>
-inline Observer auto TimeObserver(const unsigned int interval, Dataset<Store> &dataset,
+inline Observer auto TimeObserver(const unsigned int interval, SimpleDataset<Store> &dataset,
                                   const size_t maxchunk,
                                   const std::function<double(unsigned int)> step2dimlesstime) {
   return ConstTstepObserver(interval, DoTimeObs(dataset, maxchunk, step2dimlesstime));

--- a/libs/observers/totnsupers_observer.hpp
+++ b/libs/observers/totnsupers_observer.hpp
@@ -35,19 +35,19 @@
 #include "observers/observers.hpp"
 #include "superdrops/sdmmonitor.hpp"
 #include "zarr/buffer.hpp"
-#include "zarr/collective_dataset.hpp"
 #include "zarr/xarray_zarr_array.hpp"
 
 /**
  * @class DoTotNsupersObs
  * @brief Template class for functionality to observe the total number of superdroplets at the start
  * of each timestep and write it to a Zarr array in an Xarray dataset.
- * @tparam Store Type of store for dataset.
+ * @tparam Dataset Type of dataset.
+ * @tparam Store Type of store which dataset writes to.
  */
-template <typename Store>
+template <typename Dataset, typename Store>
 class DoTotNsupersObs {
  private:
-  SimpleDataset<Store> &dataset; /**< dataset to write totnsupers data to */
+  Dataset &dataset; /**< dataset to write totnsupers data to */
   std::shared_ptr<XarrayZarrArray<Store, uint32_t>> xzarr_ptr; /**< pointer to totnsupers array */
 
   /**
@@ -69,9 +69,10 @@ class DoTotNsupersObs {
   /**
    * @brief Constructor for DoTotNsupersObs.
    * @param dataset Dataset to write totnsupers data to.
+   * @param store Store which dataset writes to.
    * @param maxchunk Maximum number of elements in a chunk (1-D vector size).
    */
-  DoTotNsupersObs(SimpleDataset<Store> &dataset, const size_t maxchunk)
+  DoTotNsupersObs(Dataset &dataset, Store &store, const size_t maxchunk)
       : dataset(dataset),
         xzarr_ptr(std::make_shared<XarrayZarrArray<Store, uint32_t>>(
             dataset.template create_array<uint32_t>("totnsupers", "", 1, {maxchunk}, {"time"}))) {}
@@ -121,15 +122,17 @@ class DoTotNsupersObs {
  * observation timestep to a 1-D array with a constant observation timestep "interval".
  *
  * @tparam Store Type of store for dataset.
+ * @tparam Dataset Type of dataset
  * @param interval Observation timestep.
  * @param dataset Dataset to write time data to.
+ * @param store Store which dataset writes to.
  * @param maxchunk Maximum number of elements in a chunk (1-D vector size).
  * @return Constructed type satisfying observer concept.
  */
-template <typename Store>
-inline Observer auto TotNsupersObserver(const unsigned int interval, SimpleDataset<Store> &dataset,
+template <typename Dataset, typename Store>
+inline Observer auto TotNsupersObserver(const unsigned int interval, Dataset &dataset, Store &store,
                                         const size_t maxchunk) {
-  return ConstTstepObserver(interval, DoTotNsupersObs(dataset, maxchunk));
+  return ConstTstepObserver(interval, DoTotNsupersObs(dataset, store, maxchunk));
 }
 
 #endif  // LIBS_OBSERVERS_TOTNSUPERS_OBSERVER_HPP_

--- a/libs/observers/totnsupers_observer.hpp
+++ b/libs/observers/totnsupers_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 21st June 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -47,7 +47,7 @@
 template <typename Store>
 class DoTotNsupersObs {
  private:
-  Dataset<Store> &dataset; /**< dataset to write totnsupers data to */
+  SimpleDataset<Store> &dataset; /**< dataset to write totnsupers data to */
   std::shared_ptr<XarrayZarrArray<Store, uint32_t>> xzarr_ptr; /**< pointer to totnsupers array */
 
   /**
@@ -71,7 +71,7 @@ class DoTotNsupersObs {
    * @param dataset Dataset to write totnsupers data to.
    * @param maxchunk Maximum number of elements in a chunk (1-D vector size).
    */
-  DoTotNsupersObs(Dataset<Store> &dataset, const size_t maxchunk)
+  DoTotNsupersObs(SimpleDataset<Store> &dataset, const size_t maxchunk)
       : dataset(dataset),
         xzarr_ptr(std::make_shared<XarrayZarrArray<Store, uint32_t>>(
             dataset.template create_array<uint32_t>("totnsupers", "", 1, {maxchunk}, {"time"}))) {}
@@ -127,7 +127,7 @@ class DoTotNsupersObs {
  * @return Constructed type satisfying observer concept.
  */
 template <typename Store>
-inline Observer auto TotNsupersObserver(const unsigned int interval, Dataset<Store> &dataset,
+inline Observer auto TotNsupersObserver(const unsigned int interval, SimpleDataset<Store> &dataset,
                                         const size_t maxchunk) {
   return ConstTstepObserver(interval, DoTotNsupersObs(dataset, maxchunk));
 }

--- a/libs/observers/windvel_observer.hpp
+++ b/libs/observers/windvel_observer.hpp
@@ -36,10 +36,9 @@
 #include "observers/collect_data_for_dataset.hpp"
 #include "observers/generic_collect_data.hpp"
 #include "observers/write_to_dataset_observer.hpp"
-#include "zarr/collective_dataset.hpp"
 
 /**
- * @brief Constructs type sastifying the CollectDataForDataset concept for a given Store (using an
+ * @brief Constructs type sastifying the CollectDataForDataset concept for a given Dataset (using an
  * instance of the GenericCollectData class) which writes a wind velocity component to an Xarray in
  * a dataset.
  *
@@ -47,20 +46,20 @@
  * type with units "m/s" by collecting data according to the given FunctorFunc from within a
  * Kokkos::parallel_for loop over gridboxes with a range policy.
  *
- * @param dataset The dataset to write the wind velocity component to.
+ * @param dataset The Dataset to write the wind velocity component to.
  * @param ffunc The functor function to collect the wind velocity component from within a parallel
  * range policy over gridboxes.
  * @param name Name of the array in the store where the chunk will be written.
  * @param maxchunk The maximum chunk size (number of elements).
  * @param ngbxs The number of gridboxes.
- * @return CollectDataForDataset<Store> An instance satisfying the CollectDataForDataset concept for
- * collecting a wind velocity component from each gridbox.
+ * @return CollectDataForDataset<Dataset> An instance satisfying the CollectDataForDataset concept
+ * for collecting a wind velocity component from each gridbox.
  */
-template <typename Store, typename FunctorFunc>
-CollectDataForDataset<Store> auto CollectWindVariable(const SimpleDataset<Store> &dataset,
-                                                      const FunctorFunc ffunc,
-                                                      const std::string_view name,
-                                                      const size_t maxchunk, const size_t ngbxs) {
+template <typename Dataset, typename FunctorFunc>
+CollectDataForDataset<Dataset> auto CollectWindVariable(const Dataset &dataset,
+                                                        const FunctorFunc ffunc,
+                                                        const std::string_view name,
+                                                        const size_t maxchunk, const size_t ngbxs) {
   const auto units = std::string_view("m/s");
   const auto scale_factor = dlc::W0;
   const auto chunkshape = good2Dchunkshape(maxchunk, ngbxs);
@@ -143,24 +142,24 @@ struct VvelFunc {
  * This function combines CollectDataForDataset types for the three wind velocity components (wvel,
  * vvel and uvel) in each gridbox using instances of the GenericCollectData class.
  *
- * @tparam Store The type of the dataset store.
  * @param dataset The dataset to write the wind velocity components to.
  * @param maxchunk The maximum chunk size (number of elements).
  * @param ngbxs The number of gridboxes.
- * @return CollectDataForDataset<Store> An instance of CollectDataForDataset for collecting wind
+ * @return CollectDataForDataset<Dataset> An instance of CollectDataForDataset for collecting wind
  * velocity data.
  */
-template <typename Store>
-inline CollectDataForDataset<Store> auto CollectWindVel(const SimpleDataset<Store> &dataset,
-                                                        const size_t maxchunk, const size_t ngbxs) {
-  const CollectDataForDataset<Store> auto wvel =
-      CollectWindVariable<Store, WvelFunc>(dataset, WvelFunc{}, "wvel", maxchunk, ngbxs);
+template <typename Dataset>
+inline CollectDataForDataset<Dataset> auto CollectWindVel(const Dataset &dataset,
+                                                          const size_t maxchunk,
+                                                          const size_t ngbxs) {
+  const CollectDataForDataset<Dataset> auto wvel =
+      CollectWindVariable<Dataset, WvelFunc>(dataset, WvelFunc{}, "wvel", maxchunk, ngbxs);
 
-  const CollectDataForDataset<Store> auto uvel =
-      CollectWindVariable<Store, UvelFunc>(dataset, UvelFunc{}, "uvel", maxchunk, ngbxs);
+  const CollectDataForDataset<Dataset> auto uvel =
+      CollectWindVariable<Dataset, UvelFunc>(dataset, UvelFunc{}, "uvel", maxchunk, ngbxs);
 
-  const CollectDataForDataset<Store> auto vvel =
-      CollectWindVariable<Store, VvelFunc>(dataset, VvelFunc{}, "vvel", maxchunk, ngbxs);
+  const CollectDataForDataset<Dataset> auto vvel =
+      CollectWindVariable<Dataset, VvelFunc>(dataset, VvelFunc{}, "vvel", maxchunk, ngbxs);
 
   return vvel >> uvel >> wvel;
 }
@@ -170,18 +169,16 @@ inline CollectDataForDataset<Store> auto CollectWindVel(const SimpleDataset<Stor
  * vvel and uvel) at start of each observation timestep to a arrays with a constant observation
  * timestep "interval".
  *
- * @tparam Store Type of store for dataset.
  * @param interval Observation timestep.
  * @param dataset Dataset to write time data to.
  * @param maxchunk Maximum number of elements in a chunk (1-D vector size).
  * @param ngbxs The number of gridboxes.
  * @return Observer An observer instance for writing the wind velocity components.
  */
-template <typename Store>
-inline Observer auto WindVelObserver(const unsigned int interval,
-                                     const SimpleDataset<Store> &dataset, const size_t maxchunk,
-                                     const size_t ngbxs) {
-  const CollectDataForDataset<Store> auto windvel = CollectWindVel(dataset, maxchunk, ngbxs);
+template <typename Dataset>
+inline Observer auto WindVelObserver(const unsigned int interval, const Dataset &dataset,
+                                     const size_t maxchunk, const size_t ngbxs) {
+  const CollectDataForDataset<Dataset> auto windvel = CollectWindVel(dataset, maxchunk, ngbxs);
   return WriteToDatasetObserver(interval, dataset, windvel);
 }
 

--- a/libs/observers/windvel_observer.hpp
+++ b/libs/observers/windvel_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 21st June 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -57,7 +57,7 @@
  * collecting a wind velocity component from each gridbox.
  */
 template <typename Store, typename FunctorFunc>
-CollectDataForDataset<Store> auto CollectWindVariable(const Dataset<Store> &dataset,
+CollectDataForDataset<Store> auto CollectWindVariable(const SimpleDataset<Store> &dataset,
                                                       const FunctorFunc ffunc,
                                                       const std::string_view name,
                                                       const size_t maxchunk, const size_t ngbxs) {
@@ -151,7 +151,7 @@ struct VvelFunc {
  * velocity data.
  */
 template <typename Store>
-inline CollectDataForDataset<Store> auto CollectWindVel(const Dataset<Store> &dataset,
+inline CollectDataForDataset<Store> auto CollectWindVel(const SimpleDataset<Store> &dataset,
                                                         const size_t maxchunk, const size_t ngbxs) {
   const CollectDataForDataset<Store> auto wvel =
       CollectWindVariable<Store, WvelFunc>(dataset, WvelFunc{}, "wvel", maxchunk, ngbxs);
@@ -178,8 +178,9 @@ inline CollectDataForDataset<Store> auto CollectWindVel(const Dataset<Store> &da
  * @return Observer An observer instance for writing the wind velocity components.
  */
 template <typename Store>
-inline Observer auto WindVelObserver(const unsigned int interval, const Dataset<Store> &dataset,
-                                     const size_t maxchunk, const size_t ngbxs) {
+inline Observer auto WindVelObserver(const unsigned int interval,
+                                     const SimpleDataset<Store> &dataset, const size_t maxchunk,
+                                     const size_t ngbxs) {
   const CollectDataForDataset<Store> auto windvel = CollectWindVel(dataset, maxchunk, ngbxs);
   return WriteToDatasetObserver(interval, dataset, windvel);
 }

--- a/libs/observers/write_to_dataset_observer.hpp
+++ b/libs/observers/write_to_dataset_observer.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 21st June 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -113,7 +113,7 @@ inline Observer auto WriteToDatasetObserver(const unsigned int interval,
  */
 template <typename Store, CollectDataForDataset<Store> CollectData>
 inline Observer auto WriteToDatasetObserver(const unsigned int interval,
-                                            const Dataset<Store> &dataset,
+                                            const SimpleDataset<Store> &dataset,
                                             CollectData collect_data) {
   const auto parallel_write =
       ParallelWriteGridboxes(ParallelGridboxesRangePolicyFunc{}, dataset, collect_data);
@@ -135,8 +135,8 @@ inline Observer auto WriteToDatasetObserver(const unsigned int interval,
 template <typename Store, CollectDataForDataset<Store> CollectData,
           CollectRaggedCount<Store> RaggedCount>
 inline Observer auto WriteToDatasetObserver(const unsigned int interval,
-                                            const Dataset<Store> &dataset, CollectData collect_data,
-                                            RaggedCount ragged_count) {
+                                            const SimpleDataset<Store> &dataset,
+                                            CollectData collect_data, RaggedCount ragged_count) {
   const auto parallel_write = ParallelWriteSupers(dataset, collect_data, ragged_count);
   return ConstTstepObserver(interval, DoWriteToDataset(parallel_write));
 }

--- a/libs/observers/write_to_dataset_observer.hpp
+++ b/libs/observers/write_to_dataset_observer.hpp
@@ -33,7 +33,6 @@
 #include "observers/observers.hpp"
 #include "observers/parallel_write_data.hpp"
 #include "superdrops/sdmmonitor.hpp"
-#include "zarr/collective_dataset.hpp"
 
 /**
  * @class DoWriteToDataset
@@ -104,16 +103,14 @@ inline Observer auto WriteToDatasetObserver(const unsigned int interval,
 /**
  * @brief Constructs an observer to write data from gridboxes to arrays in a dataset at a
  * constant time interval using a range policy parallelism over the gridboxes.
- * @tparam Store Type of store for dataset.
  * @tparam CollectData Type of collect data function.
  * @param interval Constant timestep interval.
  * @param dataset Dataset to write data to.
  * @param collect_data Function to collect data from gridboxes.
  * @return Constructed observer.
  */
-template <typename Store, CollectDataForDataset<Store> CollectData>
-inline Observer auto WriteToDatasetObserver(const unsigned int interval,
-                                            const SimpleDataset<Store> &dataset,
+template <typename Dataset, CollectDataForDataset<Dataset> CollectData>
+inline Observer auto WriteToDatasetObserver(const unsigned int interval, const Dataset &dataset,
                                             CollectData collect_data) {
   const auto parallel_write =
       ParallelWriteGridboxes(ParallelGridboxesRangePolicyFunc{}, dataset, collect_data);
@@ -123,7 +120,6 @@ inline Observer auto WriteToDatasetObserver(const unsigned int interval,
 /**
  * @brief Constructs an observer to write data from superdroplets to ragged arrays in a dataset
  * at a constant time interval.
- * @tparam Store Type of store for dataset.
  * @tparam CollectData Type of collect data function.
  * @tparam RaggedCount Type of collect ragged count function.
  * @param interval Constant timestep interval.
@@ -132,10 +128,9 @@ inline Observer auto WriteToDatasetObserver(const unsigned int interval,
  * @param ragged_count Function to collect ragged count for superdroplet data arrays(s).
  * @return Constructed observer.
  */
-template <typename Store, CollectDataForDataset<Store> CollectData,
-          CollectRaggedCount<Store> RaggedCount>
-inline Observer auto WriteToDatasetObserver(const unsigned int interval,
-                                            const SimpleDataset<Store> &dataset,
+template <typename Dataset, CollectDataForDataset<Dataset> CollectData,
+          CollectRaggedCount<Dataset> RaggedCount>
+inline Observer auto WriteToDatasetObserver(const unsigned int interval, const Dataset &dataset,
                                             CollectData collect_data, RaggedCount ragged_count) {
   const auto parallel_write = ParallelWriteSupers(dataset, collect_data, ragged_count);
   return ConstTstepObserver(interval, DoWriteToDataset(parallel_write));

--- a/libs/zarr/CMakeLists.txt
+++ b/libs/zarr/CMakeLists.txt
@@ -24,7 +24,7 @@ add_library("${LIBNAME}" STATIC ${SOURCES})
 target_include_directories(${LIBNAME} PRIVATE "${CLEO_SOURCE_DIR}/libs") # CLEO libs directory
 
 # Link libraries to target library
-set(LINKLIBS cartesiandomain)
+set(LINKLIBS "")
 target_link_libraries(${LIBNAME} PUBLIC "${LINKLIBS}")
 target_link_libraries(${LIBNAME} PUBLIC Kokkos::kokkos)
 

--- a/libs/zarr/collective_dataset.hpp
+++ b/libs/zarr/collective_dataset.hpp
@@ -36,7 +36,7 @@
 #include <utility>
 #include <vector>
 
-#include "cartesiandomain/cartesian_decomposition.hpp"  // TODO(CB): remove dependency on cartesiandomain (also in zarr's CMakeLists)
+#include "cartesiandomain/cartesian_decomposition.hpp"  // TODO(CB): remove dependency on cartesiandomain (also in zarr's CMakeLists) WIP
 #include "zarr/xarray_zarr_array.hpp"
 #include "zarr/zarr_group.hpp"
 

--- a/libs/zarr/collective_dataset.hpp
+++ b/libs/zarr/collective_dataset.hpp
@@ -36,7 +36,6 @@
 #include <utility>
 #include <vector>
 
-#include "cartesiandomain/cartesian_decomposition.hpp"  // TODO(CB): remove dependency on cartesiandomain (also in zarr's CMakeLists) WIP
 #include "zarr/xarray_zarr_array.hpp"
 #include "zarr/zarr_group.hpp"
 
@@ -50,14 +49,14 @@
  *
  * @tparam Store The type of the store object used by the dataset.
  */
-template <typename Store>
+template <typename Store, typename Decomposition>
 class CollectiveDataset {
  private:
   /**< Reference to the zarr group object. */
   ZarrGroup<Store> group;
   /**< map from name of each dimension in dataset to their size */
   std::unordered_map<std::string, size_t> datasetdims;
-  CartesianDecomposition decomposition;
+  Decomposition decomposition;
   std::shared_ptr<std::vector<unsigned int>> global_superdroplet_ordering;
 
   /**< map from name of each dimension in dataset to their size */
@@ -263,11 +262,9 @@ class CollectiveDataset {
   /**
    * @brief Sets the decomposition maps for correctly writing data out
    *
-   * @param decomposition A CartesianDecomposition instance with the domain decomposition
+   * @param decomposition A Decomposition instance for CLEO's domain decomposition
    */
-  void set_decomposition(CartesianDecomposition decomposition) {
-    this->decomposition = decomposition;
-  }
+  void set_decomposition(Decomposition decomposition) { this->decomposition = decomposition; }
 
   /**
    * @brief Sets the maximum number of superdroplets for data allocation, comes from the config file

--- a/libs/zarr/collective_dataset.hpp
+++ b/libs/zarr/collective_dataset.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors: Wilton Jaciel Loch
  * -----
- * Last Modified: Wednesday 28th May 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -28,7 +28,7 @@
 // be changed to use MPI-enabled functionality
 // For this to work dataset.hpp must be included before any other hpp that uses
 // collective_dataset.hpp
-#ifndef LIBS_ZARR_DATASET_HPP_
+#ifndef LIBS_ZARR_SIMPLE_DATASET_HPP_
 
 #include <mpi.h>
 
@@ -57,7 +57,7 @@
  * @tparam Store The type of the store object used by the dataset.
  */
 template <typename Store>
-class Dataset {
+class CollectiveDataset {
  private:
   /**< Reference to the zarr group object. */
   ZarrGroup<Store> group;
@@ -231,7 +231,7 @@ class Dataset {
    *
    * @param store The store object associated with the Dataset.
    */
-  explicit Dataset(Store &store) : group(store), datasetdims() {
+  explicit CollectiveDataset(Store &store) : group(store), datasetdims() {
     store[".zattrs"] =
         "{\n"
         "  \"creator\": \"Clara Bayley\",\n"

--- a/libs/zarr/collective_dataset.hpp
+++ b/libs/zarr/collective_dataset.hpp
@@ -24,12 +24,6 @@
 #ifndef LIBS_ZARR_COLLECTIVE_DATASET_HPP_
 #define LIBS_ZARR_COLLECTIVE_DATASET_HPP_
 
-// This should be only a temporary solution so that not all of the examples must
-// be changed to use MPI-enabled functionality
-// For this to work dataset.hpp must be included before any other hpp that uses
-// collective_dataset.hpp
-#ifndef LIBS_ZARR_SIMPLE_DATASET_HPP_
-
 #include <mpi.h>
 
 #include <Kokkos_Core.hpp>
@@ -532,7 +526,5 @@ class CollectiveDataset {
     }
   }
 };
-
-#endif
 
 #endif  // LIBS_ZARR_COLLECTIVE_DATASET_HPP_

--- a/libs/zarr/simple_dataset.hpp
+++ b/libs/zarr/simple_dataset.hpp
@@ -3,13 +3,13 @@
  *
  *
  * ----- CLEO -----
- * File: dataset.hpp
+ * File: simple_dataset.hpp
  * Project: zarr
  * Created Date: Monday 18th March 2024
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 21st June 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -19,8 +19,8 @@
  * Structure to create a ZarrGroup which is xarray and netCDF compatible.
  */
 
-#ifndef LIBS_ZARR_DATASET_HPP_
-#define LIBS_ZARR_DATASET_HPP_
+#ifndef LIBS_ZARR_SIMPLE_DATASET_HPP_
+#define LIBS_ZARR_SIMPLE_DATASET_HPP_
 
 #include <Kokkos_Core.hpp>
 #include <memory>
@@ -44,7 +44,7 @@
  * @tparam Store The type of the store object used by the dataset.
  */
 template <typename Store>
-class Dataset {
+class SimpleDataset {
  private:
   ZarrGroup<Store> group; /**< Reference to the zarr group object. */
   std::unordered_map<std::string, size_t>
@@ -68,7 +68,7 @@ class Dataset {
    *
    * @param store The store object associated with the Dataset.
    */
-  explicit Dataset(Store &store) : group(store), datasetdims() {
+  explicit SimpleDataset(Store &store) : group(store), datasetdims() {
     store[".zattrs"] =
         "{\n"
         "  \"creator\": \"Clara Bayley\",\n"
@@ -292,4 +292,4 @@ class Dataset {
   }
 };
 
-#endif  // LIBS_ZARR_DATASET_HPP_
+#endif  // LIBS_ZARR_SIMPLE_DATASET_HPP_

--- a/roughpaper/scratch/cleotypes_sizes.hpp
+++ b/roughpaper/scratch/cleotypes_sizes.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 21st June 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -65,7 +65,7 @@ struct SuperdropAttrs2 {
 };
 
 void print_type_sizes(int argc, char *argv[]) {
-  Kokkos::initialize(config.get_kokkos_initialization_settings());
+  Kokkos::initialize();
   {
     std::cout << "GBx: " << sizeof(Gridbox) << "\n";
     std::cout << "re-ordered GBx: " << sizeof(Gridbox2) << "\n";

--- a/roughpaper/scratch/main.cpp
+++ b/roughpaper/scratch/main.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Wednesday 28th May 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -24,7 +24,7 @@
 #include <concepts>
 #include <iostream>
 
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "./cleotypes_sizes.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
@@ -59,7 +59,7 @@
 
 template <typename Store>
 inline Observer auto create_superdrops_observer(const Config &config, const Timesteps &tsteps,
-                                                Dataset<Store> &dataset) {
+                                                SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
 
@@ -79,7 +79,7 @@ inline Observer auto create_superdrops_observer(const Config &config, const Time
 
 template <typename Store>
 inline Observer auto create_gridbox_observer(const Config &config, const Timesteps &tsteps,
-                                             Dataset<Store> &dataset) {
+                                             SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
   const auto ngbxs = config.get_ngbxs();
@@ -103,7 +103,7 @@ inline Observer auto create_gridbox_observer(const Config &config, const Timeste
 
 template <typename Store>
 inline Observer auto create_observer2(const Config &config, const Timesteps &tsteps,
-                                      Dataset<Store> &dataset) {
+                                      SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
   const auto ngbxs = config.get_ngbxs();
@@ -124,7 +124,7 @@ inline Observer auto create_observer2(const Config &config, const Timesteps &tst
 
 template <typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset<Store> &dataset) {
+                                     SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
 
   const Observer auto obs0 = StreamOutObserver(obsstep, &step2realtime);
@@ -161,7 +161,8 @@ inline CoupledDynamics auto create_coupldyn(const Config &config, const Cartesia
 }
 
 template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       SimpleDataset<Store> &dataset) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps = create_cartesian_maps(
       config.get_ngbxs(), config.get_nspacedims(), config.get_grid_filename());
@@ -198,7 +199,7 @@ int main(int argc, char *argv[]) {
 
     /* Create zarr store for writing output to storage */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = Dataset(store);
+    auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));

--- a/roughpaper/src/main.cpp
+++ b/roughpaper/src/main.cpp
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]) {
     auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
-    const SDMMethods sdm(create_sdm(config, tsteps, dataset));
+    const SDMMethods sdm(create_sdm(config, tsteps, dataset, store));
 
     /* Solver of dynamics coupled to CLEO SDM */
     CoupledDynamics auto coupldyn(

--- a/roughpaper/src/main.cpp
+++ b/roughpaper/src/main.cpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 21st June 2024
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
 
     /* Create Xarray dataset wit Zarr backend for writing output data to a store */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = Dataset(store);
+    auto dataset = SimpleDataset(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm(create_sdm(config, tsteps, dataset));

--- a/roughpaper/src/main_impl.hpp
+++ b/roughpaper/src/main_impl.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Tuesday 3rd June 2025
+ * Last Modified: Friday 20th June 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -30,7 +30,7 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "zarr/dataset.hpp"
+#include "zarr/simple_dataset.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/add_supers_at_domain_top.hpp"
@@ -177,7 +177,8 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
 
 template <typename Store>
 inline Observer auto create_superdrops_observer(const unsigned int interval,
-                                                Dataset<Store> &dataset, const size_t maxchunk) {
+                                                SimpleDataset<Store> &dataset,
+                                                const size_t maxchunk) {
   CollectDataForDataset<Store> auto sdid = CollectSdId(dataset, maxchunk);
   CollectDataForDataset<Store> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
   CollectDataForDataset<Store> auto xi = CollectXi(dataset, maxchunk);
@@ -193,8 +194,9 @@ inline Observer auto create_superdrops_observer(const unsigned int interval,
 }
 
 template <typename Store>
-inline Observer auto create_gridboxes_observer(const unsigned int interval, Dataset<Store> &dataset,
-                                               const size_t maxchunk, const size_t ngbxs) {
+inline Observer auto create_gridboxes_observer(const unsigned int interval,
+                                               SimpleDataset<Store> &dataset, const size_t maxchunk,
+                                               const size_t ngbxs) {
   const CollectDataForDataset<Store> auto thermo = CollectThermo(dataset, maxchunk, ngbxs);
   const CollectDataForDataset<Store> auto windvel = CollectWindVel(dataset, maxchunk, ngbxs);
   const CollectDataForDataset<Store> auto nsupers = CollectNsupers(dataset, maxchunk, ngbxs);
@@ -205,8 +207,8 @@ inline Observer auto create_gridboxes_observer(const unsigned int interval, Data
 
 template <typename Store>
 inline Observer auto create_sdmmonitor_observer(const unsigned int interval,
-                                                Dataset<Store> &dataset, const size_t maxchunk,
-                                                const size_t ngbxs) {
+                                                SimpleDataset<Store> &dataset,
+                                                const size_t maxchunk, const size_t ngbxs) {
   const Observer auto obs_cond = MonitorCondensationObserver(interval, dataset, maxchunk, ngbxs);
   const Observer auto obs_massmoms = MonitorMassMomentsObserver(interval, dataset, maxchunk, ngbxs);
   const Observer auto obs_rainmassmoms =
@@ -217,7 +219,7 @@ inline Observer auto create_sdmmonitor_observer(const unsigned int interval,
 
 template <typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset<Store> &dataset) {
+                                     SimpleDataset<Store> &dataset) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
   const auto ngbxs = config.get_ngbxs();
@@ -244,7 +246,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 }
 
 template <typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset<Store> &dataset) {
+inline auto create_sdm(const Config &config, const Timesteps &tsteps,
+                       SimpleDataset<Store> &dataset) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));


### PR DESCRIPTION
dependent on [PR 185](https://github.com/yoctoyotta1024/CLEO/pull/185)

- removes hack which allows collective and simple dataset to both be called "Dataset" and template over dataset instead
- make examples compatible with either SimpleDataset or CollectiveDataset as instance of templated Dataset
- remove dependency of zarr lib on cartesian domain