### PR TITLE
YAC-Coupling 1: First two-way ICON coupling

### DIFF
--- a/examples/bubble3d/src/config/bubble3d_config.yaml
+++ b/examples/bubble3d/src/config/bubble3d_config.yaml
@@ -41,8 +41,8 @@ timesteps:
   CONDTSTEP : 2                                           # time between SD condensation [s]
   COLLTSTEP : 2                                           # time between SD collision [s]
   MOTIONTSTEP : 3                                         # time between SDM motion [s]
-  COUPLTSTEP : 60                                         # time between dynamic couplings [s]
-  OBSTSTEP : 60                                           # time between SDM observations [s]
+  COUPLTSTEP : 30                                         # time between dynamic couplings [s]
+  OBSTSTEP : 30                                           # time between SDM observations [s]
   T_END : 7200                                            # time span of integration from 0s to T_END [s]
 
 ### Initialisation Parameters ###

--- a/examples/bubble3d/src/main_bubble3d.cpp
+++ b/examples/bubble3d/src/main_bubble3d.cpp
@@ -41,11 +41,14 @@
 #include "initialise/timesteps.hpp"
 #include "observers/collect_data_for_simple_dataset.hpp"
 #include "observers/gbxindex_observer.hpp"
+#include "observers/massmoments_observer.hpp"
 #include "observers/observers.hpp"
+#include "observers/sdmmonitor/monitor_precipitation_observer.hpp"
 #include "observers/state_observer.hpp"
 #include "observers/streamout_observer.hpp"
 #include "observers/superdrops_observer.hpp"
 #include "observers/time_observer.hpp"
+#include "observers/totnsupers_observer.hpp"
 #include "runcleo/coupleddynamics.hpp"
 #include "runcleo/couplingcomms.hpp"
 #include "runcleo/runcleo.hpp"
@@ -127,9 +130,17 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 
   const Observer auto obs3 = StateObserver(obsstep, dataset, maxchunk, ngbxs);
 
+  const Observer auto obs4 = MassMomentsObserver(obsstep, dataset, store, maxchunk, ngbxs);
+
+  const Observer auto obs5 = MassMomentsRaindropsObserver(obsstep, dataset, store, maxchunk, ngbxs);
+
+  const Observer auto obs6 = MonitorPrecipitationObserver(obsstep, dataset, store, maxchunk, ngbxs);
+
+  const Observer auto obs7 = TotNsupersObserver(obsstep, dataset, store, maxchunk);
+
   const Observer auto obssd = create_superdrops_observer(obsstep, dataset, store, maxchunk);
 
