### PR TITLE
More breakup examples

### DIFF
--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -478,6 +478,20 @@ url = {https://www.sciencedirect.com/science/article/pii/S0169809517313066},
 author = {Miklós Szakáll and Isabel Urbich}
 }
 
+@ARTICLE{testik2009,
+       author = {{Testik}, Firat Y.},
+        title = "{Outcome regimes of binary raindrop collisions}",
+      journal = {Atmospheric Research},
+         year = 2009,
+        month = nov,
+       volume = {94},
+       number = {3},
+        pages = {389-399},
+          doi = {10.1016/j.atmosres.2009.06.017},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2009AtmRe..94..389T},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @article{testik2011,
 author = "F. Y. Testik and A. P. Barros and L. F. Bliven",
 title = "Toward a Physical Characterization of Raindrop Collision Outcome Regimes",

--- a/docs/source/usage/examples/examples_levante.rst
+++ b/docs/source/usage/examples/examples_levante.rst
@@ -159,8 +159,8 @@ The Examples
   The ``breakup.py`` example models collision-coalescence-rebound-breakup using the hydrodynamic kernel with Long's
   collision efficiency as given by equation 13 of Simmel et al. 2002 :cite:`simmel2002`, and the
   coalescence/breakup/rebound probability based on section 4 of Testik et al. 2011 (figure 12)
-  :cite:`testik2011` as well as coalescence efficiency and number of fragements produced from
-  Straub et al. 2010 and Schlottke et al. 2010 respectively (:cite:`schlottke2010`, :cite:`straub2010`).
+  :cite:`testik2011` (first proposed in :cite:`testik2009`), as well as coalescence efficiency and number of fragements
+  produced from Straub et al. 2010 and Schlottke et al. 2010 respectively (:cite:`schlottke2010`, :cite:`straub2010`).
 
   This example produces a plot, by default called ``~/CLEO/build_colls0d/[...]/bin/testikstraub_validation.png``.
 

--- a/docs/source/usage/examples/examples_vanilla.rst
+++ b/docs/source/usage/examples/examples_vanilla.rst
@@ -175,8 +175,8 @@ The Examples
   The ``breakup.py`` example models collision-coalescence-rebound-breakup using the hydrodynamic kernel with Long's
   collision efficiency as given by equation 13 of Simmel et al. 2002 :cite:`simmel2002`, and the
   coalescence/breakup/rebound probability based on section 4 of Testik et al. 2011 (figure 12)
-  :cite:`testik2011` as well as coalescence efficiency and number of fragements produced from
-  Straub et al. 2010 and Schlottke et al. 2010 respectively (:cite:`schlottke2010`, :cite:`straub2010`).
+  :cite:`testik2011` (first proposed in :cite:`testik2009`), as well as coalescence efficiency and number of fragements
+  produced from Straub et al. 2010 and Schlottke et al. 2010 respectively (:cite:`schlottke2010`, :cite:`straub2010`).
 
   This example produces a plot, by default called ``~/CLEO/build_colls0d/[...]/bin/testikstraub_validation.png``.
 

--- a/examples/boxmodelcollisions/src/main_testikstraubcolls.cpp
+++ b/examples/boxmodelcollisions/src/main_testikstraubcolls.cpp
@@ -14,8 +14,8 @@
  * -----
  * File Description:
  * runs the CLEO super-droplet model (SDM) for 0-D box model with coalescence, rebound and
- * breakup with flag decided based on section 4 of Testik et al. 2011 (figure 12) as well
- * as coalescence efficiency from Straub et al. 2010 and Schlottke et al. 2010.
+ * breakup with flag decided based on section 4 of Testik et al. 2011 (figure 12; first proposed in
+ * Testik 2009) as well as coalescence efficiency from Straub et al. 2010 and Schlottke et al. 2010.
  * After make/compiling, execute for example via:
  * ./src/testikstraubcolls ../src/config/config.yaml
  */

--- a/examples/boxmodelcollisions/src/main_testikstraubcolls.cpp
+++ b/examples/boxmodelcollisions/src/main_testikstraubcolls.cpp
@@ -29,7 +29,7 @@
 #include "superdrops/collisions/longhydroprob.hpp"
 
 struct TestikStraubCreateMicrophysics {
-  MicrophysicalProcess auto operator()(const Config &config, const Timesteps &tsteps) const {
+  MicrophysicalProcess auto operator()(const Config& config, const Timesteps& tsteps) const {
     const PairProbability auto collprob = LongHydroProb();
     const NFragments auto nfrags = CollisionKineticEnergyNFrags{};
     const CoalBuReFlag auto coalbure_flag = TSCoalBuReFlag{};
@@ -39,6 +39,6 @@ struct TestikStraubCreateMicrophysics {
   }
 };
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   return generic_microphysics_main(argc, argv, TestikStraubCreateMicrophysics{});
 }

--- a/libs/configuration/config.hpp
+++ b/libs/configuration/config.hpp
@@ -83,6 +83,8 @@ struct Config {
     return optional.condensation;
   }
 
+  OptionalConfigParams::CoalescenceParams get_coalescence() const { return optional.coalescence; }
+
   OptionalConfigParams::BreakupParams get_breakup() const { return optional.breakup; }
 
   OptionalConfigParams::InitSupersFromBinaryParams get_initsupersfrombinary() const {

--- a/libs/configuration/optional_config_params.cpp
+++ b/libs/configuration/optional_config_params.cpp
@@ -93,6 +93,11 @@ void OptionalConfigParams::set_microphysics(const YAML::Node& config) {
     condensation.print_params();
   }
 
+  if (node["coalescence"]) {
+    coalescence.set_params(config);
+    coalescence.print_params();
+  }
+
   if (node["breakup"]) {
     breakup.set_params(config);
     breakup.print_params();
@@ -159,6 +164,17 @@ void OptionalConfigParams::CondensationParams::print_params() const {
   std::cout << "\n-------- Condensation Configuration Parameters --------------"
             << "\ndo_alter_thermo: " << do_alter_thermo << "\nmaxniters: " << maxniters
             << "\nMINSUBSTEP: " << MINSUBTSTEP << "\nrtol: " << rtol << "\natol: " << atol
+            << "\n---------------------------------------------------------\n";
+}
+
+void OptionalConfigParams::CoalescenceParams::set_params(const YAML::Node& config) {
+  const YAML::Node node = config["microphysics"]["coalescence"]["constcoaleff"];
+  constcoaleff.coaleff = node["coaleff"].as<double>();
+}
+
+void OptionalConfigParams::CoalescenceParams::print_params() const {
+  std::cout << "\n-------- Coalescence Configuration Parameters --------------"
+            << "\nConstCoalEff coaleff: " << constcoaleff.coaleff
             << "\n---------------------------------------------------------\n";
 }
 

--- a/libs/configuration/optional_config_params.hpp
+++ b/libs/configuration/optional_config_params.hpp
@@ -80,6 +80,14 @@ struct OptionalConfigParams {
     double atol = NaNVals::dbl();        /**< absolute tolerance for implicit Euler integration */
   } condensation;
 
+  struct CoalescenceParams {
+    void set_params(const YAML::Node& config);
+    void print_params() const;
+    struct ConstCoalEffParams {
+      double coaleff = NaNVals::dbl(); /**< constant coalescence efficiency */
+    } constcoaleff;
+  } coalescence;
+
   struct BreakupParams {
     void set_params(const YAML::Node& config);
     void print_params() const;

--- a/libs/superdrops/collisions/CMakeLists.txt
+++ b/libs/superdrops/collisions/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIB_BINARY_DIR ${CMAKE_BINARY_DIR}/lib)
 set(SOURCES
   "shuffle.cpp"
   "coalbure_flag.cpp"
+  "coalescence_efficiency.cpp"
   "coalescence.cpp"
   "collisionkinetics.cpp"
   "golovinprob.cpp"

--- a/libs/superdrops/collisions/breakup.hpp
+++ b/libs/superdrops/collisions/breakup.hpp
@@ -49,13 +49,13 @@ struct DoBreakup {
   superdroplets produces (non-identical) twin superdroplets.
   Similar to Shima et al. 2009 Section 5.1.3. part (5) option (b).
   Note implicit assumption that gamma factor = 1. */
-  KOKKOS_FUNCTION void twin_superdroplet_breakup(Superdrop &drop1, Superdrop &drop2) const;
+  KOKKOS_FUNCTION void twin_superdroplet_breakup(Superdrop& drop1, Superdrop& drop2) const;
 
   /* if xi1 > gamma*xi2 breakup alters drop2 radius and
   mass via decreasing multiplicity of drop1. Similar to
   Shima et al. 2009 Section 5.1.3. part (5) option (a).
   Note implicit assumption that gamma factor = 1. */
-  KOKKOS_FUNCTION void different_superdroplet_breakup(Superdrop &drop1, Superdrop &drop2) const;
+  KOKKOS_FUNCTION void different_superdroplet_breakup(Superdrop& drop1, Superdrop& drop2) const;
 
  public:
   explicit DoBreakup(const NFrags nfrags) : nfrags(nfrags) {}
@@ -80,7 +80,7 @@ struct DoBreakup {
   superdroplet in a pair. Method created by Author
   (no citation yet available). Note implicit assumption
   that gamma factor = 1. */
-  KOKKOS_FUNCTION void breakup_superdroplet_pair(Superdrop &drop1, Superdrop &drop2) const;
+  KOKKOS_FUNCTION void breakup_superdroplet_pair(Superdrop& drop1, Superdrop& drop2) const;
 };
 
 /* constructs Microphysical Process for collision-breakup
@@ -144,8 +144,8 @@ superdroplet in a pair. Method created by Author
 (no citation yet available). Note implicit assumption
 that gamma factor = 1. */
 template <NFragments NFrags>
-KOKKOS_FUNCTION void DoBreakup<NFrags>::breakup_superdroplet_pair(Superdrop &drop1,
-                                                                  Superdrop &drop2) const {
+KOKKOS_FUNCTION void DoBreakup<NFrags>::breakup_superdroplet_pair(Superdrop& drop1,
+                                                                  Superdrop& drop2) const {
   if (drop1.get_xi() == drop2.get_xi()) {
     twin_superdroplet_breakup(drop1, drop2);
   } else {
@@ -159,8 +159,8 @@ Similar to Shima et al. 2009 Section 5.1.3. part (5) option (b).
 Note implicit assumption that gamma factor = 1.
 _Note:_ Implicit casting of xi from uint64_t to double. */
 template <NFragments NFrags>
-KOKKOS_FUNCTION void DoBreakup<NFrags>::twin_superdroplet_breakup(Superdrop &drop1,
-                                                                  Superdrop &drop2) const {
+KOKKOS_FUNCTION void DoBreakup<NFrags>::twin_superdroplet_breakup(Superdrop& drop1,
+                                                                  Superdrop& drop2) const {
   const auto old_xi = drop2.get_xi();  // = drop1.xi
   const auto totnfrags = double{nfrags(drop1, drop2) * old_xi};
   assert(((totnfrags / old_xi) > 2.5) && "nfrags must be > 2.5");
@@ -194,8 +194,8 @@ Shima et al. 2009 Section 5.1.3. part (5) option (a).
 Note implicit assumption that gamma factor = 1.
 _Note:_ Implicit casting of xi from uint64_t to double. */
 template <NFragments NFrags>
-KOKKOS_FUNCTION void DoBreakup<NFrags>::different_superdroplet_breakup(Superdrop &drop1,
-                                                                       Superdrop &drop2) const {
+KOKKOS_FUNCTION void DoBreakup<NFrags>::different_superdroplet_breakup(Superdrop& drop1,
+                                                                       Superdrop& drop2) const {
   const auto old_xi1 = drop1.get_xi();
   const auto old_xi2 = drop2.get_xi();
 

--- a/libs/superdrops/collisions/breakup.hpp
+++ b/libs/superdrops/collisions/breakup.hpp
@@ -69,11 +69,13 @@ struct DoBreakup {
    * @param drop1 First superdroplet.
    * @param drop2 Second superdroplet.
    * @param prob Probability of collision.
-   * @param phi Phi value.
+   * @param phi_coll Random number in the range [0.0, 1.0] for collision.
+   * @param phi_out Random number in the range [0.0, 1.0] for outcome of collision (not used).
    * @return True if the resulting superdroplet is null, otherwise false.
    */
   KOKKOS_FUNCTION
-  bool operator()(Superdrop &drop1, Superdrop &drop2, const double prob, const double phi) const;
+  bool operator()(Superdrop& drop1, Superdrop& drop2, const double prob, const double phi_coll,
+                  const double phi_out) const;
 
   /* enact collisional-breakup of droplets by changing
   multiplicity, radius and solute mass of each
@@ -108,15 +110,17 @@ inline MicrophysicalProcess auto CollBu(const unsigned int interval,
  * @param drop1 First superdroplet.
  * @param drop2 Second superdroplet.
  * @param prob Probability of collision.
- * @param phi Phi value.
+ * @param phi_coll Random number in the range [0.0, 1.0] for collision.
+ * @param phi_out Random number in the range [0.0, 1.0] for outcome of collision (not used).
  * @return True if the resulting superdroplet is null, otherwise false.
  */
 template <NFragments NFrags>
-KOKKOS_FUNCTION bool DoBreakup<NFrags>::operator()(Superdrop &drop1, Superdrop &drop2,
-                                                   const double prob, const double phi) const {
+KOKKOS_FUNCTION bool DoBreakup<NFrags>::operator()(Superdrop& drop1, Superdrop& drop2,
+                                                   const double prob, const double phi_coll,
+                                                   const double phi_out) const {
   /* enact collision-breakup on pair of superdroplets if
   gamma factor for collision-breakup is not zero */
-  if (breakup_gamma(prob, phi) != 0) {
+  if (breakup_gamma(prob, phi_coll) != 0) {
     breakup_superdroplet_pair(drop1, drop2);
   }
 

--- a/libs/superdrops/collisions/coalbure.hpp
+++ b/libs/superdrops/collisions/coalbure.hpp
@@ -123,8 +123,8 @@ struct DoCoalBuRe {
    * @return True if the resulting superdroplet is null, otherwise false.
    */
   KOKKOS_FUNCTION
-  bool coalesce_breakup_or_rebound(const uint64_t gamma, const double phi, Superdrop &drop1,
-                                   Superdrop &drop2) const;
+  bool coalesce_breakup_or_rebound(const uint64_t gamma, const double phi, Superdrop& drop1,
+                                   Superdrop& drop2) const;
 
  public:
   /**
@@ -233,8 +233,8 @@ KOKKOS_FUNCTION bool DoCoalBuRe<NFrags, Flag>::operator()(Superdrop &drop1, Supe
 template <NFragments NFrags, CoalBuReFlag Flag>
 KOKKOS_FUNCTION bool DoCoalBuRe<NFrags, Flag>::coalesce_breakup_or_rebound(const uint64_t gamma,
                                                                            const double phi,
-                                                                           Superdrop &drop1,
-                                                                           Superdrop &drop2) const {
+                                                                           Superdrop& drop1,
+                                                                           Superdrop& drop2) const {
   const auto flag = coalbure_flag(phi, drop1, drop2);
 
   bool is_null(0);

--- a/libs/superdrops/collisions/coalbure.hpp
+++ b/libs/superdrops/collisions/coalbure.hpp
@@ -54,31 +54,6 @@ struct DoCoalBuRe {
   DoBreakup<NFrags> bu; /**< Instance of DoBreakup with specified no. of fragments calculation. */
   Flag coalbure_flag;   /**< Instance of CoalBuReFlag indicating the action to perform. */
 
-  /*
-  rescale random number phi be in desired range of [0, 1] to account for fact that if a
-  collision occurs (i.e. if gamma != 0) then phi lies in range [0, prob - floor(prob)] rather than
-  [0, 1].
-  * _Note:_ This function is assumed to be consitent with collision_gamma(...) and must be.
-  */
-
-  /**
-   * @brief Rescales a random number phi to be in the desired range [0, 1].
-   *
-   * This function adjusts the value of phi to account for the fact that if a collision occurs
-   * (i.e., if gamma != 0), then phi lies in the range [0, prob - floor(prob)] instead of [0, 1].
-   *
-   * @note This function is assumed to be consistent with collision_gamma(...) and must be.
-   *
-   * @param prob The probability of collision.
-   * @param phi Random number, assumed to be in the range [0.0, prob - floor(prob)].
-   *
-   * @return The rescaled value of phi as a uint64_t.
-   */
-  KOKKOS_FUNCTION
-  uint64_t rescale_phi(const double prob, const double phi) const {
-    return phi / (prob - Kokkos::floor(prob));
-  }
-
   /**
    * @brief Calculates the value of the gamma factor in Monte Carlo collision.
    *
@@ -145,11 +120,14 @@ struct DoCoalBuRe {
    * @param drop1 First superdroplet.
    * @param drop2 Second superdroplet.
    * @param prob Probability of collision.
-   * @param phi Phi value.
+   * @param phi_coll Random number in the range [0.0, 1.0] for collision.
+   * @param phi_out Random number in the range [0.0, 1.0] for outcome of collision as breakup,
+   * rebound or coalescence.
    * @return True if the resulting superdroplet is null, otherwise false.
    */
   KOKKOS_INLINE_FUNCTION
-  bool operator()(Superdrop &drop1, Superdrop &drop2, const double prob, const double phi) const;
+  bool operator()(Superdrop& drop1, Superdrop& drop2, const double prob, const double phi_coll,
+                  const double phi_out) const;
 };
 
 /**
@@ -194,23 +172,24 @@ inline MicrophysicalProcess auto CoalBuRe(const unsigned int interval,
  * @param drop1 First superdroplet.
  * @param drop2 Second superdroplet.
  * @param prob Probability of collision.
- * @param phi Phi value.
+ * @param phi_coll Random number in the range [0.0, 1.0] for collision.
+ * @param phi_out Random number in the range [0.0, 1.0] for outcome of collision as breakup,
+ * rebound or coalescence.
  * @return True if the resulting superdroplet is null, otherwise false.
  */
 template <NFragments NFrags, CoalBuReFlag Flag>
-KOKKOS_FUNCTION bool DoCoalBuRe<NFrags, Flag>::operator()(Superdrop &drop1, Superdrop &drop2,
-                                                          const double prob,
-                                                          const double phi) const {
+KOKKOS_FUNCTION bool DoCoalBuRe<NFrags, Flag>::operator()(Superdrop& drop1, Superdrop& drop2,
+                                                          const double prob, const double phi_coll,
+                                                          const double phi_out) const {
   /* 1. calculate gamma factor for collision  */
   const auto xi1 = drop1.get_xi();
   const auto xi2 = drop2.get_xi();
-  const auto gamma = collision_gamma(xi1, xi2, prob, phi);
+  const auto gamma = collision_gamma(xi1, xi2, prob, phi_coll);
 
   /* 2. enact collision between pair
   of superdroplets if gamma is not zero */
   if (gamma != 0) {
-    const double phi_collision = rescale_phi(prob, phi);
-    return coalesce_breakup_or_rebound(gamma, phi_collision, drop1, drop2);
+    return coalesce_breakup_or_rebound(gamma, phi_out, drop1, drop2);
   }
 
   return 0;

--- a/libs/superdrops/collisions/coalbure_flag.cpp
+++ b/libs/superdrops/collisions/coalbure_flag.cpp
@@ -67,29 +67,12 @@ KOKKOS_FUNCTION unsigned int TSCoalBuReFlag::operator()(const double phi, const 
   }
 }
 
-/* coalescence efficency given a collision occurs
-according to parameterisation from Straub et al. 2010
-section 3, equation 5 and Schlottke et al. 2010
-section 4a equation 11 */
-KOKKOS_FUNCTION double TSCoalBuReFlag::coalescence_efficiency(const Superdrop &drop1,
-                                                              const Superdrop &drop2,
-                                                              const double cke) const {
-  constexpr double beta = -1.15;
-
-  const auto surf_c = coal_surfenergy(drop1.get_radius(),
-                                      drop2.get_radius());  // [J] S_c
-  const auto weber = double{cke / surf_c};
-  const auto ecoal = double{Kokkos::exp(beta * weber)};
-
-  return ecoal;
-}
-
 /* returns truw if comparison of random numnber
 with coalescence efficiency from Straub et al. 2010
 indicates coalescence should occur */
 KOKKOS_FUNCTION bool TSCoalBuReFlag::is_coalescence(const Superdrop& drop1, const Superdrop& drop2,
                                                     const double phi, const double cke) const {
-  const auto ecoal = coalescence_efficiency(drop1, drop2, cke);
+  const auto ecoal = coalescence_efficiency_straub2010(drop1, drop2, cke);
 
   if (phi < ecoal) {
     return true;

--- a/libs/superdrops/collisions/coalbure_flag.cpp
+++ b/libs/superdrops/collisions/coalbure_flag.cpp
@@ -26,8 +26,8 @@ If flag = 2 -> breakup. Otherwise -> rebound.
 Flag decided based on the kinetic arguments in section 2.2 of Szakáll and Urbich 2018 (neglecting
 grazing angle considerations)
 */
-KOKKOS_FUNCTION unsigned int SUCoalBuReFlag::operator()(const Superdrop &drop1,
-                                                        const Superdrop &drop2) const {
+KOKKOS_FUNCTION unsigned int SUCoalBuReFlag::operator()(const Superdrop& drop1,
+                                                        const Superdrop& drop2) const {
   const auto r1 = drop1.get_radius();
   const auto r2 = drop2.get_radius();
   const auto terminalv = RogersGKTerminalVelocity{};
@@ -50,8 +50,8 @@ If flag = 2 -> breakup. Otherwise -> rebound.
 Flag decided based on the kinetic arguments from
 section 4 of Testik et al. 2011 (figure 12) as well
 as coalescence efficiency from Straub et al. 2010 */
-KOKKOS_FUNCTION unsigned int TSCoalBuReFlag::operator()(const double phi, const Superdrop &drop1,
-                                                        const Superdrop &drop2) const {
+KOKKOS_FUNCTION unsigned int TSCoalBuReFlag::operator()(const double phi, const Superdrop& drop1,
+                                                        const Superdrop& drop2) const {
   const auto r1 = drop1.get_radius();
   const auto r2 = drop2.get_radius();
   const auto terminalv = RogersGKTerminalVelocity{};
@@ -87,7 +87,7 @@ KOKKOS_FUNCTION double TSCoalBuReFlag::coalescence_efficiency(const Superdrop &d
 /* returns truw if comparison of random numnber
 with coalescence efficiency from Straub et al. 2010
 indicates coalescence should occur */
-KOKKOS_FUNCTION bool TSCoalBuReFlag::is_coalescence(const Superdrop &drop1, const Superdrop &drop2,
+KOKKOS_FUNCTION bool TSCoalBuReFlag::is_coalescence(const Superdrop& drop1, const Superdrop& drop2,
                                                     const double phi, const double cke) const {
   const auto ecoal = coalescence_efficiency(drop1, drop2, cke);
 
@@ -101,8 +101,8 @@ KOKKOS_FUNCTION bool TSCoalBuReFlag::is_coalescence(const Superdrop &drop1, cons
 /* returns flag that indicates coalescence (flag=1)
 or rebound (flag=0) based on coalescence efficiency
 from Straub et al. 2010 */
-KOKKOS_FUNCTION unsigned int TSCoalBuReFlag::rebound_or_coalescence(const Superdrop &drop1,
-                                                                    const Superdrop &drop2,
+KOKKOS_FUNCTION unsigned int TSCoalBuReFlag::rebound_or_coalescence(const Superdrop& drop1,
+                                                                    const Superdrop& drop2,
                                                                     const double phi,
                                                                     const double cke) const {
   if (is_coalescence(drop1, drop2, phi, cke)) {
@@ -115,8 +115,8 @@ KOKKOS_FUNCTION unsigned int TSCoalBuReFlag::rebound_or_coalescence(const Superd
 /* returns flag that indicates coalescence (flag=1)
 or breakup (flag=2) based on coalescence efficiency
 from Straub et al. 2010 */
-KOKKOS_FUNCTION unsigned int TSCoalBuReFlag::coalescence_or_breakup(const Superdrop &drop1,
-                                                                    const Superdrop &drop2,
+KOKKOS_FUNCTION unsigned int TSCoalBuReFlag::coalescence_or_breakup(const Superdrop& drop1,
+                                                                    const Superdrop& drop2,
                                                                     const double phi,
                                                                     const double cke) const {
   if (is_coalescence(drop1, drop2, phi, cke)) {

--- a/libs/superdrops/collisions/coalbure_flag.cpp
+++ b/libs/superdrops/collisions/coalbure_flag.cpp
@@ -44,12 +44,10 @@ KOKKOS_FUNCTION unsigned int SUCoalBuReFlag::operator()(const Superdrop& drop1,
   }
 }
 
-/* function returns flag indicating rebound or
-coalescence or breakup. If flag = 1 -> coalescence.
-If flag = 2 -> breakup. Otherwise -> rebound.
-Flag decided based on the kinetic arguments from
-section 4 of Testik et al. 2011 (figure 12) as well
-as coalescence efficiency from Straub et al. 2010 */
+/* function returns flag indicating rebound or coalescence or breakup. If flag = 1 -> coalescence.
+If flag = 2 -> breakup. Otherwise -> rebound. Flag decided based on the kinetic arguments from
+section 4 of Testik et al. 2011 (figure 12; first proposed in Testik 2009) as well as the
+coalescence efficiency from Straub et al. 2010 */
 KOKKOS_FUNCTION unsigned int TSCoalBuReFlag::operator()(const double phi, const Superdrop& drop1,
                                                         const Superdrop& drop2) const {
   const auto r1 = drop1.get_radius();

--- a/libs/superdrops/collisions/coalbure_flag.hpp
+++ b/libs/superdrops/collisions/coalbure_flag.hpp
@@ -34,7 +34,7 @@
 coalescence or breakup. If flag = 1 -> coalescence.
 If flag = 2 -> breakup. Otherwise -> rebound. */
 template <typename F>
-concept CoalBuReFlag = requires(F f, const double phi, const Superdrop &d1, const Superdrop &d2) {
+concept CoalBuReFlag = requires(F f, const double phi, const Superdrop& d1, const Superdrop& d2) {
   { f(phi, d1, d2) } -> std::convertible_to<unsigned int>;
 };
 
@@ -47,12 +47,12 @@ struct SUCoalBuReFlag {
   section 2.2 of Szakáll and Urbich 2018
   (neglecting grazing angle considerations) */
   KOKKOS_FUNCTION
-  unsigned int operator()(const Superdrop &drop1, const Superdrop &drop2) const;
+  unsigned int operator()(const Superdrop& drop1, const Superdrop& drop2) const;
 
  public:
   /* adaptor of operator to satisfy CoalBuReFlag concept */
   KOKKOS_FUNCTION
-  unsigned int operator()(const double phi, const Superdrop &drop1, const Superdrop &drop2) const {
+  unsigned int operator()(const double phi, const Superdrop& drop1, const Superdrop& drop2) const {
     return operator()(drop1, drop2);
   }
 };
@@ -63,20 +63,20 @@ struct TSCoalBuReFlag {
   or rebound (flag=0) based on coalescence efficiency
   from Straub et al. 2010 */
   KOKKOS_FUNCTION
-  unsigned int rebound_or_coalescence(const Superdrop &drop1, const Superdrop &drop2,
+  unsigned int rebound_or_coalescence(const Superdrop& drop1, const Superdrop& drop2,
                                       const double phi, const double cke) const;
 
   /* returns flag that indicates coalescence (flag=1)
   or breakup (flag=2) based on coalescence efficiency
   from Straub et al. 2010 */
   KOKKOS_FUNCTION
-  unsigned int coalescence_or_breakup(const Superdrop &drop1, const Superdrop &drop2,
+  unsigned int coalescence_or_breakup(const Superdrop& drop1, const Superdrop& drop2,
                                       const double phi, const double cke) const;
 
   /* returns truw if comparison of random numnber
   with coalescence efficiency from Straub et al. 2010
   indicates coalescence should occur */
-  KOKKOS_FUNCTION bool is_coalescence(const Superdrop &drop1, const Superdrop &drop2,
+  KOKKOS_FUNCTION bool is_coalescence(const Superdrop& drop1, const Superdrop& drop2,
                                       const double phi, const double cke) const;
 
   /* coalescence efficency given a collision occurs
@@ -84,7 +84,7 @@ struct TSCoalBuReFlag {
   section 3, equation 5 and Schlottke et al. 2010
   section 4a equation 11 */
   KOKKOS_FUNCTION
-  double coalescence_efficiency(const Superdrop &drop1, const Superdrop &drop2,
+  double coalescence_efficiency(const Superdrop& drop1, const Superdrop& drop2,
                                 const double cke) const;
 
  public:
@@ -97,7 +97,7 @@ struct TSCoalBuReFlag {
   section 4 of Testik et al. 2011 (figure 12) as well
   as coalescence efficiency from Straub et al. 2010 */
   KOKKOS_FUNCTION
-  unsigned int operator()(const double phi, const Superdrop &drop1, const Superdrop &drop2) const;
+  unsigned int operator()(const double phi, const Superdrop& drop1, const Superdrop& drop2) const;
 };
 
 #endif  // LIBS_SUPERDROPS_COLLISIONS_COALBURE_FLAG_HPP_

--- a/libs/superdrops/collisions/coalbure_flag.hpp
+++ b/libs/superdrops/collisions/coalbure_flag.hpp
@@ -100,4 +100,25 @@ struct TSCoalBuReFlag {
   unsigned int operator()(const double phi, const Superdrop& drop1, const Superdrop& drop2) const;
 };
 
+struct ConstCoalBuReFlag {
+ private:
+  double coaleff;  // flag indicating whether coalescence, breakup or rebound should occur
+ public:
+  explicit ConstCoalBuReFlag(const double coaleff) : coaleff(coaleff) {}
+
+  /* function returns flag indicating coalescence or breakup (never rebound).
+   * If flag = 1 -> coalescence. If flag = 2 -> breakup.
+   * Flag decided based on constant coalescence efficiency compared to random number "phi"
+   * function signature matches conditions to satisfy CoalBuReFlag concept
+   * */
+  KOKKOS_FUNCTION
+  unsigned int operator()(const double phi, const Superdrop& drop1, const Superdrop& drop2) const {
+    if (phi < coaleff) {
+      return 1;  // coalescence
+    } else {
+      return 2;  // breakup
+    }
+  }
+};
+
 #endif  // LIBS_SUPERDROPS_COLLISIONS_COALBURE_FLAG_HPP_

--- a/libs/superdrops/collisions/coalbure_flag.hpp
+++ b/libs/superdrops/collisions/coalbure_flag.hpp
@@ -28,6 +28,7 @@
 
 #include "../superdrop.hpp"
 #include "../terminalvelocity.hpp"
+#include "./coalescence_efficiency.hpp"
 #include "./collisionkinetics.hpp"
 
 /* operator returns flag indicating rebound or
@@ -78,14 +79,6 @@ struct TSCoalBuReFlag {
   indicates coalescence should occur */
   KOKKOS_FUNCTION bool is_coalescence(const Superdrop& drop1, const Superdrop& drop2,
                                       const double phi, const double cke) const;
-
-  /* coalescence efficency given a collision occurs
-  according to parameterisation from Straub et al. 2010
-  section 3, equation 5 and Schlottke et al. 2010
-  section 4a equation 11 */
-  KOKKOS_FUNCTION
-  double coalescence_efficiency(const Superdrop& drop1, const Superdrop& drop2,
-                                const double cke) const;
 
  public:
   TSCoalBuReFlag() {}

--- a/libs/superdrops/collisions/coalbure_flag.hpp
+++ b/libs/superdrops/collisions/coalbure_flag.hpp
@@ -93,6 +93,37 @@ struct TSCoalBuReFlag {
   unsigned int operator()(const double phi, const Superdrop& drop1, const Superdrop& drop2) const;
 };
 
+template <VelocityFormula TerminalVelocity>
+struct StraubCoalBuReFlag {
+ private:
+  TerminalVelocity terminalv;
+
+ public:
+  explicit StraubCoalBuReFlag(TerminalVelocity tv) : terminalv(tv) {}
+
+  /* function returns flag indicating coalescence or breakup (never rebound).
+   * If flag = 1 -> coalescence. If flag = 2 -> breakup.
+   * Flag decided based on Straub et al. 2010 coalescence efficiency equation 3
+   * (with definition of terms from Schlottle et al. 2010) compared to random number "phi"
+   * function signature matches conditions to satisfy CoalBuReFlag concept
+   * */
+  KOKKOS_INLINE_FUNCTION
+  unsigned int operator()(const double phi, const Superdrop& drop1, const Superdrop& drop2) const {
+    const auto r1 = drop1.get_radius();
+    const auto r2 = drop2.get_radius();
+    const auto cke = collision_kinetic_energy(r1, r2, terminalv(drop1),
+                                              terminalv(drop2));  // [J]
+
+    const auto ecoal = coalescence_efficiency_straub2010(drop1, drop2, cke);
+
+    if (phi < ecoal) {
+      return 1;  // coalescence
+    } else {
+      return 2;  // breakup
+    }
+  }
+};
+
 struct ConstCoalBuReFlag {
  private:
   double coaleff;  // flag indicating whether coalescence, breakup or rebound should occur
@@ -104,7 +135,7 @@ struct ConstCoalBuReFlag {
    * Flag decided based on constant coalescence efficiency compared to random number "phi"
    * function signature matches conditions to satisfy CoalBuReFlag concept
    * */
-  KOKKOS_FUNCTION
+  KOKKOS_INLINE_FUNCTION
   unsigned int operator()(const double phi, const Superdrop& drop1, const Superdrop& drop2) const {
     if (phi < coaleff) {
       return 1;  // coalescence

--- a/libs/superdrops/collisions/coalbure_flag.hpp
+++ b/libs/superdrops/collisions/coalbure_flag.hpp
@@ -83,12 +83,10 @@ struct TSCoalBuReFlag {
  public:
   TSCoalBuReFlag() {}
 
-  /* function returns flag indicating rebound or
-  coalescence or breakup. If flag = 1 -> coalescence.
-  If flag = 2 -> breakup. Otherwise -> rebound.
-  Flag decided based on the kinetic arguments from
-  section 4 of Testik et al. 2011 (figure 12) as well
-  as coalescence efficiency from Straub et al. 2010 */
+  /* function returns flag indicating rebound or coalescence or breakup. If flag = 1 -> coalescence.
+  If flag = 2 -> breakup. Otherwise -> rebound. Flag decided based on the kinetic arguments from
+  section 4 of Testik et al. 2011 (figure 12; first proposed in Testik 2009) as well as the
+  coalescence efficiency from Straub et al. 2010 */
   KOKKOS_FUNCTION
   unsigned int operator()(const double phi, const Superdrop& drop1, const Superdrop& drop2) const;
 };

--- a/libs/superdrops/collisions/coalescence.cpp
+++ b/libs/superdrops/collisions/coalescence.cpp
@@ -85,8 +85,8 @@ KOKKOS_FUNCTION uint64_t DoCoalescence::coalescence_gamma(const uint64_t xi1, co
  * @return True if coalescence results in a null superdroplet, false otherwise.
  */
 KOKKOS_FUNCTION bool DoCoalescence::coalesce_superdroplet_pair(const uint64_t gamma,
-                                                               Superdrop &drop1,
-                                                               Superdrop &drop2) const {
+                                                               Superdrop& drop1,
+                                                               Superdrop& drop2) const {
   const auto xi1 = drop1.get_xi();
   const auto xi2 = drop2.get_xi();
 
@@ -123,8 +123,8 @@ KOKKOS_FUNCTION bool DoCoalescence::coalesce_superdroplet_pair(const uint64_t ga
  * @param drop2 The second superdroplet.
  */
 KOKKOS_FUNCTION void DoCoalescence::twin_superdroplet_coalescence(const uint64_t gamma,
-                                                                  Superdrop &drop1,
-                                                                  Superdrop &drop2) const {
+                                                                  Superdrop& drop1,
+                                                                  Superdrop& drop2) const {
   assert((drop1.get_xi() == gamma * drop2.get_xi()) && "condition for twin coalescence not met");
 
   const auto old_xi = drop2.get_xi();  // = drop1.xi
@@ -161,8 +161,8 @@ KOKKOS_FUNCTION void DoCoalescence::twin_superdroplet_coalescence(const uint64_t
  * @param drop2 The second superdroplet.
  */
 KOKKOS_FUNCTION void DoCoalescence::different_superdroplet_coalescence(const uint64_t gamma,
-                                                                       Superdrop &drop1,
-                                                                       Superdrop &drop2) const {
+                                                                       Superdrop& drop1,
+                                                                       Superdrop& drop2) const {
   assert((drop1.get_xi() > gamma * drop2.get_xi()) && "condition on xis for coalescence not met");
 
   const auto new_xi = drop1.get_xi() - gamma * drop2.get_xi();

--- a/libs/superdrops/collisions/coalescence.cpp
+++ b/libs/superdrops/collisions/coalescence.cpp
@@ -29,15 +29,17 @@
  * @param drop1 The first super-droplet.
  * @param drop2 The second super-droplet.
  * @param prob The probability of collision-coalescence.
- * @param phi Random number in the range [0.0, 1.0].
+ * @param phi_coll Random number in the range [0.0, 1.0] for collision.
+ * @param phi_out Random number in the range [0.0, 1.0] for outcome of collision (not used).
  * @return boolean=true if collision-coalescence resulted in null superdrops.
  */
-KOKKOS_FUNCTION bool DoCoalescence::operator()(Superdrop &drop1, Superdrop &drop2,
-                                               const double prob, const double phi) const {
+KOKKOS_FUNCTION bool DoCoalescence::operator()(Superdrop& drop1, Superdrop& drop2,
+                                               const double prob, const double phi_coll,
+                                               const double phi_out) const {
   /* 1. calculate gamma factor for collision-coalescence  */
   const auto xi1 = drop1.get_xi();
   const auto xi2 = drop2.get_xi();
-  const auto gamma = coalescence_gamma(xi1, xi2, prob, phi);
+  const auto gamma = coalescence_gamma(xi1, xi2, prob, phi_coll);
 
   /* 2. enact collision-coalescence on pair
   of superdroplets if gamma is not zero */

--- a/libs/superdrops/collisions/coalescence.hpp
+++ b/libs/superdrops/collisions/coalescence.hpp
@@ -91,11 +91,13 @@ struct DoCoalescence {
    * @param drop1 The first super-droplet.
    * @param drop2 The second super-droplet.
    * @param prob The probability of collision-coalescence.
-   * @param phi Random number in the range [0.0, 1.0].
+   * @param phi_coll Random number in the range [0.0, 1.0] for collision.
+   * @param phi_out Random number in the range [0.0, 1.0] for outcome of collision (not used).
    * @return boolean=true if collision-coalescence resulted in null superdrops.
    */
   KOKKOS_FUNCTION
-  bool operator()(Superdrop &drop1, Superdrop &drop2, const double prob, const double phi) const;
+  bool operator()(Superdrop& drop1, Superdrop& drop2, const double prob, const double phi_coll,
+                  const double phi_out) const;
 
   /**
    * @brief Calculates the value of the gamma factor in Monte Carlo collision-coalescence.

--- a/libs/superdrops/collisions/coalescence.hpp
+++ b/libs/superdrops/collisions/coalescence.hpp
@@ -39,7 +39,7 @@
  * @param drop A reference to the `Superdrop` object to be checked.
  * @return Always returns 0 (=false).
  */
-KOKKOS_INLINE_FUNCTION bool is_null_superdrop(const Superdrop &drop) {
+KOKKOS_INLINE_FUNCTION bool is_null_superdrop(const Superdrop& drop) {
   assert((drop.get_xi() > 0) && "superdrop xi < 1, null drop in coalescence");
   return 0;
 }
@@ -62,8 +62,8 @@ struct DoCoalescence {
    * @param drop1 The first superdroplet.
    * @param drop2 The second superdroplet.
    */
-  KOKKOS_FUNCTION void twin_superdroplet_coalescence(const uint64_t gamma, Superdrop &drop1,
-                                                     Superdrop &drop2) const;
+  KOKKOS_FUNCTION void twin_superdroplet_coalescence(const uint64_t gamma, Superdrop& drop1,
+                                                     Superdrop& drop2) const;
 
   /**
    * @brief Coalesces a pair of superdroplets where xi1 > gamma*xi2.
@@ -78,8 +78,8 @@ struct DoCoalescence {
    * @param drop1 The first superdroplet.
    * @param drop2 The second superdroplet.
    */
-  KOKKOS_FUNCTION void different_superdroplet_coalescence(const uint64_t gamma, Superdrop &drop1,
-                                                          Superdrop &drop2) const;
+  KOKKOS_FUNCTION void different_superdroplet_coalescence(const uint64_t gamma, Superdrop& drop1,
+                                                          Superdrop& drop2) const;
 
  public:
   /**
@@ -123,8 +123,8 @@ struct DoCoalescence {
    * @param drop2 The second superdroplet.
    * @return True if coalescence results in a null superdroplet, false otherwise.
    */
-  KOKKOS_FUNCTION bool coalesce_superdroplet_pair(const uint64_t gamma, Superdrop &drop1,
-                                                  Superdrop &drop2) const;
+  KOKKOS_FUNCTION bool coalesce_superdroplet_pair(const uint64_t gamma, Superdrop& drop1,
+                                                  Superdrop& drop2) const;
 };
 
 /**

--- a/libs/superdrops/collisions/coalescence_efficiency.cpp
+++ b/libs/superdrops/collisions/coalescence_efficiency.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 MPI-M, Clara Bayley
+ *
+ *
+ * ----- CLEO -----
+ * File: coalescence_efficiency.cpp
+ * Project: collisions
+ * Created Date: Monday 9th March 2026
+ * Author: Clara Bayley (CB)
+ * Additional Contributors:
+ * -----
+ * License: BSD 3-Clause "New" or "Revised" License
+ * https://opensource.org/licenses/BSD-3-Clause
+ * -----
+ * File Description:
+ * various parameterisations of the coalescence efficiency
+ */
+
+#include "./coalescence_efficiency.hpp"
+
+/*
+ * coalescence efficency given a collision occurs according to parameterisation from
+ * Straub et al. 2010 section 3, equation 5
+ * and Schlottke et al. 2010 section 4a equation 11
+ * cke == collision_kinetic_energy
+ * */
+KOKKOS_FUNCTION
+double coalescence_efficiency_straub2010(const Superdrop& drop1, const Superdrop& drop2,
+                                         const double cke) {
+  constexpr double beta = -1.15;
+
+  const auto surf_c = coal_surfenergy(drop1.get_radius(),
+                                      drop2.get_radius());  // [J] S_c
+  const auto weber = double{cke / surf_c};
+  const auto ecoal = double{Kokkos::exp(beta * weber)};
+
+  return ecoal;
+}

--- a/libs/superdrops/collisions/coalescence_efficiency.hpp
+++ b/libs/superdrops/collisions/coalescence_efficiency.hpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 MPI-M, Clara Bayley
+ *
+ *
+ * ----- CLEO -----
+ * File: coalescence_efficiency.hpp
+ * Project: collisions
+ * Created Date: Monday 9th March 2026
+ * Author: Clara Bayley (CB)
+ * Additional Contributors:
+ * -----
+ * License: BSD 3-Clause "New" or "Revised" License
+ * https://opensource.org/licenses/BSD-3-Clause
+ * -----
+ * File Description:
+ * various parameterisations of the coalescence efficiency
+ */
+
+#ifndef LIBS_SUPERDROPS_COLLISIONS_COALESCENCE_EFFICIENCY_HPP_
+#define LIBS_SUPERDROPS_COLLISIONS_COALESCENCE_EFFICIENCY_HPP_
+
+#include <Kokkos_Core.hpp>
+
+#include "../superdrop.hpp"
+#include "./collisionkinetics.hpp"
+
+/*
+ * coalescence efficency given a collision occurs according to parameterisation from
+ * Straub et al. 2010 section 3, equation 5
+ * and Schlottke et al. 2010 section 4a equation 11
+ * cke == collision_kinetic_energy
+ * */
+KOKKOS_FUNCTION
+double coalescence_efficiency_straub2010(const Superdrop& drop1, const Superdrop& drop2,
+                                         const double cke);
+
+#endif  // LIBS_SUPERDROPS_COLLISIONS_COALESCENCE_EFFICIENCY_HPP_

--- a/libs/superdrops/collisions/collisions.hpp
+++ b/libs/superdrops/collisions/collisions.hpp
@@ -46,7 +46,7 @@ namespace dlc = dimless_constants;
  * @tparam P The type representing the pair probability object.
  */
 template <typename P>
-concept PairProbability = requires(P p, Superdrop &drop, double d) {
+concept PairProbability = requires(P p, Superdrop& drop, double d) {
   { p(drop, drop, d, d) } -> std::convertible_to<double>;
 };
 
@@ -61,7 +61,7 @@ concept PairProbability = requires(P p, Superdrop &drop, double d) {
  * @tparam X The type representing the pair enactment object.
  */
 template <typename X>
-concept PairEnactX = requires(X x, Superdrop &drop, double d) {
+concept PairEnactX = requires(X x, Superdrop& drop, double d) {
   { x(drop, drop, d, d) } -> std::convertible_to<bool>;
 };
 
@@ -72,8 +72,8 @@ other members of DoCollisions coincidentally
 */
 template <PairProbability Probability, PairEnactX EnactCollision>
 struct CollideSupersFunctor {
-  const Probability &probability;        /**< Object for calculating collision probabilities. */
-  const EnactCollision &enact_collision; /**< Enactment object for enacting collision events. */
+  const Probability& probability;        /**< Object for calculating collision probabilities. */
+  const EnactCollision& enact_collision; /**< Enactment object for enacting collision events. */
   const GenRandomPool genpool;           /**< Kokkos thread-safe random number generator pool.*/
   const subviewd_supers supers;          /**< The randomly shuffled view of super-droplets. */
   const double scale_p;                  /**< The probability scaling factor. */
@@ -90,8 +90,8 @@ struct CollideSupersFunctor {
    * @param dropB The second super-droplet.
    * @return A pair of references to super-droplets ordered by descending xi value.
    */
-  KOKKOS_INLINE_FUNCTION Kokkos::pair<Superdrop &, Superdrop &> assign_drops(
-      Superdrop &dropA, Superdrop &dropB) const {
+  KOKKOS_INLINE_FUNCTION Kokkos::pair<Superdrop&, Superdrop&> assign_drops(Superdrop& dropA,
+                                                                           Superdrop& dropB) const {
     if (!(dropA.get_xi() < dropB.get_xi())) {
       return {dropA, dropB};
     } else {
@@ -113,7 +113,7 @@ struct CollideSupersFunctor {
    * @param VOLUME The volume [m^-3].
    * @return The scaled probability of the collision.
    */
-  KOKKOS_INLINE_FUNCTION double scaled_probability(const Superdrop &drop1, const Superdrop &drop2,
+  KOKKOS_INLINE_FUNCTION double scaled_probability(const Superdrop& drop1, const Superdrop& drop2,
                                                    const double scale_p,
                                                    const double VOLUME) const {
     const auto prob_jk = double{probability(drop1, drop2, DELT, VOLUME)};
@@ -136,7 +136,7 @@ struct CollideSupersFunctor {
    * @param VOLUME The volume [m^-3].
    * @return True if the collision event results in null superdrops with xi=0), otherwise false.
    */
-  KOKKOS_INLINE_FUNCTION void collide_superdroplet_pair(Superdrop &dropA, Superdrop &dropB,
+  KOKKOS_INLINE_FUNCTION void collide_superdroplet_pair(Superdrop& dropA, Superdrop& dropB,
                                                         const double scale_p,
                                                         const double VOLUME) const {
     /* 1. assign references to each superdrop in pair that will collide
@@ -197,7 +197,7 @@ struct DoCollisions {
    * @param volume The volume in which to calculate the probability of collisions.
    * @return The number of null (xi=0) superdrops.
    */
-  KOKKOS_INLINE_FUNCTION void collide_supers(const TeamMember &team_member, subviewd_supers supers,
+  KOKKOS_INLINE_FUNCTION void collide_supers(const TeamMember& team_member, subviewd_supers supers,
                                              const double volume) const {
     const auto nsupers = static_cast<size_t>(supers.extent(0));
     const auto npairs = size_t{nsupers / 2};  // no. pairs of superdrops (=floor() for nsupers > 0)
@@ -223,7 +223,7 @@ struct DoCollisions {
    * @param volume The volume in which to calculate the probability of collisions.
    * @return The updated superdroplets.
    */
-  KOKKOS_INLINE_FUNCTION void do_collisions(const TeamMember &team_member, subviewd_supers supers,
+  KOKKOS_INLINE_FUNCTION void do_collisions(const TeamMember& team_member, subviewd_supers supers,
                                             const double volume) const {
     /* Randomly shuffle order of superdroplet objects
     in supers in order to generate random pairs */
@@ -265,8 +265,8 @@ struct DoCollisions {
    * @param mo Monitor of SDM processes.
    * @return The updated superdroplets.
    */
-  KOKKOS_INLINE_FUNCTION void operator()(const TeamMember &team_member, const unsigned int subt,
-                                         subviewd_supers supers, const State &state,
+  KOKKOS_INLINE_FUNCTION void operator()(const TeamMember& team_member, const unsigned int subt,
+                                         subviewd_supers supers, const State& state,
                                          const SDMMonitor auto mo) const {
     do_collisions(team_member, supers, state.get_volume());
   }

--- a/libs/superdrops/collisions/collisions.hpp
+++ b/libs/superdrops/collisions/collisions.hpp
@@ -62,7 +62,7 @@ concept PairProbability = requires(P p, Superdrop& drop, double d) {
  */
 template <typename X>
 concept PairEnactX = requires(X x, Superdrop& drop, double d) {
-  { x(drop, drop, d, d) } -> std::convertible_to<bool>;
+  { x(drop, drop, d, d, d) } -> std::convertible_to<bool>;
 };
 
 /*
@@ -147,11 +147,13 @@ struct CollideSupersFunctor {
     const auto prob = scaled_probability(drops.first, drops.second, scale_p, VOLUME);
 
     /* 3. Monte Carlo Step: use random number to enact (or not) collision of superdroplets pair */
-    URBG<ExecSpace> urbg{genpool.get_state()};  // thread safe random number generator
-    const auto phi = urbg.drand(0.0, 1.0);      // random number in range [0.0, 1.0]
+    /* TODO(CB): move phi_out generation into coalbure? */
+    URBG<ExecSpace> urbg{genpool.get_state()};   // thread safe random number generator
+    const auto phi_coll = urbg.drand(0.0, 1.0);  // random number in range [0.0, 1.0] for collision
+    const auto phi_out = urbg.drand(0.0, 1.0);  // for outcome of collisions extended algorithm only
     genpool.free_state(urbg.gen);
 
-    enact_collision(drops.first, drops.second, prob, phi);
+    enact_collision(drops.first, drops.second, prob, phi_coll, phi_out);
   }
 
   /*

--- a/roughpaper/src/config/config.yaml
+++ b/roughpaper/src/config/config.yaml
@@ -62,6 +62,9 @@ microphysics:
     MINSUBTSTEP : 0.01                                 # minimum subtimestep in cases of substepping [s]
     rtol : 0.0                                         # relative tolerance for implicit Euler integration
     atol : 0.001                                       # absolute tolerance for implicit Euler integration
+  coalescence:
+    constcoaleff:
+      coaleff: 0.95                                    # constant coalescence efficiency
   # breakup:
   #   constnfrags:
   #     nfrags: 5.0                                      # average no. of fragments per droplet breakup

--- a/roughpaper/src/main_impl.hpp
+++ b/roughpaper/src/main_impl.hpp
@@ -76,7 +76,7 @@
 #include "zarr/fsstore.hpp"
 #include "zarr/simple_dataset.hpp"
 
-inline CoupledDynamics auto create_coupldyn(const Config &config, const CartesianMaps &gbxmaps,
+inline CoupledDynamics auto create_coupldyn(const Config& config, const CartesianMaps& gbxmaps,
                                             const unsigned int couplstep,
                                             const unsigned int t_end) {
   const auto h_ndims = gbxmaps.get_global_ndims_hostcopy();
@@ -88,7 +88,7 @@ inline CoupledDynamics auto create_coupldyn(const Config &config, const Cartesia
 }
 
 template <GridboxMaps GbxMaps>
-inline InitialConditions auto create_initconds(const Config &config, const GbxMaps &gbxmaps) {
+inline InitialConditions auto create_initconds(const Config& config, const GbxMaps& gbxmaps) {
   // const auto initsupers = InitAllSupersFromBinary(config.get_initsupersfrombinary());
   const auto initsupers = InitSupersFromBinary(config.get_initsupersfrombinary(), gbxmaps);
   const auto initgbxs = InitGbxsNull(gbxmaps.get_local_ngridboxes_hostcopy());
@@ -96,7 +96,7 @@ inline InitialConditions auto create_initconds(const Config &config, const GbxMa
   return InitConds(initsupers, initgbxs);
 }
 
-inline GridboxMaps auto create_gbxmaps(const Config &config) {
+inline GridboxMaps auto create_gbxmaps(const Config& config) {
   const auto gbxmaps = create_cartesian_maps(config.get_ngbxs(), config.get_nspacedims(),
                                              config.get_grid_filename());
   return gbxmaps;
@@ -113,13 +113,13 @@ inline Motion<CartesianMaps> auto create_motion(const unsigned int motionstep) {
   // return NullMotion{};
 }
 
-inline BoundaryConditions<CartesianMaps> auto create_boundary_conditions(const Config &config) {
+inline BoundaryConditions<CartesianMaps> auto create_boundary_conditions(const Config& config) {
   // return AddSupersToDomain(config.get_addsuperstodomain());
   return NullBoundaryConditions{};
 }
 
 template <GridboxMaps GbxMaps>
-inline auto create_movement(const Config &config, const Timesteps &tsteps, const GbxMaps &gbxmaps) {
+inline auto create_movement(const Config& config, const Timesteps& tsteps, const GbxMaps& gbxmaps) {
   const Motion<CartesianMaps> auto motion = create_motion(tsteps.get_motionstep());
   const BoundaryConditions<CartesianMaps> auto boundary_conditions =
       create_boundary_conditions(config);
@@ -127,15 +127,15 @@ inline auto create_movement(const Config &config, const Timesteps &tsteps, const
   return movement;
 }
 
-inline MicrophysicalProcess auto config_condensation(const Config &config,
-                                                     const Timesteps &tsteps) {
+inline MicrophysicalProcess auto config_condensation(const Config& config,
+                                                     const Timesteps& tsteps) {
   const auto c = config.get_condensation();
 
   return Condensation(tsteps.get_condstep(), &step2dimlesstime, c.do_alter_thermo, c.maxniters,
                       c.rtol, c.atol, c.MINSUBTSTEP, &realtime2dimless);
 }
 
-inline MicrophysicalProcess auto config_collisions(const Config &config, const Timesteps &tsteps) {
+inline MicrophysicalProcess auto config_collisions(const Config& config, const Timesteps& tsteps) {
   // const PairProbability auto collprob = LongHydroProb();
   // // const NFragments auto nfrags = ConstNFrags(config.get_breakup().constnfrags.nfrags);
   // const NFragments auto nfrags = CollisionKineticEnergyNFrags{};
@@ -157,15 +157,17 @@ inline MicrophysicalProcess auto config_collisions(const Config &config, const T
 
   // const PairProbability auto coalprob = LowListCoalProb();
   // const PairProbability auto coalprob = GolovinProb();
-  const PairProbability auto coalprob = LongHydroProb(1.0);
+  // const PairProbability auto coalprob = LongHydroProb(1.0);
+  const PairProbability auto coalprob =
+      LongHydroProb(config.get_coalescence().constcoaleff.coaleff);
   const MicrophysicalProcess auto coal = CollCoal(tsteps.get_collstep(), &step2realtime, coalprob);
 
   return coal;
   // return coal >> bu;
 }
 
-inline MicrophysicalProcess auto create_microphysics(const Config &config,
-                                                     const Timesteps &tsteps) {
+inline MicrophysicalProcess auto create_microphysics(const Config& config,
+                                                     const Timesteps& tsteps) {
   const MicrophysicalProcess auto cond = config_condensation(config, tsteps);
   // const MicrophysicalProcess auto colls = config_collisions(config, tsteps);
   // return colls >> cond;
@@ -177,8 +179,8 @@ inline MicrophysicalProcess auto create_microphysics(const Config &config,
 }
 
 template <typename Dataset, typename Store>
-inline Observer auto create_superdrops_observer(const unsigned int interval, Dataset &dataset,
-                                                Store &store, const size_t maxchunk) {
+inline Observer auto create_superdrops_observer(const unsigned int interval, Dataset& dataset,
+                                                Store& store, const size_t maxchunk) {
   CollectDataForDataset<Dataset> auto sdid = CollectSdId(dataset, maxchunk);
   CollectDataForDataset<Dataset> auto sdgbxindex = CollectSdgbxindex(dataset, maxchunk);
   CollectDataForDataset<Dataset> auto xi = CollectXi(dataset, maxchunk);
@@ -194,7 +196,7 @@ inline Observer auto create_superdrops_observer(const unsigned int interval, Dat
 }
 
 template <typename Dataset>
-inline Observer auto create_gridboxes_observer(const unsigned int interval, Dataset &dataset,
+inline Observer auto create_gridboxes_observer(const unsigned int interval, Dataset& dataset,
                                                const size_t maxchunk, const size_t ngbxs) {
   const CollectDataForDataset<Dataset> auto thermo = CollectThermo(dataset, maxchunk, ngbxs);
   const CollectDataForDataset<Dataset> auto windvel = CollectWindVel(dataset, maxchunk, ngbxs);
@@ -205,8 +207,8 @@ inline Observer auto create_gridboxes_observer(const unsigned int interval, Data
 }
 
 template <typename Dataset, typename Store>
-inline Observer auto create_sdmmonitor_observer(const unsigned int interval, Dataset &dataset,
-                                                Store &store, const size_t maxchunk,
+inline Observer auto create_sdmmonitor_observer(const unsigned int interval, Dataset& dataset,
+                                                Store& store, const size_t maxchunk,
                                                 const size_t ngbxs) {
   const Observer auto obs_cond =
       MonitorCondensationObserver(interval, dataset, store, maxchunk, ngbxs);
@@ -221,8 +223,8 @@ inline Observer auto create_sdmmonitor_observer(const unsigned int interval, Dat
 }
 
 template <typename Dataset, typename Store>
-inline Observer auto create_observer(const Config &config, const Timesteps &tsteps,
-                                     Dataset &dataset, Store &store) {
+inline Observer auto create_observer(const Config& config, const Timesteps& tsteps,
+                                     Dataset& dataset, Store& store) {
   const auto obsstep = tsteps.get_obsstep();
   const auto maxchunk = config.get_maxchunk();
   const auto ngbxs = config.get_ngbxs();
@@ -249,8 +251,8 @@ inline Observer auto create_observer(const Config &config, const Timesteps &tste
 }
 
 template <typename Dataset, typename Store>
-inline auto create_sdm(const Config &config, const Timesteps &tsteps, Dataset &dataset,
-                       Store &store) {
+inline auto create_sdm(const Config& config, const Timesteps& tsteps, Dataset& dataset,
+                       Store& store) {
   const auto couplstep = (unsigned int)tsteps.get_couplstep();
   const GridboxMaps auto gbxmaps = create_gbxmaps(config);
   const MicrophysicalProcess auto microphys = create_microphysics(config, tsteps);

--- a/roughpaper/src/main_impl.hpp
+++ b/roughpaper/src/main_impl.hpp
@@ -141,6 +141,9 @@ inline MicrophysicalProcess auto config_collisions(const Config& config, const T
   // const NFragments auto nfrags = CollisionKineticEnergyNFrags{};
   // // const CoalBuReFlag auto coalbure_flag = SUCoalBuReFlag{};
   // const CoalBuReFlag auto coalbure_flag = TSCoalBuReFlag{};
+  // // const CoalBuReFlag auto coalbure_flag = StraubCoalBuReFlag(RogersGKTerminalVelocity{});
+  // // const CoalBuReFlag auto coalbure_flag =
+  // //     ConstCoalBuReFlag{config.get_coalescence().constcoaleff.coaleff};
   // const MicrophysicalProcess auto colls = CoalBuRe(tsteps.get_collstep(),
   //                                                  &step2realtime,
   //                                                  collprob,


### PR DESCRIPTION
Follow-up on [PR296](https://github.com/yoctoyotta1024/CLEO/pull/296)

TODO: add new kernels (StraubCoalBuReFlag and ConstCoalBuReFlag) to main_impl.hpp and to breakup example
TODO: add coalescence efficiency example and remove implicit coaleff = 1.0?
TODO: make coalbure and lowlistprob.cpp not only use rogersgk terminal velocity (also check elsewhere for fixed tv)
TODO: test changes with GPU build