### PR TITLE
YAC-Coupling 2: MPI-YAC-Compatibility 3: 

### DIFF
--- a/examples/bubble3d/bubble3d_inputfiles.py
+++ b/examples/bubble3d/bubble3d_inputfiles.py
@@ -139,13 +139,13 @@ def main(
     zgrid = get_zgrid(icon_grid_file, num_vertical_levels)  # [m]
     xgrid = [
         0,
-        100000,
+        30000,
         2500,
     ]  # evenly spaced xhalf coords [m] # distance must match longitude in config file
     ygrid = [
         0,
-        20000,
-        4000,
+        6250,
+        1250,
     ]  # evenly spaced xhalf coords [m] # distance must match latitudes in config file
 
     ### --- settings for initial superdroplets --- ###

--- a/examples/bubble3d/bubble3d_inputfiles.py
+++ b/examples/bubble3d/bubble3d_inputfiles.py
@@ -139,13 +139,13 @@ def main(
     zgrid = get_zgrid(icon_grid_file, num_vertical_levels)  # [m]
     xgrid = [
         0,
-        30000,
+        100000,
         2500,
     ]  # evenly spaced xhalf coords [m] # distance must match longitude in config file
     ygrid = [
         0,
-        6250,
-        1250,
+        20000,
+        4000,
     ]  # evenly spaced xhalf coords [m] # distance must match latitudes in config file
 
     ### --- settings for initial superdroplets --- ###

--- a/examples/bubble3d/src/config/bubble3d_config.yaml
+++ b/examples/bubble3d/src/config/bubble3d_config.yaml
@@ -34,8 +34,8 @@ kokkos_settings:
 ### SDM Runtime Parameters ###
 domain:
   nspacedims : 3                                          # no. of spatial dimensions to model
-  ngbxs : 4800                                            # total number of Gbxs
-  maxnsupers: 4800                                        # maximum number of SDs
+  ngbxs : 1440                                            # total number of Gbxs
+  maxnsupers: 1440                                        # maximum number of SDs
 
 timesteps:
   CONDTSTEP : 2                                           # time between SD condensation [s]

--- a/examples/bubble3d/src/config/bubble3d_config.yaml
+++ b/examples/bubble3d/src/config/bubble3d_config.yaml
@@ -41,8 +41,8 @@ timesteps:
   CONDTSTEP : 2                                           # time between SD condensation [s]
   COLLTSTEP : 2                                           # time between SD collision [s]
   MOTIONTSTEP : 3                                         # time between SDM motion [s]
-  COUPLTSTEP : 60                                         # time between dynamic couplings [s]
-  OBSTSTEP : 60                                           # time between SDM observations [s]
+  COUPLTSTEP : 30                                         # time between dynamic couplings [s]
+  OBSTSTEP : 30                                           # time between SDM observations [s]
   T_END : 7200                                            # time span of integration from 0s to T_END [s]
 
 ### Initialisation Parameters ###

--- a/examples/bubble3d/src/config/bubble3d_config.yaml
+++ b/examples/bubble3d/src/config/bubble3d_config.yaml
@@ -34,8 +34,8 @@ kokkos_settings:
 ### SDM Runtime Parameters ###
 domain:
   nspacedims : 3                                          # no. of spatial dimensions to model
-  ngbxs : 1440                                            # total number of Gbxs
-  maxnsupers: 1440                                        # maximum number of SDs
+  ngbxs : 4800                                            # total number of Gbxs
+  maxnsupers: 4800                                        # maximum number of SDs
 
 timesteps:
   CONDTSTEP : 2                                           # time between SD condensation [s]
@@ -62,7 +62,7 @@ outputdata:
 
 coupled_dynamics:
   type: yac
-  lower_longitude: -0.989601687                               # must match xgrid domain delta_x
-  upper_longitude: 0.895353906
-  lower_latitude: -0.392699082                                # must match ygrid domain delta_y
-  upper_latitude: 0.392699082
+  lower_longitude: -3.29867229                                # must match xgrid domain delta_x
+  upper_longitude: 2.98451302
+  lower_latitude: -1.25665                                    # must match ygrid domain delta_y
+  upper_latitude: 1.25665

--- a/examples/bubble3d/src/config/bubble3d_config.yaml
+++ b/examples/bubble3d/src/config/bubble3d_config.yaml
@@ -34,8 +34,8 @@ kokkos_settings:
 ### SDM Runtime Parameters ###
 domain:
   nspacedims : 3                                          # no. of spatial dimensions to model
-  ngbxs : 1440                                            # total number of Gbxs
-  maxnsupers: 1440                                        # maximum number of SDs
+  ngbxs : 4800                                            # total number of Gbxs
+  maxnsupers: 4800                                        # maximum number of SDs
 
 timesteps:
   CONDTSTEP : 2                                           # time between SD condensation [s]
@@ -47,17 +47,17 @@ timesteps:
 
 ### Initialisation Parameters ###
 inputfiles:
-  constants_filename : ./libs/cleoconstants.hpp          # name of file for values of physical constants
-  grid_filename : ./build/share/bubble3d_dimlessGBxboundaries.dat   # binary filename for initialisation of GBxs / GbxMaps
+  constants_filename : /home/k/k202203/CLEO/libs/cleoconstants.hpp          # name of file for values of physical constants
+  grid_filename : /home/k/k202203/CLEO/build/share/bubble3d_dimlessGBxboundaries.dat   # binary filename for initialisation of GBxs / GbxMaps
 
 initsupers:
   type: frombinary                                        # type of initialisation of super-droplets
-  initsupers_filename : ./build/share/bubble3d_dimlessSDsinit.dat   # binary filename for initialisation of SDs
+  initsupers_filename : /home/k/k202203/CLEO/build/share/bubble3d_dimlessSDsinit.dat   # binary filename for initialisation of SDs
 
 ### Output Parameters ###
 outputdata:
-  setup_filename : ./build/bin/bubble3d_setup.txt    # .txt filename to copy configuration to
-  zarrbasedir : ./build/bin/bubble3d_sol.zarr        # zarr store base directory
+  setup_filename : /home/k/k202203/CLEO/build/bin/bubble3d_setup.txt    # .txt filename to copy configuration to
+  zarrbasedir : /home/k/k202203/CLEO/build/bin/bubble3d_sol.zarr        # zarr store base directory
   maxchunk : 2500000                                          # maximum no. of elements in chunks of zarr store array
 
 coupled_dynamics:

--- a/examples/bubble3d/src/main_bubble3d.cpp
+++ b/examples/bubble3d/src/main_bubble3d.cpp
@@ -65,8 +65,8 @@ inline CoupledDynamics auto create_coupldyn(const Config &config, const Cartesia
   const std::array<size_t, 3> ndims({h_ndims(0), h_ndims(1), h_ndims(2)});
 
   const auto nsteps = (unsigned int)(std::ceil(t_end / couplstep) + 1);
-
-  return YacDynamics(config, couplstep, ndims, nsteps);
+  const CartesianDecomposition& decomp = gbxmaps.get_domain_decomposition();
+  return YacDynamics(config, couplstep, ndims, nsteps, decomp);
 }
 
 template <GridboxMaps GbxMaps>
@@ -87,11 +87,17 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
                                                      const Timesteps &tsteps) {
   return NullMicrophysicalProcess{};
 }
+// inline auto create_movement(const unsigned int motionstep, const CartesianMaps &gbxmaps) {
+//   const Motion<CartesianMaps> auto motion = NullMotion{};
+//   const BoundaryConditions<CartesianMaps> auto boundary_conditions = NullBoundaryConditions{};
+
+//  return cartesian_movement(gbxmaps, motion, boundary_conditions);
+// }
 
 inline auto create_movement(const unsigned int motionstep, const CartesianMaps &gbxmaps) {
   const auto terminalv = NullTerminalVelocity{};
   const Motion<CartesianMaps> auto motion =
-      CartesianMotion(motionstep, &step2dimlesstime, terminalv);
+       CartesianMotion(motionstep, &step2dimlesstime, terminalv);
 
   const BoundaryConditions<CartesianMaps> auto boundary_conditions = NullBoundaryConditions{};
 

--- a/examples/bubble3d/src/main_bubble3d.cpp
+++ b/examples/bubble3d/src/main_bubble3d.cpp
@@ -41,11 +41,14 @@
 #include "initialise/timesteps.hpp"
 #include "observers/collect_data_for_simple_dataset.hpp"
 #include "observers/gbxindex_observer.hpp"
+#include "observers/massmoments_observer.hpp"
 #include "observers/observers.hpp"
+#include "observers/sdmmonitor/monitor_precipitation_observer.hpp"
 #include "observers/state_observer.hpp"
 #include "observers/streamout_observer.hpp"
 #include "observers/superdrops_observer.hpp"
 #include "observers/time_observer.hpp"
+#include "observers/totnsupers_observer.hpp"
 #include "runcleo/coupleddynamics.hpp"
 #include "runcleo/couplingcomms.hpp"
 #include "runcleo/runcleo.hpp"
@@ -127,9 +130,17 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 
   const Observer auto obs3 = StateObserver(obsstep, dataset, maxchunk, ngbxs);
 
+  const Observer auto obs4 = MassMomentsObserver(obsstep, dataset, store, maxchunk, ngbxs);
+
+  const Observer auto obs5 = MassMomentsRaindropsObserver(obsstep, dataset, store, maxchunk, ngbxs);
+
+  const Observer auto obs6 = MonitorPrecipitationObserver(obsstep, dataset, store, maxchunk, ngbxs);
+
+  const Observer auto obs7 = TotNsupersObserver(obsstep, dataset, store, maxchunk);
+
   const Observer auto obssd = create_superdrops_observer(obsstep, dataset, store, maxchunk);
 
-  return obssd >> obs3 >> obs2 >> obs1 >> obs0;
+  return obssd >> obs7 >> obs6 >> obs5 >> obs4 >> obs3 >> obs2 >> obs1 >> obs0;
 }
 
 template <typename Dataset, typename Store>

--- a/libs/cartesiandomain/cartesian_decomposition.cpp
+++ b/libs/cartesiandomain/cartesian_decomposition.cpp
@@ -401,7 +401,7 @@ int find_best_decomposition(std::vector<std::vector<size_t>> &factors,
                             const std::vector<size_t> ndims) {
   std::array<size_t, 3> partition_origin, partition_size;
   int comm_size, best_factorization = -1;
-  double vertical_split_penalization = 1.0;
+  double vertical_split_penalization = 100.0;
   comm_size = init_communicator::get_comm_size();
 
   // Calculates the ideal (most even possible) division and initializes the minimum error

--- a/libs/cartesiandomain/cartesian_decomposition.cpp
+++ b/libs/cartesiandomain/cartesian_decomposition.cpp
@@ -37,6 +37,13 @@ std::array<size_t, 3> CartesianDecomposition::get_local_partition_size() const {
   return partition_sizes[my_rank];
 };
 
+std::vector<std::vector<double>> CartesianDecomposition::get_local_gridbox_bounds() const {
+  return gridbox_bounds;
+};
+std::array<std::array<double, 3>, 2> CartesianDecomposition::get_domain_bounds() const {
+  return domain_bounds;
+};
+
 void CartesianDecomposition::set_gridbox_bounds(GbxBoundsFromBinary gfb) {
   // Function to store gridbox bounds in an array
   // Array contains lower (i) and upper bounds (i+1) of all the local gridboxes

--- a/libs/cartesiandomain/cartesian_decomposition.cpp
+++ b/libs/cartesiandomain/cartesian_decomposition.cpp
@@ -400,7 +400,7 @@ int find_best_decomposition(std::vector<std::vector<size_t>>& factors,
                             const std::vector<size_t> ndims) {
   std::array<size_t, 3> partition_origin, partition_size;
   int comm_size, best_factorization = -1;
-  double vertical_split_penalization = 1.0;
+  double vertical_split_penalization = 100.0;
   comm_size = init_communicator::get_comm_size();
 
   // Calculates the ideal (most even possible) division and initializes the minimum error

--- a/libs/cartesiandomain/cartesian_decomposition.hpp
+++ b/libs/cartesiandomain/cartesian_decomposition.hpp
@@ -93,6 +93,9 @@ class CartesianDecomposition {
   std::array<size_t, 3> get_local_partition_origin() const;
   std::array<size_t, 3> get_local_partition_size() const;
 
+  std::vector<std::vector<double>> get_local_gridbox_bounds() const;
+  std::array<std::array<double, 3>, 2> get_domain_bounds() const;
+
   // Get partition index and partition coordinates
   int get_partition_index_from_slice(std::array<int, 3> slice_indices) const;
   std::array<int, 3> get_slice_indices_from_partition(int partition_index) const;

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
@@ -188,9 +188,9 @@ void CartesianDynamics::send_yac_field(int field_id, double* field_data,
 
   send_buffer = new double **[ndims_vertical];
 
-  for (int j = 0; j < ndims_vertical; ++j) {
-      send_buffer[j] = new double*[1];
-      send_buffer[j][0] = new double[ncells];
+  for (size_t j = 0; j < ndims_vertical; ++j) {
+    send_buffer[j] = new double*[1];
+    send_buffer[j][0] = new double[ncells];
   }
 
   for (size_t j = 0; j < ndims_north; j++) {
@@ -211,9 +211,9 @@ void CartesianDynamics::send_yac_field(int field_id, double* field_data,
 
   std::cout << "yac_cput_ completed with info as: " << info << std::endl;
 
-  for (int j = 0; j < ndims_vertical; ++j) {
-      delete send_buffer[j][0];
-      delete send_buffer[j];
+  for (size_t j = 0; j < ndims_vertical; ++j) {
+    delete send_buffer[j][0];
+    delete send_buffer[j];
   }
   delete[] send_buffer;
 }

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
@@ -183,8 +183,8 @@ void CartesianDynamics::send_yac_field(int field_id, double* field_data,
   auto ncells = ndims_north * ndims_east;
 
   int info, ierror;
-  auto field_size = ncells*ndims_vertical;
-  double **collection_data;
+  // auto field_size = ncells*ndims_vertical;
+  // double **collection_data;
 
   send_buffer = new double **[ndims_vertical];
 

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
@@ -84,9 +84,6 @@ void create_vertex_coordinates(const Config &config, const std::array<size_t, 3>
   auto vertex_longitudes_new = std::vector<double>(partition_size[EASTWARD] + 1, 0);
   auto vertex_latitudes_new = std::vector<double>(partition_size[NORTHWARD] + 1, 0);
 
-  constexpr double RadToDeg = 180.0 / M_PI;
-  constexpr double DegToRad = M_PI / 180.0;
-
   // Defines the vertex longitude and latitude values in radians for grid creation
   // The values are later permuted by YAC to generate all vertex coordinates
 
@@ -209,8 +206,6 @@ void CartesianDynamics::receive_yac_field(unsigned int yac_field_id, double **ya
   int info, error;
   int action;
   yac_cget_action(yac_field_id, &action);
-  // std::cout << "Action: " << action << std::endl;
-  // yac_cget(yac_field_id, vertical_levels, yac_raw_data, &info, &error);
 
   if (action != YAC_ACTION_GET_FOR_RESTART) {
     std::cout << "Get Action: " << action << std::endl;
@@ -280,9 +275,6 @@ void CartesianDynamics::send_yac_field(int field_id, double* field_data,
     }
   }
   yac_cget_action(field_id, &action);
-
-  // std::cout << " Put Action: " << action << std::endl;
-  // yac_cput(field_id, ndims_vertical, send_buffer, &info, &ierror);
 
   if (action != YAC_ACTION_PUT_FOR_RESTART) {
     std::cout << "Put Action: " << action << std::endl;
@@ -359,8 +351,13 @@ CartesianDynamics::CartesianDynamics(const Config &config, const std::array<size
 
   // --- Interpolation stack ---
   int interp_stack_id;
-  yac_cget_interp_stack_config(&interp_stack_id);
-  yac_cadd_interp_stack_config_nnn(interp_stack_id, YAC_NNN_AVG, 1, 0.0, 1.0);
+  // yac_cget_interp_stack_config(&interp_stack_id);
+  // yac_cadd_interp_stack_config_nnn(interp_stack_id, YAC_NNN_AVG, 1, 0.0, 1.0);
+  yac_cget_interp_stack_config_from_string_yaml(
+    "[{\"nnn\":"
+    "  {\"n\": 1,"
+    "   \"weighted\": \"arithmetic_average\"}}]",
+    &interp_stack_id);
 
   // --- Field definitions ---
   int num_point_sets = 1;

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
@@ -143,14 +143,12 @@ void create_grid_and_points_definitions(const Config& config, const std::array<s
 
   std::vector<double> edge_centers_longitudes;
   std::vector<double> edge_centers_latitudes;
-  int* global_cell_ids = nullptr;
   create_vertex_coordinates(config, partition_size, gridbox_bounds, domain_bounds,
                             vertex_longitudes, vertex_latitudes);
 
   // Defines a regular 2D grid
   yac_cdef_grid_reg2d(grid_name.c_str(), total_vertices, cyclic_dimension, vertex_longitudes.data(),
                       vertex_latitudes.data(), &grid_id);
-  yac_cset_global_index(global_cell_ids, YAC_LOCATION_CELL, grid_id);
   // --- Point definitions ---
   // Defines the cell center longitude and latitude values in radians
   // The values are later permuted by YAC to generate all cell center coordinates

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.cpp
@@ -48,7 +48,7 @@ std::array<size_t, 3> kijfromindex(const std::array<size_t, 3>& ndims, const siz
 }
 
 double get_dlon_from_metres(const double lower_latitude, double delta_east) {
-  double EarthRadiusMeters = (100000) / (2 * M_PI);  // semi‑major axis a
+  // double EarthRadiusMeters = (100000) / (2 * M_PI);  // semi‑major axis a
   double dLon = 0.0;
 
   double MetresToRadians = (2 * M_PI) / (100000);
@@ -65,7 +65,7 @@ double get_dlon_from_metres(const double lower_latitude, double delta_east) {
   return dLon;
 }
 double get_dlat_from_metres(const double lower_latitude, double delta_north) {
-  double EarthRadiusMeters = (100000) / (2 * M_PI);  // semi‑major axis a
+  // double EarthRadiusMeters = (100000) / (2 * M_PI);  // semi‑major axis a
   double dLat = 0.0;
   double MetresToRadians = (2 * M_PI) / (100000);
   dLat = (delta_north * dlc::COORD0) * MetresToRadians;
@@ -85,9 +85,9 @@ void create_vertex_coordinates(const Config& config, const std::array<size_t, 3>
                                std::vector<double>& vertex_longitudes,
                                std::vector<double>& vertex_latitudes) {
   const auto lower_longitude = config.get_yac_dynamics().lower_longitude;
-  const auto upper_longitude = config.get_yac_dynamics().upper_longitude;
+  // const auto upper_longitude = config.get_yac_dynamics().upper_longitude;
   const auto lower_latitude = config.get_yac_dynamics().lower_latitude;
-  const auto upper_latitude = config.get_yac_dynamics().upper_latitude;
+  // const auto upper_latitude = config.get_yac_dynamics().upper_latitude;
 
   auto vertex_longitudes_new = std::vector<double>(partition_size[EASTWARD] + 1, 0);
   auto vertex_latitudes_new = std::vector<double>(partition_size[NORTHWARD] + 1, 0);
@@ -143,7 +143,7 @@ void create_grid_and_points_definitions(const Config& config, const std::array<s
 
   std::vector<double> edge_centers_longitudes;
   std::vector<double> edge_centers_latitudes;
-  int* global_cell_ids;
+  int* global_cell_ids = nullptr;
   create_vertex_coordinates(config, partition_size, gridbox_bounds, domain_bounds,
                             vertex_longitudes, vertex_latitudes);
 

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
@@ -33,6 +33,7 @@
 
 #include "configuration/communicator.hpp"
 #include "configuration/config.hpp"
+#include "superdrops/state.hpp"
 
 /* contains 1-D vector for each (thermo)dynamic
 variable which is ordered by gridbox at every timestep
@@ -63,8 +64,11 @@ struct CartesianDynamics {
   // YAC field ids
   int pressure_yac_id;
   int temp_yac_id;
+  int temp_yac_id2;
   int qvap_yac_id;
+  int qvap_yac_id2;
   int qcond_yac_id;
+  int qcond_yac_id2;
   int eastward_wind_yac_id;
   int northward_wind_yac_id;
   int vertical_wind_yac_id;
@@ -125,6 +129,10 @@ struct CartesianDynamics {
                          std::vector<double> &target_array, const size_t ndims_north,
                          const size_t ndims_east, const size_t vertical_levels,
                          double conversion_factor) const;
+  void send_yac_field(double* field_data, double conversion_factor);
+  void send_fields_to_yac(double* temp_state,
+                          double* qvap_state,
+                          double* qcond_state);
 };
 
 /* type satisfying CoupledDyanmics solver concept
@@ -158,6 +166,8 @@ struct YacDynamics {
       run_dynamics(t_mdl);
     }
   }
+
+  const std::shared_ptr<CartesianDynamics>& get_dynvars() const { return dynvars; }
 
   double get_press(const size_t ii) const { return dynvars->get_press(ii); }
 

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
@@ -183,7 +183,7 @@ struct YacDynamics {
 
   const std::shared_ptr<CartesianDynamics>& get_dynvars() const { return dynvars; }
 
-  const int get_yac_coupling_flag() const {return dynvars->get_yac_coupling_flag();}
+  int get_yac_coupling_flag() const { return dynvars->get_yac_coupling_flag(); }
 
   double get_press(const size_t ii) const { return dynvars->get_press(ii); }
 

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
@@ -34,7 +34,6 @@
 #include "configuration/communicator.hpp"
 #include "configuration/config.hpp"
 #include "superdrops/state.hpp"
-
 /* contains 1-D vector for each (thermo)dynamic
 variable which is ordered by gridbox at every timestep
 e.g. press = [p_gbx0(t0), p_gbx1(t0), ,... , p_gbxN(t0),
@@ -78,6 +77,8 @@ struct CartesianDynamics {
   double **yac_raw_edge_data;
   double **yac_raw_vertical_wind_data;
 
+  // Container to send the data to YAC
+  double ***send_buffer;
   /* --- Private functions --- */
 
   /* depending on nspacedims, read in data
@@ -129,7 +130,7 @@ struct CartesianDynamics {
                          std::vector<double> &target_array, const size_t ndims_north,
                          const size_t ndims_east, const size_t vertical_levels,
                          double conversion_factor) const;
-  void send_yac_field(double* field_data, double conversion_factor);
+  void send_yac_field(int field_id, double* field_data, double conversion_factor);
   void send_fields_to_yac(double* temp_state,
                           double* qvap_state,
                           double* qcond_state);
@@ -142,10 +143,13 @@ struct YacDynamics {
  private:
   const unsigned int interval;
   const unsigned int end_time;
+  static int get_counter;
   std::shared_ptr<CartesianDynamics> dynvars;  // pointer to (thermo)dynamic variables
 
   /* Calls the get operations to receive data from YAC for each of the fields of interest */
-  void run_dynamics(const unsigned int t_mdl) const { dynvars->receive_fields_from_yac(); }
+  void run_dynamics(const unsigned int t_mdl) const {
+     // dynvars->receive_fields_from_yac();
+  }
 
  public:
   YacDynamics(const Config &config, const unsigned int couplstep, const std::array<size_t, 3> ndims,
@@ -183,5 +187,8 @@ struct YacDynamics {
 
   std::pair<double, double> get_vvel(const size_t ii) const { return dynvars->get_vvel(ii); }
 };
+
+// int YacDynamics::get_counter = 1;
+
 
 #endif  // LIBS_COUPLDYN_YAC_YAC_CARTESIAN_DYNAMICS_HPP_

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
@@ -64,16 +64,16 @@ struct CartesianDynamics {
   std::vector<double> wvel;
 
   // YAC field ids
-  int pressure_yac_id;
-  int temp_yac_id;
-  int temp_yac_id2;
-  int qvap_yac_id;
-  int qvap_yac_id2;
-  int qcond_yac_id;
-  int qcond_yac_id2;
-  int eastward_wind_yac_id;
-  int northward_wind_yac_id;
-  int vertical_wind_yac_id;
+  int pressure_yac_id_recv;
+  int temp_yac_id_recv;
+  int temp_yac_id_send;
+  int qvap_yac_id_recv;
+  int qvap_yac_id_send;
+  int qcond_yac_id_recv;
+  int qcond_yac_id_send;
+  int eastward_wind_yac_id_recv;
+  int northward_wind_yac_id_recv;
+  int vertical_wind_yac_id_recv;
 
   // Containers to receive data from YAC
   double **yac_raw_cell_data;

--- a/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
+++ b/libs/coupldyn_yac/yac_cartesian_dynamics.hpp
@@ -49,6 +49,7 @@ struct CartesianDynamics {
   // number of (centres of) gridboxes in [coord3, coord1, coord2] directions
   const std::array<size_t, 3> ndims;
   const Config &config;
+  int yac_coupling_flag;
 
   /* --- (thermo)dynamic variables received from YAC --- */
 
@@ -123,6 +124,8 @@ struct CartesianDynamics {
   get_winds_func get_uvel;  // warning: these functions are not const member funcs by default
   get_winds_func get_vvel;
 
+  int get_yac_coupling_flag() const {return yac_coupling_flag;}
+
   double get_press(const size_t ii) const { return press.at(ii); }
 
   double get_temp(const size_t ii) const { return temp.at(ii); }
@@ -151,7 +154,6 @@ struct YacDynamics {
  private:
   const unsigned int interval;
   const unsigned int end_time;
-  static int get_counter;
   std::shared_ptr<CartesianDynamics> dynvars;  // pointer to (thermo)dynamic variables
 
   /* Calls the get operations to receive data from YAC for each of the fields of interest */
@@ -180,6 +182,8 @@ struct YacDynamics {
   }
 
   const std::shared_ptr<CartesianDynamics>& get_dynvars() const { return dynvars; }
+
+  const int get_yac_coupling_flag() const {return dynvars->get_yac_coupling_flag();}
 
   double get_press(const size_t ii) const { return dynvars->get_press(ii); }
 

--- a/libs/coupldyn_yac/yac_comms.cpp
+++ b/libs/coupldyn_yac/yac_comms.cpp
@@ -33,7 +33,7 @@ template <typename GbxMaps, typename CD>
 void YacComms::receive_dynamics(const GbxMaps &gbxmaps, const YacDynamics &ffdyn,
                                 const viewh_gbx h_gbxs) const {
   const size_t ngbxs(h_gbxs.extent(0));
-  if (get_counter < 240) {
+  if (get_counter <= 240) {
   ffdyn.get_dynvars()->receive_fields_from_yac();
   get_counter += 1;
   std::cout << " Get counter right now: " << get_counter << std::endl;
@@ -60,7 +60,7 @@ void YacComms::send_dynamics(const GbxMaps &gbxmaps, const viewh_constgbx h_gbxs
       qvap_state[ii] = state.qvap;
       qcond_state[ii] = state.qcond;
       });
-  if (put_counter < 240) {
+  if (put_counter <= 240) {
   ffdyn.get_dynvars()->send_fields_to_yac(temp_state.data(), qvap_state.data(), qcond_state.data());
   put_counter += 1;
   std::cout << " Put counter right now: " << put_counter << std::endl;

--- a/libs/coupldyn_yac/yac_comms.cpp
+++ b/libs/coupldyn_yac/yac_comms.cpp
@@ -20,9 +20,6 @@
 
 #include "coupldyn_yac/yac_comms.hpp"
 
-int YacComms::get_counter = 0;
-int YacComms::put_counter = 0;
-
 /* update Gridboxes' states using information received
 from YacDynamics solver for 1-way coupling to CLEO SDM.
 Kokkos::parallel_for([...]) (on host) is equivalent to:
@@ -36,12 +33,9 @@ void YacComms::receive_dynamics(const GbxMaps &gbxmaps, const YacDynamics &ffdyn
                                 const viewh_gbx h_gbxs) const {
   const size_t ngbxs(h_gbxs.extent(0));
   const int coupling_flag = ffdyn.get_dynvars()->get_yac_coupling_flag();
-  std::cout << "coupling_flag inside receive dynamics: " << coupling_flag << std::endl;
 
   if ((coupling_flag ==2) || (coupling_flag ==1)) {
   ffdyn.get_dynvars()->receive_fields_from_yac();
-  get_counter += 1;
-  std::cout << " Get counter right now: " << get_counter << std::endl;
   }
   Kokkos::parallel_for(
       "receive_dynamics", Kokkos::RangePolicy<HostSpace>(0, ngbxs),
@@ -57,7 +51,6 @@ void YacComms::send_dynamics(const GbxMaps &gbxmaps, const viewh_constgbx h_gbxs
   Kokkos::View<double*, HostSpace> qvap_state("qvap_state", ngbxs);
   Kokkos::View<double*, HostSpace> qcond_state("qcond_state", ngbxs);
 
-  std::cout << "Inside send_dynamics!" << std::endl;
   Kokkos::parallel_for(
       "send_dynamics", Kokkos::RangePolicy<HostSpace>(0, ngbxs),
       [=, *this](const size_t ii) {
@@ -69,10 +62,7 @@ void YacComms::send_dynamics(const GbxMaps &gbxmaps, const viewh_constgbx h_gbxs
   const int coupling_flag = ffdyn.get_dynvars()->get_yac_coupling_flag();
 
   if (coupling_flag ==2) {
-  std::cout << "Calling send_fields_to_yac!" << std::endl;
   ffdyn.get_dynvars()->send_fields_to_yac(temp_state.data(), qvap_state.data(), qcond_state.data());
-  put_counter += 1;
-  std::cout << " Put counter right now: " << put_counter << std::endl;
   }
 }
 

--- a/libs/coupldyn_yac/yac_comms.cpp
+++ b/libs/coupldyn_yac/yac_comms.cpp
@@ -22,6 +22,7 @@
 
 int YacComms::get_counter = 0;
 int YacComms::put_counter = 0;
+
 /* update Gridboxes' states using information received
 from YacDynamics solver for 1-way coupling to CLEO SDM.
 Kokkos::parallel_for([...]) (on host) is equivalent to:
@@ -29,11 +30,15 @@ for (size_t ii(0); ii < ngbxs; ++ii){[...]}
 when in serial
 // TODO(ALL): make ii indexing compatible with MPI domain decomposition
 */
+
 template <typename GbxMaps, typename CD>
 void YacComms::receive_dynamics(const GbxMaps &gbxmaps, const YacDynamics &ffdyn,
                                 const viewh_gbx h_gbxs) const {
   const size_t ngbxs(h_gbxs.extent(0));
-  if (get_counter <= 240) {
+  const int coupling_flag = ffdyn.get_dynvars()->get_yac_coupling_flag();
+  std::cout << "coupling_flag inside receive dynamics: " << coupling_flag << std::endl;
+
+  if ((coupling_flag ==2) || (coupling_flag ==1)) {
   ffdyn.get_dynvars()->receive_fields_from_yac();
   get_counter += 1;
   std::cout << " Get counter right now: " << get_counter << std::endl;
@@ -52,6 +57,7 @@ void YacComms::send_dynamics(const GbxMaps &gbxmaps, const viewh_constgbx h_gbxs
   Kokkos::View<double*, HostSpace> qvap_state("qvap_state", ngbxs);
   Kokkos::View<double*, HostSpace> qcond_state("qcond_state", ngbxs);
 
+  std::cout << "Inside send_dynamics!" << std::endl;
   Kokkos::parallel_for(
       "send_dynamics", Kokkos::RangePolicy<HostSpace>(0, ngbxs),
       [=, *this](const size_t ii) {
@@ -60,7 +66,10 @@ void YacComms::send_dynamics(const GbxMaps &gbxmaps, const viewh_constgbx h_gbxs
       qvap_state[ii] = state.qvap;
       qcond_state[ii] = state.qcond;
       });
-  if (put_counter <= 240) {
+  const int coupling_flag = ffdyn.get_dynvars()->get_yac_coupling_flag();
+
+  if (coupling_flag ==2) {
+  std::cout << "Calling send_fields_to_yac!" << std::endl;
   ffdyn.get_dynvars()->send_fields_to_yac(temp_state.data(), qvap_state.data(), qcond_state.data());
   put_counter += 1;
   std::cout << " Put counter right now: " << put_counter << std::endl;

--- a/libs/coupldyn_yac/yac_comms.hpp
+++ b/libs/coupldyn_yac/yac_comms.hpp
@@ -36,6 +36,8 @@ struct YacComms {
   void update_gridbox_state(const YacDynamics &ffdyn, const size_t ii, Gridbox &gbx) const;
 
  public:
+  static int get_counter;
+  static int put_counter;
   /* send information from Gridboxes' states
   to coupldyn is null for YacDynamics*/
   template <typename GbxMaps, typename CD = YacDynamics>

--- a/libs/coupldyn_yac/yac_comms.hpp
+++ b/libs/coupldyn_yac/yac_comms.hpp
@@ -39,8 +39,8 @@ struct YacComms {
   /* send information from Gridboxes' states
   to coupldyn is null for YacDynamics*/
   template <typename GbxMaps, typename CD = YacDynamics>
-  void send_dynamics(const GbxMaps &gbxmaps, const viewh_constgbx h_gbxs,
-                     YacDynamics &ffdyn) const {}
+  void send_dynamics(const GbxMaps&,
+    const viewh_constgbx, const YacDynamics &ffdyn) const;
 
   /* update Gridboxes' states using information
   received from YacDynamics solver for

--- a/libs/coupldyn_yac/yac_comms.hpp
+++ b/libs/coupldyn_yac/yac_comms.hpp
@@ -36,8 +36,6 @@ struct YacComms {
   void update_gridbox_state(const YacDynamics &ffdyn, const size_t ii, Gridbox &gbx) const;
 
  public:
-  static int get_counter;
-  static int put_counter;
   /* send information from Gridboxes' states
   to coupldyn is null for YacDynamics*/
   template <typename GbxMaps, typename CD = YacDynamics>


### PR DESCRIPTION
Depends on [PR 282](https://github.com/yoctoyotta1024/CLEO/pull/282). This PR finishes what was begun by PR 282, including:
- make YAC grid definition compatible with MPI
- some debug followed by some cleanup
- add option to switch between one-way or two-way coupling based on yac metadata channel

Also:
- and redefine origin lat/lon instead of upper/lower lat/lon to avoid wierd stetching behaviour that makes CLEO gridbox boundaries always as large as upper-lower lat/lon defines, even when meters is inconsistent

To-DO:
- [ ] PR into ICON
- [ ] formatting/linting
- [ ] code review, especially deleting redundant commented out code e.g. ``upper_latitude/longitude``
- [ ] 4 things needs to be validated (plotted) before merge: one-way and two-way, with and without >1 MPI processes
- [ ] run with one-way coupling offline
- [ ] check [issue 101](https://github.com/yoctoyotta1024/CLEO/issues/101)
- [ ] delete temporary run_bubble script
- [ ] resolve using YAC from ICON
- [ ] run cleo-yac-icon with openmp/cuda/c++threads parallelism (not just serial)
- [ ] run bubble like other examples(?) / nicely from within cleo