### PR TITLE
Restrict debug code to Debug builds

### DIFF
--- a/libs/runcleo/creategbxs.hpp
+++ b/libs/runcleo/creategbxs.hpp
@@ -265,12 +265,16 @@ dualview_gbx create_gbxs(const GbxMaps &gbxmaps, const GbxInitConds &gbxic,
   const auto domainsupers = allsupers.domain_supers_readonly();
   const auto gbxs = initialise_gbxs(gbxmaps, gbxic, domainsupers);
 
+#ifndef NDEBUG
+
   std::cout << "checking initialisation\n";
   is_gbxinit_complete(gbxmaps.get_local_ngridboxes_hostcopy(), gbxs,
                       allsupers.get_totsupers_readonly());
 
-  // // Print information about the created superdrops
-  // print_gbxs(gbxs.view_host());
+  // Print information about the created superdrops
+  print_gbxs(gbxs.view_host());
+
+#endif
 
   std::cout << "--- create gridboxes: success ---\n";
 

--- a/libs/runcleo/createsupers.hpp
+++ b/libs/runcleo/createsupers.hpp
@@ -120,12 +120,16 @@ SupersInDomain create_supers(const SuperdropInitConds &sdic, const unsigned int 
   std::cout << "sorting and finding superdrops in domain\n";
   auto allsupers = SupersInDomain(totsupers, gbxindex_max);
 
+#ifndef NDEBUG
+
   // Log message and perform checks on the initialisation of superdrops
   std::cout << "checking initialisation\n";
   is_sdsinit_complete(allsupers);
 
-  // // Print information about the created superdrops
-  // print_supers(totsupers);
+  // Print information about the created superdrops
+  print_supers(totsupers);
+
+#endif
 
   // Log message indicating the successful creation of superdrops
   std::cout << "--- create superdrops: success ---\n";


### PR DESCRIPTION
Following checks will only be compiled with `-DCMAKE_BUILD_TYPE=Debug`

- `is_gbxinit_complete(..)`
- `print_gbxs(..)`
- `is_sdsinit_complete(...)`
- `print_supers(...)`