### PR TITLE
qcond must be recalculated after superdroplet motion

### DIFF
--- a/libs/superdrops/superdrop.hpp
+++ b/libs/superdrops/superdrop.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Friday 21st June 2024
+ * Last Modified: Thursday 10th July 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -173,6 +173,13 @@ class Superdrop {
    * @return mass of the super-droplet.
    */
   KOKKOS_INLINE_FUNCTION double mass() const { return attrs.mass(); }
+
+  /**
+   * @brief Get the mass of the super-droplet excluding its solute.
+   *
+   * @return mass of the super-droplet - mass of solute
+   */
+  KOKKOS_INLINE_FUNCTION double condensate_mass() const { return attrs.condensate_mass(); }
 
   /**
    * @brief Get the volume of the super-droplet.

--- a/libs/superdrops/superdrop_attrs.hpp
+++ b/libs/superdrops/superdrop_attrs.hpp
@@ -9,7 +9,7 @@
  * Author: Clara Bayley (CB)
  * Additional Contributors:
  * -----
- * Last Modified: Monday 24th March 2025
+ * Last Modified: Thursday 10th July 2025
  * Modified By: CB
  * -----
  * License: BSD 3-Clause "New" or "Revised" License
@@ -185,6 +185,13 @@ struct SuperdropAttrs {
    * @return The total droplet mass.
    */
   KOKKOS_FUNCTION double mass() const;
+
+  /**
+   * @brief Get the mass of the droplet excluding its solute.
+   *
+   * @return mass of the super-droplet - mass of solute
+   */
+  KOKKOS_INLINE_FUNCTION double condensate_mass() const { return mass() - msol; }
 
   /**
    * @brief Get the dry radius of droplet.


### PR DESCRIPTION
after superdroplet motion mass of condensates in each gridbox changes and so must be recalculated

Note this is a fix. The ideal solution would actually be to remove the qcond field entirely from CLEO's states and calculate it on-the-fly.