### PR TITLE
MPI-YAC-Compatibility 0: use intel or gcc compiler with YAC

### DIFF
--- a/docs/source/usage/extern.rst
+++ b/docs/source/usage/extern.rst
@@ -19,15 +19,23 @@ find more information about it from `its documentation: <https://dkrz-sw.gitlab-
 To build CLEO with dependency on YAC, you will first need to install YAXT and YAC manually.
 (YAXT is a dependency of YAC.)
 
-.. note::
-  The installation of YAC for CLEO is currently in active development and so may not be exactly as written here.
-
 How to Install YAC (and YAXT)
 #############################
 
 The easiest way (on Levante) to install YAXT and YAC is to run the ``install_yac.sh`` bash script found in
 ``scripts/levante/bash/``. Note you will need to provide the path to the directory where you want
-to put the installations.
+to put the installations, as well as the compiler type (``intel`` or ``gcc``), and the python
+interpreter you want to use for YAC's python bindings. E.g.
+
+.. code-block:: console
+
+  $ scripts/levante/bash/install_yac.sh /work/bm1183/m300950/yacyaxt/intel/ intel /work/bm1183/m300950/bin/envs/cleoenv/bin/python
+
+or
+
+.. code-block:: console
+
+  $ scripts/levante/bash/install_yac.sh /work/bm1183/m300950/yacyaxt/gcc/ gcc /work/bm1183/m300950/bin/envs/cleoenv/bin/python
 
 Alternatively you can download `YAXT <https://swprojects.dkrz.de/redmine/>`_ and
 `YAC <https://gitlab.dkrz.de/dkrz-sw/yac/>`_ as compressed files and then configure and compile

--- a/docs/source/usage/requirements.rst
+++ b/docs/source/usage/requirements.rst
@@ -24,15 +24,14 @@ At the time of writing this is gcc 11.2.0, e.g.
 
 .. code-block:: console
 
-  $ module load gcc/11.2.0-gcc-11.2.0
-  $ spack load openmpi/4.1.2-gcc-11.2.0
+  $ module load gcc/11.2.0-gcc-11.2.0 openmpi/4.1.2-gcc-11.2.0
 
 To compile with C++ and CUDA, use Levante's nvhpc compilers too, e.g.
 
 .. code-block:: console
 
-  $ module load gcc/11.2.0-gcc-11.2.0
-  $ spack load openmpi/4.1.2-gcc-11.2.0 cuda@12.2.0%gcc@=11.2.0
+  $ module load gcc/11.2.0-gcc-11.2.0 openmpi/4.1.2-gcc-11.2.0
+  $ spack load cuda@12.2.0%gcc@=11.2.0
 
 (Note you still need to use the gcc openmpi library as opposed to the cuda (nvhpc)
 ones because CLEO uses gcc not nvhpc where this is relevant).
@@ -83,8 +82,8 @@ compiler which you can load on Levante via:
 
 .. code-block:: console
 
-  $ module load gcc/11.2.0-gcc-11.2.0 netcdf-c/4.8.1-openmpi-4.1.2-gcc-11.2.0
-  $ spack load openmpi@4.1.2%gcc@11.2.0 openblas@0.3.18%gcc@=11.2.0
+  $ module load gcc/11.2.0-gcc-11.2.0 openmpi@4.1.2%gcc@11.2.0 netcdf-c/4.8.1-openmpi-4.1.2-gcc-11.2.0
+  $ spack load openblas@0.3.18%gcc@=11.2.0
 
 When you want to run CLEO with YAC, you will also need to export some additional paths:
 

--- a/docs/source/usage/requirements.rst
+++ b/docs/source/usage/requirements.rst
@@ -17,10 +17,10 @@ and similarly for JUWELS in our
 
 Compilers
 ---------
-A C++ compiler with the C++20 standard library is the absolute minimum.
+A C++ compiler with the C++20 standard library and MPI is the absolute minimum.
 
-On Levante you can use the latest MPI compiler wrappers for the gcc compilers.
-At the time of writing this is gcc 11.2.0, e.g.
+On Levante you can use the latest MPI compiler wrappers for the gcc or intel compilers.
+At the time of writing for gcc 11.2.0, these are:
 
 .. code-block:: console
 
@@ -40,12 +40,39 @@ CMake
 -----
 CMake minimum version 3.18.0.
 
