### PR TITLE
setup fromfile_irreg test to use mpi domain decomposition

### DIFF
--- a/examples/fromfile/fromfile.py
+++ b/examples/fromfile/fromfile.py
@@ -110,15 +110,15 @@ if do_inputfiles:
         sharepath.mkdir(exist_ok=True)
         binpath.parent.mkdir(exist_ok=True)
         binpath.mkdir(exist_ok=True)
-        savefigpath.parent.mkdir(exist_ok=True)
         savefigpath.mkdir(exist_ok=True)
 
     ### --- delete any existing initial conditions --- ###
     shutil.rmtree(grid_filename, ignore_errors=True)
     shutil.rmtree(initsupers_filename, ignore_errors=True)
-    shutil.rmtree(
-        str(thermofiles)[:-4] + "*", ignore_errors=True
-    )  # delete any existing dataset
+    all_thermofiles = thermofiles.parent / Path(
+        f"{thermofiles.stem}*{thermofiles.suffix}"
+    )
+    shutil.rmtree(all_thermofiles, ignore_errors=True)
 
     fromfile_inputfiles.main(
         path2CLEO,

--- a/examples/fromfile/fromfile.sh
+++ b/examples/fromfile/fromfile.sh
@@ -27,7 +27,8 @@ executables="fromfile"
 
 pythonscript=${path2CLEO}/examples/fromfile/fromfile.py
 configfile=${path2CLEO}/examples/fromfile/src/config/fromfile_config.yaml
-script_args="${configfile} --do_inputfiles=TRUE --do_run_executable=TRUE --do_plot_results=TRUE --ntasks=4"
+script_args="${configfile} --do_inputfiles=TRUE --do_run_executable=TRUE \
+  --do_plot_results=TRUE --ntasks=4"
 ### ---------------------------------------------------- ###
 ### ---------------------------------------------------- ###
 ### ---------------------------------------------------- ###

--- a/examples/fromfile_irreg/fromfile_irreg.sh
+++ b/examples/fromfile_irreg/fromfile_irreg.sh
@@ -27,7 +27,8 @@ executables="fromfile_irreg"
 
 pythonscript=${path2CLEO}/examples/fromfile_irreg/fromfile_irreg.py
 configfile=${path2CLEO}/examples/fromfile_irreg/src/config/fromfile_irreg_config.yaml
-script_args="${configfile} --do_inputfiles=TRUE --do_run_executable=TRUE --do_plot_results=TRUE --ntasks=4"
+script_args="${configfile} --do_inputfiles=TRUE --do_run_executable=TRUE \
+  --do_plot_results=TRUE --ntasks=4"
 ### ---------------------------------------------------- ###
 ### ---------------------------------------------------- ###
 ### ---------------------------------------------------- ###

--- a/examples/fromfile_irreg/fromfile_irreg.sh
+++ b/examples/fromfile_irreg/fromfile_irreg.sh
@@ -2,8 +2,8 @@
 #SBATCH --job-name=fromfile_irreg
 #SBATCH --partition=compute
 #SBATCH --nodes=1
-#SBATCH --ntasks-per-node=1
-#SBATCH --cpus-per-task=128
+#SBATCH --ntasks-per-node=4
+#SBATCH --cpus-per-task=16
 #SBATCH --mem=10G
 #SBATCH --time=00:05:00
 #SBATCH --mail-user=clara.bayley@mpimet.mpg.de
@@ -27,7 +27,7 @@ executables="fromfile_irreg"
 
 pythonscript=${path2CLEO}/examples/fromfile_irreg/fromfile_irreg.py
 configfile=${path2CLEO}/examples/fromfile_irreg/src/config/fromfile_irreg_config.yaml
-script_args="${configfile}"
+script_args="${configfile} --do_inputfiles=TRUE --do_run_executable=TRUE --do_plot_results=TRUE --ntasks=4"
 ### ---------------------------------------------------- ###
 ### ---------------------------------------------------- ###
 ### ---------------------------------------------------- ###

--- a/examples/fromfile_irreg/fromfile_irreg_plotting.py
+++ b/examples/fromfile_irreg/fromfile_irreg_plotting.py
@@ -1,0 +1,74 @@
+'''
+Copyright (c) 2025 MPI-M, Clara Bayley
+
+
+----- CLEO -----
+File: fromfile_irreg_plotting.py
+Project: fromfile_irreg
+Created Date: Monday 21st July 2025
+Author: Clara Bayley (CB)
+Additional Contributors:
+-----
+License: BSD 3-Clause "New" or "Revised" License
+https://opensource.org/licenses/BSD-3-Clause
+-----
+File Description:
+Script plots results of 3D example with time varying thermodynamics
+read from binary files.
+'''
+
+
+import sys
+
+
+def main(
+    path2CLEO,
+    grid_filename,
+    setupfile,
+    dataset,
+    savefigpath,
+):
+    sys.path.append(str(path2CLEO))  # imports from pySD
+    sys.path.append(
+        str(path2CLEO / "examples" / "exampleplotting")
+    )  # imports from example plots package
+
+    from src import plot_output_thermo
+    from plotssrc import pltsds, pltmoms
+    from pySD.sdmout_src import pyzarr, pysetuptxt, pygbxsdat
+
+    # read in constants and intial setup from setup .txt file
+    config = pysetuptxt.get_config(setupfile, nattrs=3, isprint=True)
+    consts = pysetuptxt.get_consts(setupfile, isprint=True)
+    gbxs = pygbxsdat.get_gridboxes(grid_filename, consts["COORD0"], isprint=True)
+
+    time = pyzarr.get_time(dataset)
+    superdrops = pyzarr.get_supers(dataset, consts)
+    maxnsupers = pyzarr.get_totnsupers(dataset)
+    thermo, winds = pyzarr.get_thermodata(
+        dataset, config["ntime"], gbxs["ndims"], consts, getwinds=True
+    )
+
+    # plot super-droplet results
+    savename = savefigpath / "fromfile_irreg_maxnsupers_validation.png"
+    pltmoms.plot_totnsupers(time, maxnsupers, savename=savename)
+
+    nsample = 1000
+    savename = savefigpath / "fromfile_irreg_motion2d_validation.png"
+    pltsds.plot_randomsample_superdrops_2dmotion(
+        superdrops,
+        nsample,
+        savename=savename,
+        arrows=False,
+        israndom=False,
+    )
+
+    # plot thermodynamics results
+    plot_output_thermo.plot_domain_thermodynamics_timeseries(
+        time, gbxs, thermo, winds, savedir=savefigpath
+    )
+
+
+if __name__ == "__main__":
+    ### args = path2CLEO, grid_filename, setupfile, dataset, savefigpath,
+    main(*sys.argv[1:])

--- a/examples/fromfile_irreg/fromfile_irreg_plotting.py
+++ b/examples/fromfile_irreg/fromfile_irreg_plotting.py
@@ -1,4 +1,4 @@
-'''
+"""
 Copyright (c) 2025 MPI-M, Clara Bayley
 
 
@@ -15,7 +15,7 @@ https://opensource.org/licenses/BSD-3-Clause
 File Description:
 Script plots results of 3D example with time varying thermodynamics
 read from binary files.
-'''
+"""
 
 
 import sys

--- a/examples/fromfile_irreg/src/CMakeLists.txt
+++ b/examples/fromfile_irreg/src/CMakeLists.txt
@@ -8,6 +8,9 @@ endif()
 project("fromfile_irreg")
 message(STATUS "CLEO including ${PROJECT_NAME} with PROJECT_SOURCE_DIR: ${PROJECT_SOURCE_DIR}")
 
+# require MPI explicitly for this library
+find_package(MPI REQUIRED COMPONENTS C)
+
 # Set libraries from CLEO to link with executable
 set(CLEOLIBS configuration gridboxes initialise observers runcleo superdrops zarr)
 
@@ -15,9 +18,9 @@ set(CLEOLIBS configuration gridboxes initialise observers runcleo superdrops zar
 add_executable(fromfile_irreg EXCLUDE_FROM_ALL "main_fromfile_irreg.cpp")
 
 # Add directories and link libraries to target
+target_include_directories(fromfile_irreg PRIVATE "${CLEO_SOURCE_DIR}/libs" ${MPI_INCLUDE_PATH})
 target_link_libraries(fromfile_irreg PRIVATE coupldyn_fromfile cartesiandomain "${CLEOLIBS}")
-target_link_libraries(fromfile_irreg PUBLIC Kokkos::kokkos)
-target_include_directories(fromfile_irreg PRIVATE "${CLEO_SOURCE_DIR}/libs") # CLEO libs directory
+target_link_libraries(fromfile_irreg PUBLIC Kokkos::kokkos MPI::MPI_C)
 
 # set specific C++ compiler options for target (optional)
 #target_compile_options(fromfile_irreg PRIVATE)

--- a/examples/fromfile_irreg/src/config/fromfile_irreg_config.yaml
+++ b/examples/fromfile_irreg/src/config/fromfile_irreg_config.yaml
@@ -19,6 +19,10 @@
 # and so can the thermodynamics files when using coupled thermodynamics "fromfile_irreg".
 #
 
+### Kokkos Initialization Parameters ###
+kokkos_settings:
+  num_threads: 16                                          # number of threads for host parallel backend
+
 ### SDM Runtime Parameters ###
 domain:
   nspacedims : 3                                          # no. of spatial dimensions to model
@@ -44,8 +48,8 @@ initsupers:
 
 ### Output Parameters ###
 outputdata:
-  setup_filename : ./bin/fromfile_irreg_setup.txt                   # .txt filename to copy configuration to
-  zarrbasedir : ./bin/fromfile_irreg_sol.zarr                       # zarr store base directory
+  setup_filename : ./bin/ntasks4/fromfile_irreg_setup.txt                   # .txt filename to copy configuration to
+  zarrbasedir : ./bin/ntasks4/fromfile_irreg_sol.zarr                       # zarr store base directory
   maxchunk : 2500000                                      # maximum no. of elements in chunks of zarr store array
 
 ### Coupled Dynamics Parameters ###

--- a/examples/fromfile_irreg/src/main_fromfile_irreg.cpp
+++ b/examples/fromfile_irreg/src/main_fromfile_irreg.cpp
@@ -25,7 +25,9 @@
 #include <stdexcept>
 #include <string_view>
 
+#include "cartesiandomain/cartesian_decomposition.hpp"
 #include "cartesiandomain/cartesianmaps.hpp"
+#include "cartesiandomain/collect_data_for_collective_dataset.hpp"
 #include "cartesiandomain/createcartesianmaps.hpp"
 #include "cartesiandomain/movement/cartesian_motion.hpp"
 #include "cartesiandomain/movement/cartesian_movement.hpp"
@@ -34,11 +36,11 @@
 #include "coupldyn_fromfile/fromfilecomms.hpp"
 #include "gridboxes/boundary_conditions.hpp"
 #include "gridboxes/gridboxmaps.hpp"
-#include "initialise/init_all_supers_from_binary.hpp"
+#include "initialise/init_supers_from_binary.hpp"
 #include "initialise/initgbxsnull.hpp"
 #include "initialise/initialconditions.hpp"
 #include "initialise/timesteps.hpp"
-#include "observers/collect_data_for_simple_dataset.hpp"
+#include "mpi.h"
 #include "observers/gbxindex_observer.hpp"
 #include "observers/observers.hpp"
 #include "observers/state_observer.hpp"
@@ -51,8 +53,8 @@
 #include "runcleo/sdmmethods.hpp"
 #include "superdrops/microphysicalprocess.hpp"
 #include "superdrops/motion.hpp"
+#include "zarr/collective_dataset.hpp"
 #include "zarr/fsstore.hpp"
-#include "zarr/simple_dataset.hpp"
 
 inline CoupledDynamics auto create_coupldyn(const Config &config, const CartesianMaps &gbxmaps,
                                             const unsigned int couplstep,
@@ -67,7 +69,7 @@ inline CoupledDynamics auto create_coupldyn(const Config &config, const Cartesia
 
 template <GridboxMaps GbxMaps>
 inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
-  const auto initsupers = InitAllSupersFromBinary(config.get_initsupersfrombinary());
+  const auto initsupers = InitSupersFromBinary(config.get_initsupersfrombinary(), gbxmaps);
   const auto initgbxs = InitGbxsNull(gbxmaps.get_local_ngridboxes_hostcopy());
 
   return InitConds(initsupers, initgbxs);
@@ -102,16 +104,16 @@ inline Observer auto create_superdrops_observer(const unsigned int interval, Dat
   CollectDataForDataset<Dataset> auto coord1 = CollectCoord1(dataset, maxchunk);
   CollectDataForDataset<Dataset> auto coord2 = CollectCoord2(dataset, maxchunk);
 
-  const auto collect_sddata = coord2 >> coord1 >> coord3 >> sdid;
+  const auto collect_sddata = sdid >> coord3 >> coord1 >> coord2;
   return SuperdropsObserver(interval, dataset, store, maxchunk, collect_sddata);
 }
 
 template <typename Dataset, typename Store>
 inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset &dataset, Store &store) {
+                                     Dataset &dataset, Store &store, const CartesianMaps &gbxmaps) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
-  const auto ngbxs = config.get_ngbxs();
+  const auto ngbxs = gbxmaps.get_local_ngridboxes();
 
   const Observer auto obs0 = StreamOutObserver(obsstep, &step2realtime);
 
@@ -119,7 +121,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 
   const Observer auto obs2 = GbxindexObserver(dataset, store, maxchunk, ngbxs);
 
-  const Observer auto obs3 = StateObserver(obsstep, dataset, maxchunk, ngbxs);
+  const Observer auto obs3 =
+      StateObserver(obsstep, dataset, maxchunk, gbxmaps.get_total_global_ngridboxes());
 
   const Observer auto obssd = create_superdrops_observer(obsstep, dataset, store, maxchunk);
 
@@ -133,7 +136,7 @@ inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset &d
   const GridboxMaps auto gbxmaps(create_gbxmaps(config));
   const MicrophysicalProcess auto microphys(create_microphysics(config, tsteps));
   const MoveSupersInDomain movesupers(create_movement(tsteps.get_motionstep(), gbxmaps));
-  const Observer auto obs = create_observer(config, tsteps, dataset, store);
+  const Observer auto obs = create_observer(config, tsteps, dataset, store, gbxmaps);
 
   return SDMMethods(couplstep, gbxmaps, microphys, movesupers, obs);
 }
@@ -144,14 +147,6 @@ int main(int argc, char *argv[]) {
   }
 
   MPI_Init(&argc, &argv);
-
-  int comm_size;
-  MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
-  if (comm_size > 1) {
-    std::cout << "ERROR: The current example is not prepared"
-              << " to be run with more than one MPI process" << std::endl;
-    MPI_Abort(MPI_COMM_WORLD, 1);
-  }
 
   Kokkos::Timer kokkostimer;
 
@@ -169,10 +164,14 @@ int main(int argc, char *argv[]) {
 
     /* Create Xarray dataset wit Zarr backend for writing output data to a store */
     auto store = FSStore(config.get_zarrbasedir());
-    auto dataset = SimpleDataset(store);
+    auto dataset = CollectiveDataset<FSStore, CartesianDecomposition>(store);
 
     /* CLEO Super-Droplet Model (excluding coupled dynamics solver) */
     const SDMMethods sdm = create_sdm(config, tsteps, dataset, store);
+
+    /* Adjust dataset given domain decomposition */
+    dataset.set_decomposition(sdm.gbxmaps.get_domain_decomposition());
+    dataset.set_max_superdroplets(config.get_maxnsupers());
 
     /* Solver of dynamics coupled to CLEO SDM */
     CoupledDynamics auto coupldyn(

--- a/examples/fromfile_irreg/src/plot_output_thermo.py
+++ b/examples/fromfile_irreg/src/plot_output_thermo.py
@@ -80,7 +80,7 @@ def plot_timeseries_domain_slices(
     """plot 2-D cross-sections along y axis of 3-D data 'data3d' for several timeslices
     given times and meshgrid for centres in x and z, 'xxh' and 'zzh'."""
 
-    fig = plt.figure(figsize=(21, 15))
+    fig = plt.figure(figsize=(16, 9))
     ncols = len(t2plts)
     nrows = data4d.shape[1]
     gs = GridSpec(
@@ -93,6 +93,8 @@ def plot_timeseries_domain_slices(
         fig, gs, nrows, ncols, time, t2plts, xxh, zzh, yfull, data4d, cmap, norm
     )
     plt.colorbar(pcm, cax=cax, orientation="horizontal")
+
+    fig.tight_layout()
 
     if savedir != "":
         savename = savedir / Path(f"timeseries_{key}.png")


### PR DESCRIPTION
- ntasks given to python script ``fromfile_irreg.py`` and in L51 and L52 of configuration file ``fromfile_irreg_config.yaml`` determines number of tasks used to run fromfile_irreg example
- ntasks > 1 is allowed but currently given erroneous results (need variable gridbox sixes changes)