### PR TITLE
remove redundant initialisation of supers

### DIFF
--- a/libs/runcleo/createsupers.hpp
+++ b/libs/runcleo/createsupers.hpp
@@ -146,10 +146,8 @@ SupersInDomain create_supers(const SuperdropInitConds &sdic, const unsigned int 
  */
 template <typename SuperdropInitConds>
 viewd_supers initialise_supers(const SuperdropInitConds &sdic) {
-  GenSuperdrop gen(sdic);
-
   // create superdrops view on device
-  auto totsupers = viewd_supers("totsupers", gen.get_maxnsupers());
+  auto totsupers = viewd_supers("totsupers", sdic.get_maxnsupers());
 
   // initialise a mirror of superdrops view on host
   auto h_totsupers = initialise_supers_on_host(sdic, totsupers);


### PR DESCRIPTION
In` initialise_supers()`, `GenSuperdrop gen(sdic)` is constructed solely to call `gen.get_maxnsupers()` for sizing the device view, but `sdic.get_maxnsupers()` provides the same value directly. This causes `sdic.fetch_data()`, which reads the super-droplet binary file , to be called twice: once in this redundant construction, and again inside `initialise_supers_on_host()` where a second `GenSuperdrop` is constructed from `sdic`. The fix is to replace `gen.get_maxnsupers()` with `sdic.get_maxnsupers()` and remove the first `GenSuperdrop` construction, so the binary file is only read once.