-On Levante it's best to use version 3.26.3 which can be loaded
-e.g. for the gcc compiler via the command
+On Levante it's best to use version 3.26.3 which can be loaded e.g. for gcc 11.2.0 via:
 
 .. code-block:: console
 
   $ cmake@3.26.3%gcc@=11.2.0/fuvwuhz
+
+
+YAC
+---
+
+YAC is one of the :doc:`external libraries<extern>` which CLEO requires for its configuration
+library (for MPI domain decomposition with/without YAC) and in order to couple to dynamics via YAC.
+
+YAC (and its YAXT dependency) need to be installed manually before you can build CLEO with them.
+Please refer to the instructions on how to do install YAC (and YAXT) in our
+:doc:`external libraries<extern>` page.
+
+YAC also requires some additional MPI, NetCDF and yaml libraries alongside the compatible gcc/intel
+compiler. For example for gcc 11.2.0, you can load these on Levante via:
+
+.. code-block:: console
+
+  $ module load gcc/11.2.0-gcc-11.2.0 openmpi@4.1.2%gcc@11.2.0 netcdf-c/4.8.1-openmpi-4.1.2-gcc-11.2.0
+  $ spack load openblas@0.3.18%gcc@=11.2.0
+
+When you want to run CLEO, you will also need to export the fyaml library and python bindings paths,
+e.g.
+
+.. code-block:: console
+
+  $ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/sw/spack-levante/libfyaml-0.7.12-fvbhgo/lib
+  $ export PYTHONPATH=${PYTHONPATH}:/your/path/to/yac/python/
+
 
 Python
 ------
@@ -66,29 +93,3 @@ You can install Python packages to an existing Conda (or Micromamba) environment
 
   $ micromamba activate [your environment]
   $ python -m pip install [package name(s)]
-
-YAC
----
-
-YAC is one of the :doc:`external libraries<extern>` which CLEO may require in order to
-couple to dynamics and/or have MPI domain decomposition.
-
-Note that YAC (and its YAXT dependency) need to be installed manually before you can build
-CLEO with them. You can find instructions on how to do install YAC (and YAXT) in the
-external libraries section.
-
-YAC also requires some additional MPI, NetCDF and yaml libraries alongside the compatible gcc
-compiler which you can load on Levante via:
-
-.. code-block:: console
-
-  $ module load gcc/11.2.0-gcc-11.2.0 openmpi@4.1.2%gcc@11.2.0 netcdf-c/4.8.1-openmpi-4.1.2-gcc-11.2.0
-  $ spack load openblas@0.3.18%gcc@=11.2.0
-
-When you want to run CLEO with YAC, you will also need to export some additional paths:
-
-.. code-block:: console
-
-  $ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/sw/spack-levante/libfyaml-0.7.12-fvbhgo/lib
-  $ export PYTHONPATH=${PYTHONPATH}:/your/path/to/yac/python/
-  $ spack load python@3.9.9%gcc@=11.2.0/fwv py-cython@0.29.33%gcc@=11.2.0/j7b4fa py-mpi4py@3.1.2%gcc@=11.2.0/hdi5yl6

--- a/examples/run_example_levante.sh
+++ b/examples/run_example_levante.sh
@@ -41,7 +41,7 @@ if [[ "${buildtype}" == "cuda" ]]
 then
   compilername=gcc
 else
-  compilername=gcc  # TODO(ALL): use intel (first fix yac installation to higher intel version)
+  compilername=intel
 fi
 
 if [[ "${compilername}" == "gcc" ]]

--- a/scripts/levante/bash/compile_cleo.sh
+++ b/scripts/levante/bash/compile_cleo.sh
@@ -39,13 +39,11 @@ source ${bashsrc}/levante_packages.sh
 
 if [ "${CLEO_COMPILERNAME}" == "intel" ]
 then
-  module load ${levante_intel}
-  spack load ${levante_intel_openmpi}
+  module load ${levante_intel} ${levante_intel_openmpi}
   spack load ${levante_intel_cmake}
 elif [ "${CLEO_COMPILERNAME}" == "gcc" ]
 then
-  module load ${levante_gcc}
-  spack load ${levante_gcc_openmpi}
+  module load ${levante_gcc} ${levante_gcc_openmpi}
   spack load ${levante_gcc_cmake}
   if [ "${CLEO_BUILDTYPE}" == "cuda" ]
   then