-  return obssd >> obs3 >> obs2 >> obs1 >> obs0;
+  return obssd >> obs7 >> obs6 >> obs5 >> obs4 >> obs3 >> obs2 >> obs1 >> obs0;
 }
 
 template <typename Dataset, typename Store>

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
@@ -188,9 +188,9 @@ void CartesianDynamics::send_yac_field(int field_id, double* field_data,
 
   send_buffer = new double **[ndims_vertical];
 
-  for (int j = 0; j < ndims_vertical; ++j) {
-      send_buffer[j] = new double*[1];
-      send_buffer[j][0] = new double[ncells];
+  for (size_t j = 0; j < ndims_vertical; ++j) {
+    send_buffer[j] = new double*[1];
+    send_buffer[j][0] = new double[ncells];
   }
 
   for (size_t j = 0; j < ndims_north; j++) {
@@ -211,9 +211,9 @@ void CartesianDynamics::send_yac_field(int field_id, double* field_data,
 
   std::cout << "yac_cput_ completed with info as: " << info << std::endl;
 
-  for (int j = 0; j < ndims_vertical; ++j) {
-      delete send_buffer[j][0];
-      delete send_buffer[j];
+  for (size_t j = 0; j < ndims_vertical; ++j) {
+    delete send_buffer[j][0];
+    delete send_buffer[j];
   }
   delete[] send_buffer;
 }

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
@@ -183,8 +183,8 @@ void CartesianDynamics::send_yac_field(int field_id, double* field_data,
   auto ncells = ndims_north * ndims_east;
 
   int info, ierror;
-  auto field_size = ncells*ndims_vertical;
-  double **collection_data;
+  // auto field_size = ncells*ndims_vertical;
+  // double **collection_data;
 
   send_buffer = new double **[ndims_vertical];
 

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
@@ -33,6 +33,7 @@
 
 #include "configuration/communicator.hpp"
 #include "configuration/config.hpp"
+#include "superdrops/state.hpp"
 
 /* contains 1-D vector for each (thermo)dynamic
 variable which is ordered by gridbox at every timestep
@@ -63,8 +64,11 @@ struct CartesianDynamics {
   // YAC field ids
   int pressure_yac_id;
   int temp_yac_id;
+  int temp_yac_id2;
   int qvap_yac_id;
+  int qvap_yac_id2;
   int qcond_yac_id;
+  int qcond_yac_id2;
   int eastward_wind_yac_id;
   int northward_wind_yac_id;
   int vertical_wind_yac_id;
@@ -125,6 +129,10 @@ struct CartesianDynamics {
                          std::vector<double> &target_array, const size_t ndims_north,
                          const size_t ndims_east, const size_t vertical_levels,
                          double conversion_factor) const;
+  void send_yac_field(double* field_data, double conversion_factor);
+  void send_fields_to_yac(double* temp_state,
+                          double* qvap_state,
+                          double* qcond_state);
 };
 
 /* type satisfying CoupledDyanmics solver concept
@@ -158,6 +166,8 @@ struct YacDynamics {
       run_dynamics(t_mdl);
     }
   }
+
+  const std::shared_ptr<CartesianDynamics>& get_dynvars() const { return dynvars; }
 
   double get_press(const size_t ii) const { return dynvars->get_press(ii); }
 

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
@@ -34,7 +34,6 @@
 #include "configuration/communicator.hpp"
 #include "configuration/config.hpp"
 #include "superdrops/state.hpp"
-
 /* contains 1-D vector for each (thermo)dynamic
 variable which is ordered by gridbox at every timestep
 e.g. press = [p_gbx0(t0), p_gbx1(t0), ,... , p_gbxN(t0),
@@ -78,6 +77,8 @@ struct CartesianDynamics {
   double **yac_raw_edge_data;
   double **yac_raw_vertical_wind_data;
 
+  // Container to send the data to YAC
+  double ***send_buffer;
   /* --- Private functions --- */
 
   /* depending on nspacedims, read in data
@@ -129,7 +130,7 @@ struct CartesianDynamics {
                          std::vector<double> &target_array, const size_t ndims_north,
                          const size_t ndims_east, const size_t vertical_levels,
                          double conversion_factor) const;
-  void send_yac_field(double* field_data, double conversion_factor);
+  void send_yac_field(int field_id, double* field_data, double conversion_factor);
   void send_fields_to_yac(double* temp_state,
                           double* qvap_state,
                           double* qcond_state);
@@ -142,10 +143,13 @@ struct YacDynamics {
  private:
   const unsigned int interval;
   const unsigned int end_time;
+  static int get_counter;
   std::shared_ptr<CartesianDynamics> dynvars;  // pointer to (thermo)dynamic variables
 
   /* Calls the get operations to receive data from YAC for each of the fields of interest */
-  void run_dynamics(const unsigned int t_mdl) const { dynvars->receive_fields_from_yac(); }
+  void run_dynamics(const unsigned int t_mdl) const {
+     // dynvars->receive_fields_from_yac();
+  }
 
  public:
   YacDynamics(const Config &config, const unsigned int couplstep, const std::array<size_t, 3> ndims,
@@ -183,5 +187,8 @@ struct YacDynamics {
 
   std::pair<double, double> get_vvel(const size_t ii) const { return dynvars->get_vvel(ii); }
 };
+
+// int YacDynamics::get_counter = 1;
+
 
 #endif  // LIBS_COUPLDYN_YAC_YAC_CARTESIAN_DYNAMICS_HPP_

--- a/libs/coupldyn_yac/yac_comms.hpp
+++ b/libs/coupldyn_yac/yac_comms.hpp
@@ -36,6 +36,8 @@ struct YacComms {
   void update_gridbox_state(const YacDynamics &ffdyn, const size_t ii, Gridbox &gbx) const;
 
  public:
+  static int get_counter;
+  static int put_counter;
   /* send information from Gridboxes' states
   to coupldyn is null for YacDynamics*/
   template <typename GbxMaps, typename CD = YacDynamics>

--- a/libs/coupldyn_yac/yac_comms.hpp
+++ b/libs/coupldyn_yac/yac_comms.hpp
@@ -39,8 +39,8 @@ struct YacComms {
   /* send information from Gridboxes' states
   to coupldyn is null for YacDynamics*/
   template <typename GbxMaps, typename CD = YacDynamics>
-  void send_dynamics(const GbxMaps &gbxmaps, const viewh_constgbx h_gbxs,
-                     YacDynamics &ffdyn) const {}
+  void send_dynamics(const GbxMaps&,
+    const viewh_constgbx, const YacDynamics &ffdyn) const;
 
   /* update Gridboxes' states using information
   received from YacDynamics solver for


### PR DESCRIPTION
Do not merge without [PR 283](https://github.com/yoctoyotta1024/CLEO/pull/283)!!

First running two-way coupling:
- Added new put function which calls yac_cput
- Addressed the issue of staggered coupling, by issuing less number of puts in CLEO
