### PR TITLE
major bugfix: remove assumption of constant dry air density

### DIFF
--- a/cleopy/thermobinary_src/create_thermodynamics.py
+++ b/cleopy/thermobinary_src/create_thermodynamics.py
@@ -1,4 +1,7 @@
 """
+Copyright (c) 2025 MPI-M, Clara Bayley
+
+
 ----- CLEO -----
 File: create_thermodynamics.py
 Project: thermobinary_src
@@ -8,8 +11,6 @@ Additional Contributors:
 -----
 License: BSD 3-Clause "New" or "Revised" License
 https://opensource.org/licenses/BSD-3-Clause
------
-Copyright (c) 2023 MPI-M, Clara Bayley
 -----
 File Description:
 """
@@ -35,7 +36,6 @@ def thermoinputsdict(config_filename, constants_filename):
         # for creating thermodynamic profiles
         "G": consts["G"],
         "CP_DRY": consts["CP_DRY"],
-        "RHO_DRY": consts["RHO_DRY"],  # dry air density [Kg/m^3]
         "RGAS_DRY": mconsts["RGAS_DRY"],
         "RGAS_V": mconsts["RGAS_V"],
         "Mr_ratio": mconsts["Mr_ratio"],

--- a/libs/cleoconstants.hpp
+++ b/libs/cleoconstants.hpp
@@ -46,7 +46,6 @@ constexpr double CP_V = 1865.01;
 constexpr double C_L = 4192.664;
 /**< Specific heat capacity of liquid water[J/Kg/K] (ICON c_l = (3.1733 + 1.0) * cp_dry). */
 
-constexpr double RHO_DRY = 1.177; /**< Density of dry air [Kg/m^3] (at 300K). */
 constexpr double RHO_L = 998.203;
 /**< Density of liquid water condensing [kg/m^3] (water at 293K from SCALE-SDM). */
 constexpr double DYNVISC = 18.45 * 1e-6; /**< dynamic viscosity of air [Pa s] (at 300K). */
@@ -95,7 +94,6 @@ constexpr double C_l = DC::C_L / CP0;                  /**< Dimensionless C_L. *
 constexpr double Latent_v = DC::LATENT_V / (TEMP0 * CP0); /**< Dimensionless LATENT_V. */
 constexpr double Rgas_dry = DC::RGAS_DRY / CP0;           /**< Dimensionless RGAS_DRY. */
 constexpr double Rgas_v = DC::RGAS_V / CP0;               /**< Dimensionless RGAS_V. */
-constexpr double Rho_dry = DC::RHO_DRY / RHO0;            /**< Dimensionless RHO_DRY. */
 constexpr double Rho_l = DC::RHO_L / RHO0;                /**< Dimensionless RHO_L. */
 constexpr double Rho_sol = DC::RHO_SOL / RHO0;            /**< Dimensionless RHO_SOL. */
 constexpr double Mr_sol = DC::MR_SOL / MR0;               /**< Dimensionless MR_SOL. */

--- a/libs/gridboxes/movesupersindomain.hpp
+++ b/libs/gridboxes/movesupersindomain.hpp
@@ -35,6 +35,7 @@
 #include "mpi.h"
 #include "superdrops/motion.hpp"
 #include "superdrops/sdmmonitor.hpp"
+#include "superdrops/thermodynamic_equations.hpp"
 
 namespace dlc = dimless_constants;
 namespace KCS = KokkosCleoSettings;
@@ -107,7 +108,8 @@ struct EffectOnHydrometeorStatesFunctor {
     KOKKOS_INLINE_FUNCTION void operator()(State& state) const {
       constexpr double R0cubed_VOL0 = dlc::R0 * dlc::R0 * dlc::R0 / dlc::VOL0;
       const auto rho_cond = totmass_cond / state.get_volume() * R0cubed_VOL0;  // rho_condensed
-      state.qcond = rho_cond / dlc::Rho_dry;
+      const auto rho_dry = dry_air_density(state.press, state.temp, state.qvap);
+      state.qcond = rho_cond / rho_dry;
     }
   };
 