--- a/scripts/levante/bash/install_yac.sh
+++ b/scripts/levante/bash/install_yac.sh
@@ -48,8 +48,6 @@ then
   netcdf=${levante_gcc_netcdf_yac}
   netcdf_root=${levante_gcc_netcdf_root}
   fyaml_root=${levante_gcc_fyaml_root}
-  CC=${levante_gcc_compiler}
-  FC=${levante_gcc_f90_compiler}
 elif [ "${compilername}" == "intel" ]
 then
   compiler=${levante_intel}
@@ -57,8 +55,6 @@ then
   netcdf=${levante_intel_netcdf_yac}
   netcdf_root=${levante_intel_netcdf_root}
   fyaml_root=${levante_intel_fyaml_root}
-  CC=${levante_icc_compiler}
-  FC=${levante_intel_ifort_compiler}
 else
   echo "Bad input, unrecognised compiler name"
   exit 1
@@ -69,8 +65,10 @@ then
   echo "Bad input, please specify absolute path for where you want to install YAC and python to use to make bindings"
 else
   mkdir ${root4YAC}
-  module load ${compiler} ${netcdf}
-  spack load ${openmpi}
+  module load ${compiler} ${openmpi} ${netcdf}
+
+  CC="$(command -v mpicc)"
+  FC="$(command -v mpifort)"
 
   ### --------------------- install YAXT ------------------- ###
   mkdir ${root4YAC}/${yaxt_version}

--- a/scripts/levante/bash/src/build_basic.sh
+++ b/scripts/levante/bash/src/build_basic.sh
@@ -17,8 +17,7 @@ source ${bashsrc}/levante_packages.sh
 
 if [ "${CLEO_COMPILERNAME}" == "intel" ]
 then
-  module load ${levante_intel}
-  spack load ${levante_intel_openmpi}
+  module load ${levante_intel} ${levante_intel_openmpi}
   spack load ${levante_intel_cmake}
   export CLEO_CXX_COMPILER=${levante_icpc_compiler}
   export CLEO_CC_COMPILER=${levante_icc_compiler}
@@ -35,8 +34,7 @@ then
   fi
 elif [ "${CLEO_COMPILERNAME}" == "gcc" ]
 then
-  module load ${levante_gcc}
-  spack load ${levante_gcc_openmpi}
+  module load ${levante_gcc} ${levante_gcc_openmpi}
   spack load ${levante_gcc_cmake}
   export CLEO_CXX_COMPILER=${levante_gxx_compiler}
   export CLEO_CC_COMPILER=${levante_gcc_compiler}

--- a/scripts/levante/bash/src/build_yac.sh
+++ b/scripts/levante/bash/src/build_yac.sh
@@ -13,12 +13,13 @@ check_args_not_empty "${CLEO_PATH2CLEO}" "${CLEO_COMPILERNAME}" "${CLEO_CXX_COMP
 if  [[ "${CLEO_COMPILERNAME}" == "gcc" &&
        "${CLEO_CXX_COMPILER}" != "/sw/spack-levante/openmpi-4.1.2-mnmady/bin/mpic++" ]]
 then
-  echo "YAC currently requires gcc/11.2.0-gcc-11.2.0 compilers"
+  echo "YAC currently requires gcc/11.2.0-gcc-11.2.0 with openmpi/4.1.2-gcc-11.2.0 compilers"
   exit 1
 elif  [[ "${CLEO_COMPILERNAME}" == "intel" &&
-       "${CLEO_CXX_COMPILER}" != "/sw/spack-levante/openmpi-4.1.2-yfwe6t/bin/mpic++" ]]
+       "${CLEO_CXX_COMPILER}" != "/sw/spack-levante/openmpi-4.1.6-ux3zoj/bin/mpic++" ]]
 then
-  echo "YAC currently requires intel-oneapi-compilers/2023.2.1-gcc-11.2.0 compilers"
+  echo "YAC currently requires intel-oneapi-compilers/2024.2.1-gcc-13.3.0 with\
+  openmpi/4.1.6-oneapi-2024.2.1 compilers"
   exit 1
 fi
 ### ---------------------------------------------------- ###

--- a/scripts/levante/bash/src/levante_packages.sh
+++ b/scripts/levante/bash/src/levante_packages.sh
@@ -3,7 +3,7 @@
 ### -------------- GCC compiler(s) Packages ------------ ###
 levante_gcc="gcc/11.2.0-gcc-11.2.0" # bcn7mbu # module load
 levante_gcc_cmake="cmake@3.26.3%gcc@=11.2.0/fuvwuhz" # spack load
-levante_gcc_openmpi="openmpi@4.1.2%gcc@11.2.0" # spack load
+levante_gcc_openmpi="openmpi/4.1.2-gcc-11.2.0" # module load
 levante_gxx_compiler="/sw/spack-levante/openmpi-4.1.2-mnmady/bin/mpic++"
 levante_gcc_compiler="/sw/spack-levante/openmpi-4.1.2-mnmady/bin/mpicc"
 levante_gcc_cuda="cuda@12.2.0%gcc@=11.2.0"  # spack load
@@ -20,18 +20,18 @@ levante_gcc_netcdf_root="/sw/spack-levante/netcdf-c-4.8.1-6qheqr" # match `modul
 ### ---------------------------------------------------- ###
 
 ### ------------- Intel compiler(s) Packages ------------ ###
-levante_intel="intel-oneapi-mpi/2021.5.0-gcc-11.2.0" # module load
+levante_intel="intel-oneapi-compilers/2024.2.1-gcc-13.3.0" # module load
 levante_intel_cmake="cmake@3.23.1%oneapi" # spack load
-levante_intel_openmpi="openmpi@4.1.2%intel@=2021.5.0/yfwe6t4" # spack load
-levante_icpc_compiler="/sw/spack-levante/openmpi-4.1.2-yfwe6t/bin/mpic++"
-levante_icc_compiler="/sw/spack-levante/openmpi-4.1.2-yfwe6t/bin/mpicc"
+levante_intel_openmpi="openmpi/4.1.6-oneapi-2024.2.1" # module load
+levante_icpc_compiler="/sw/spack-levante/openmpi-4.1.6-ux3zoj/bin/mpic++"
+levante_icc_compiler="/sw/spack-levante/openmpi-4.1.6-ux3zoj/bin/mpicc"
 
 ### specific gcc compiler compatible packages for YAC installation and usage
-levante_intel_netcdf_yac="netcdf-c/4.8.1-intel-oneapi-mpi-2021.5.0-gcc-11.2.0" # module load
+levante_intel_netcdf_yac="netcdf-c/4.9.3pre-openmpi-4.1.6-oneapi-2024.2.1" # module load
 levante_intel_openblas_yac="openblas@0.3.18%intel@=2021.5.0" # spack load
 levante_intel_fyaml_root="/sw/spack-levante/libfyaml-0.7.12-fvbhgo" # match `spack location -i libfyaml`
 levante_intel_fyamllib="${levante_intel_fyaml_root}/lib"
 ### specific packages for YAC installation only
-levante_intel_ifort_compiler="/sw/spack-levante/openmpi-4.1.2-yfwe6t/bin/mpifort"
-levante_intel_netcdf_root="/sw/spack-levante/netcdf-c-4.8.1-xguss5" # match `module show ${netcdf}`
+levante_intel_ifort_compiler="/sw/spack-levante/openmpi-4.1.6-ux3zoj/bin/mpifort"
+levante_intel_netcdf_root="/sw/spack-levante/netcdf-c-main-l24a66" # match `module show ${netcdf}`
 ### ---------------------------------------------------- ###

--- a/scripts/levante/bash/src/runtime_settings.sh
+++ b/scripts/levante/bash/src/runtime_settings.sh
@@ -16,11 +16,11 @@ check_args_not_empty "${CLEO_COMPILERNAME}" "${CLEO_YACYAXTROOT}"
 source ${bashsrc}/levante_packages.sh
 if [ "${CLEO_COMPILERNAME}" == "gcc" ]
 then
-  spack load ${levante_gcc_openmpi}
+  module load ${levante_gcc_openmpi}
   fyamllib=${levante_gcc_fyamllib}
 elif [ "${CLEO_COMPILERNAME}" == "intel" ]
 then
-  spack load ${levante_intel_openmpi}
+  module load ${levante_intel_openmpi}
   fyamllib=${levante_intel_fyamllib}
 else
   echo "Bad inputs, YAC only compatible with "intel" or "gcc" compiler names"


### PR DESCRIPTION
fix incompatiblity between installing and using yac on levante, and using intel compiler version > 2022

dependent on [PR 185](https://github.com/yoctoyotta1024/CLEO/pull/185)