--- a/libs/gridboxes/movesupersindomain.hpp
+++ b/libs/gridboxes/movesupersindomain.hpp
@@ -62,12 +62,12 @@ struct MoveSupersInGridboxesFunctor {
    * when in serial
    */
   KOKKOS_INLINE_FUNCTION
-  void move_supers_in_gbx(const TeamMember &team_member, const unsigned int gbxindex,
-                          const State &state, const subviewd_supers supers) const {
+  void move_supers_in_gbx(const TeamMember& team_member, const unsigned int gbxindex,
+                          const State& state, const subviewd_supers supers) const {
     const size_t nsupers(supers.extent(0));
-    auto &_sdmotion = this->sdmotion;
-    auto &_gbxmaps = this->gbxmaps;
-    auto &_mo = this->mo;
+    auto& _sdmotion = this->sdmotion;
+    auto& _gbxmaps = this->gbxmaps;
+    auto& _mo = this->mo;
     Kokkos::parallel_for(Kokkos::TeamThreadRange(team_member, nsupers),
                          [=, &_sdmotion, &_gbxmaps, &_mo](const size_t kk) {
                            /* step (1) */
@@ -85,9 +85,9 @@ struct MoveSupersInGridboxesFunctor {
    * d_gbxs view in order to call move_supers_in_gbx
    */
   KOKKOS_INLINE_FUNCTION
-  void operator()(const TeamMember &team_member) const {
+  void operator()(const TeamMember& team_member) const {
     const auto ii = team_member.league_rank();
-    auto &gbx = d_gbxs(ii);
+    auto& gbx = d_gbxs(ii);
     move_supers_in_gbx(team_member, gbx.get_gbxindex(), gbx.state, gbx.supersingbx(domainsupers));
   }
 };
@@ -104,7 +104,7 @@ struct EffectOnHydrometeorStatesFunctor {
      * operator for functor in effect_on_hydrometeor_states function called in
      * parallel (Single PerTeam Policy) in order to change qcond of state
      */
-    KOKKOS_INLINE_FUNCTION void operator()(State &state) const {
+    KOKKOS_INLINE_FUNCTION void operator()(State& state) const {
       constexpr double R0cubed_VOL0 = dlc::R0 * dlc::R0 * dlc::R0 / dlc::VOL0;
       const auto rho_cond = totmass_cond / state.get_volume() * R0cubed_VOL0;  // rho_condensed
       state.qcond = rho_cond / dlc::Rho_dry;
@@ -115,7 +115,7 @@ struct EffectOnHydrometeorStatesFunctor {
    * operator for functor in effect_on_hydrometeor_states function called in
    * parallel loop over gridboxes in order to change hydrometeor mass(es) of each state
    */
-  KOKKOS_INLINE_FUNCTION void operator()(const TeamMember &team_member) const {
+  KOKKOS_INLINE_FUNCTION void operator()(const TeamMember& team_member) const {
     const auto ii = team_member.league_rank();
     const auto supers = d_gbxs(ii).supersingbx.readonly(domainsupers);
     const size_t nsupers(supers.extent(0));
@@ -123,8 +123,8 @@ struct EffectOnHydrometeorStatesFunctor {
     auto totmass_cond = double{0.0};  // total condensate mass in parcel volume 'dm'
     Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(team_member, nsupers),
-        KOKKOS_LAMBDA(const size_t kk, double &m_cond) {
-          const auto &drop = supers(kk);
+        KOKKOS_LAMBDA(const size_t kk, double& m_cond) {
+          const auto& drop = supers(kk);
           m_cond += drop.condensate_mass() * drop.get_xi();
         },
         totmass_cond);
@@ -151,7 +151,7 @@ class MoveSupersInDomain {
     const auto ngbxs = d_gbxs.extent(0);
     Kokkos::parallel_for(
         "check_sdgbxindex_during_motion", TeamPolicy(ngbxs, KCS::team_size),
-        KOKKOS_LAMBDA(const TeamMember &team_member) {
+        KOKKOS_LAMBDA(const TeamMember& team_member) {
           const auto ii = team_member.league_rank();
           assert(d_gbxs(ii).supersingbx.iscorrect(team_member, totsupers) &&
                  "incorrect references to superdrops in gridbox during motion");
@@ -183,7 +183,7 @@ class MoveSupersInDomain {
    * when in serial
    */
   template <SDMMonitor SDMMo>
-  void move_supers_in_gridboxes(const GbxMaps &gbxmaps, const viewd_gbx d_gbxs,
+  void move_supers_in_gridboxes(const GbxMaps& gbxmaps, const viewd_gbx d_gbxs,
                                 const subviewd_supers domainsupers, const SDMMo mo) const {
     Kokkos::Profiling::ScopedRegion region("sdm_movement_move_in_gridboxes");
 
@@ -207,8 +207,8 @@ class MoveSupersInDomain {
    *
    * optionally can incude test to check superdroplets end up in correct gridbox (for debugging)
    */
-  SupersInDomain move_supers_between_gridboxes(const GbxMaps &gbxmaps, const viewd_gbx d_gbxs,
-                                               SupersInDomain &allsupers) const {
+  SupersInDomain move_supers_between_gridboxes(const GbxMaps& gbxmaps, const viewd_gbx d_gbxs,
+                                               SupersInDomain& allsupers) const {
     Kokkos::Profiling::ScopedRegion region("sdm_movement_between_gridboxes");
 
     allsupers = transport_across_domain(gbxmaps, d_gbxs, allsupers);
@@ -227,8 +227,8 @@ class MoveSupersInDomain {
   (3) move superdroplets between gridboxes (host)
   (4) apply domain boundary conditions (host and/or device)
   */
-  SupersInDomain move_superdrops_in_domain(const unsigned int t_sdm, const GbxMaps &gbxmaps,
-                                           viewd_gbx d_gbxs, SupersInDomain &allsupers,
+  SupersInDomain move_superdrops_in_domain(const unsigned int t_sdm, const GbxMaps& gbxmaps,
+                                           viewd_gbx d_gbxs, SupersInDomain& allsupers,
                                            const SDMMonitor auto mo) const {
     /* steps (1 - 2) */
     move_supers_in_gridboxes(gbxmaps, d_gbxs, allsupers.domain_supers(), mo);
@@ -270,7 +270,7 @@ class MoveSupersInDomain {
         boundary_conditions(i_boundary_conditions) {}
 
   /* extra constructor useful to help when compiler cannot deduce type of GbxMaps */
-  MoveSupersInDomain(const GbxMaps &gbxmaps, const M i_sdmotion, const T i_transport_across_domain,
+  MoveSupersInDomain(const GbxMaps& gbxmaps, const M i_sdmotion, const T i_transport_across_domain,
                      const BCs i_boundary_conditions)
       : MoveSupersInDomain(i_sdmotion, i_transport_across_domain, i_boundary_conditions) {}
 
@@ -285,8 +285,8 @@ class MoveSupersInDomain {
    * @param allsupers Struct to handle all superdrops (both in and out of bounds of domain).
    *
    */
-  SupersInDomain run_step(const unsigned int t_sdm, const GbxMaps &gbxmaps, viewd_gbx d_gbxs,
-                          SupersInDomain &allsupers, const SDMMonitor auto mo) const {
+  SupersInDomain run_step(const unsigned int t_sdm, const GbxMaps& gbxmaps, viewd_gbx d_gbxs,
+                          SupersInDomain& allsupers, const SDMMonitor auto mo) const {
     if (sdmotion.on_step(t_sdm)) {
       allsupers = move_superdrops_in_domain(t_sdm, gbxmaps, d_gbxs, allsupers, mo);
       effect_on_hydrometeor_states(d_gbxs, allsupers.domain_supers_readonly());

--- a/libs/superdrops/condensation.cpp
+++ b/libs/superdrops/condensation.cpp
@@ -41,9 +41,9 @@
  * @return The total change in liquid water mass.
  */
 KOKKOS_FUNCTION
-double DoCondensation::superdroplets_change(const TeamMember &team_member,
+double DoCondensation::superdroplets_change(const TeamMember& team_member,
                                             const subviewd_supers supers,
-                                            const State &state) const {
+                                            const State& state) const {
   const auto nsupers = static_cast<size_t>(supers.extent(0));
 
   const auto psat = saturation_pressure(state.temp);
@@ -70,9 +70,9 @@ double DoCondensation::superdroplets_change(const TeamMember &team_member,
  * (prior to condensation / evaporation).
  */
 KOKKOS_FUNCTION
-void DoCondensation::effect_on_thermodynamic_state(const TeamMember &team_member,
+void DoCondensation::effect_on_thermodynamic_state(const TeamMember& team_member,
                                                    const double totmass_condensed,
-                                                   State &state) const {
+                                                   State& state) const {
   if (do_alter_thermo) {
     const auto functor = EffectOnThermodynamicStateFunctor{totmass_condensed};
     Kokkos::single(Kokkos::PerTeam(team_member), functor, state);
@@ -96,7 +96,7 @@ void DoCondensation::effect_on_thermodynamic_state(const TeamMember &team_member
  * @return The mass of liquid condensed or evaporated.
  */
 KOKKOS_FUNCTION
-double SuperdropletsChangeFunctor::superdrop_mass_change(Superdrop &drop, const double temp,
+double SuperdropletsChangeFunctor::superdrop_mass_change(Superdrop& drop, const double temp,
                                                          const double s_ratio,
                                                          const double ffactor) const {
   const double old_m_cond = drop.condensate_mass();
@@ -124,7 +124,7 @@ double SuperdropletsChangeFunctor::superdrop_mass_change(Superdrop &drop, const 
  * @return The updated State.
  */
 KOKKOS_FUNCTION State EffectOnThermodynamicStateFunctor::state_change(const double totrho_condensed,
-                                                                      State &state) const {
+                                                                      State& state) const {
   const auto delta_qcond = double{totrho_condensed / dlc::Rho_dry};
   const auto delta_temp =
       double{(dlc::Latent_v / moist_specifc_heat(state.qvap, state.qcond)) * delta_qcond};

--- a/libs/superdrops/condensation.cpp
+++ b/libs/superdrops/condensation.cpp
@@ -125,13 +125,14 @@ double SuperdropletsChangeFunctor::superdrop_mass_change(Superdrop& drop, const 
  */
 KOKKOS_FUNCTION State EffectOnThermodynamicStateFunctor::state_change(const double totrho_condensed,
                                                                       State& state) const {
-  const auto delta_qcond = double{totrho_condensed / dlc::Rho_dry};
-  const auto delta_temp =
-      double{(dlc::Latent_v / moist_specifc_heat(state.qvap, state.qcond)) * delta_qcond};
-
-  state.temp += delta_temp;
+  const auto rho_dry = dry_air_density(state.press, state.temp, state.qvap);
+  const auto delta_qcond = double{totrho_condensed / rho_dry};
   state.qvap -= delta_qcond;
   state.qcond += delta_qcond;
+
+  const auto delta_temp =
+      double{(dlc::Latent_v / moist_specifc_heat(state.qvap, state.qcond)) * delta_qcond};
+  state.temp += delta_temp;
 
   return state;
 }

--- a/libs/superdrops/thermodynamic_equations.hpp
+++ b/libs/superdrops/thermodynamic_equations.hpp
@@ -75,7 +75,7 @@ double supersaturation_ratio(const double press, const double qvap, const double
  * @return A Kokkos pair containing 'a' and 'b' factors in that order.
  */
 KOKKOS_INLINE_FUNCTION
-Kokkos::pair<double, double> kohler_factors(const Superdrop &drop, const double temp) {
+Kokkos::pair<double, double> kohler_factors(const Superdrop& drop, const double temp) {
   constexpr double akoh_constant = 3.3e-7 / (dlc::TEMP0 * dlc::R0);
   const auto akoh = akoh_constant / temp;  // dimensionless version of eqn [6.24]
 

--- a/libs/superdrops/thermodynamic_equations.hpp
+++ b/libs/superdrops/thermodynamic_equations.hpp
@@ -31,6 +31,25 @@ namespace dlc = dimless_constants;
 namespace DC = dimmed_constants;
 
 /**
+ * @brief Calculate the dry air density of a moist volume.
+ *
+ * This function calculates the density of dry air using the ideal gas law, accounting
+ * for the presence of water vapor by adjusting the specific gas constant.
+ *
+ * @param press pressure [dimensionless]
+ * @param temp temperature [dimensionless]
+ * @param qvap mass mixing ratio of water vapor [dimensionless]
+ *
+ * @return dimensionless dry air density
+ */
+KOKKOS_INLINE_FUNCTION
+double dry_air_density(const double press, const double temp, const double qvap) {
+  const double rgas_equiv = dlc::Rgas_dry + dlc::Rgas_v * qvap;
+  const double rho_dry = press / (rgas_equiv * temp);
+  return rho_dry;
+}
+
+/**
  * @brief Calculate the specific heat capacity of moist air.
  *
  * This function calculates the specific heat capacity of a moist parcel of air using the specific


### PR DESCRIPTION
instead calculate rho_dry form ideal gas law. Important for condensate calculations of qvap and qcond (vapour and liquid mass mixing ratios)