### PR TITLE
allow xi=0 to occur during collisions

### DIFF
--- a/docs/source/libs/superdrops/collisions/coalescence.rst
+++ b/docs/source/libs/superdrops/collisions/coalescence.rst
@@ -4,9 +4,6 @@ Coalescence
 Header file: ``<libs/superdrops/collisions/coalescence.hpp>``
 `[source] <https://github.com/yoctoyotta1024/CLEO/blob/main/libs/superdrops/collisions/coalescence.hpp>`_
 
-.. doxygenfunction:: is_null_superdrop
-   :project: superdrops
-
 .. doxygenstruct:: DoCoalescence
    :project: superdrops
    :private-members:

--- a/examples/eurec4a1d/src/config/eurec4a1d_config.yaml
+++ b/examples/eurec4a1d/src/config/eurec4a1d_config.yaml
@@ -24,7 +24,7 @@ python_inputfiles:
   xgrid_max: 10                                # domain size in x [m]
   ygrid_max: 10                                # domain size in y [m]
   sd_zlim: 0                                   # min z coord of initial superdroplets
-  nsupers_pergbx: 128                          # number of SDs per gridbox above sd_zlim <- note(!) total initial SDs must be <= maxnsupers (see below)
+  nsupers_pergbx: 128                          # number of SDs per gridbox above sd_zlim <- note(!) total initial SDs must be <= maxnsupers and == initnsupers (see below)
   rspan:                                       # [min, max] range of radii to sample [m]
     - 0.5e-8
     - 2.5e-7

--- a/examples/python_bindings/src/config/pybind_config.yaml
+++ b/examples/python_bindings/src/config/pybind_config.yaml
@@ -25,7 +25,7 @@ python_inputfiles:
   zgrid_ngbxs: 3                               # z direction ngbxs <- note(!) zgrid_ngbxs * xgrid_ngbxs == ngbxs (see below)
   xgrid_ngbxs: 3                               # x direction ngbxs <- note(!) zgrid_ngbxs * xgrid_ngbxs == ngbxs (see below)
   sd_zlim: 750                                 # max z coord of initial superdroplets
-  nsupers_pergbx: 8                            # number of SDs per gridbox below sd_zlim <- note(!) total initial SDs must be <= maxnsupers (see below)
+  nsupers_pergbx: 8                            # number of SDs per gridbox below sd_zlim <- note(!) total initial SDs must be <= maxnsupers and == initnsupers (see below)
   rspan:                                       # [min, max] range of radii to sample [m]
     - 3e-9
     - 3e-6

--- a/libs/runcleo/sdmmethods.hpp
+++ b/libs/runcleo/sdmmethods.hpp
@@ -64,7 +64,7 @@ struct SDMMicrophysicsFunctor {
     const auto ii = team_member.league_rank();
     auto supers = d_gbxs(ii).supersingbx(domainsupers);
     for (unsigned int subt = t_sdm; subt < t_next; subt = microphys.next_step(subt)) {
-      microphys.run_step(team_member, subt, supers, d_gbxs(ii).state, mo);
+      supers = microphys.run_step(team_member, subt, supers, d_gbxs(ii).state, mo);
       // TODO(CB): explicitly feed supers back into domainsupers after microphys.run_step(...)?
     }
 

--- a/libs/runcleo/sdmmethods.hpp
+++ b/libs/runcleo/sdmmethods.hpp
@@ -44,7 +44,7 @@ namespace KCS = KokkosCleoSettings;
  * @struct SDMMicrophysicsFunctor
  * @brief Structure for encapsulating the microphysics process in SDM.
  *
- * The `operator()` is called for SDM microphysics, and it uses Kokkos parallel_for(...)
+ * The `operator()` is called for SDM microphysics, and it uses Kokkos parallel_reduce(...)
  * for parallelized execution over gridboxes and/or superdroplets. Struct ensures parallel region
  * only captures objects relevant to microphysics and not other members of SDMMethods
  * (which may not be GPU compatible).
@@ -60,15 +60,35 @@ struct SDMMicrophysicsFunctor {
   const subviewd_supers domainsupers; /**view on device of all superdroplets in all gridboxes. */
   const SDMMo mo;                     /**< object that is type of SDMMonitor to use. */
 
-  KOKKOS_INLINE_FUNCTION void operator()(const TeamMember& team_member) const {
-    const auto ii = team_member.league_rank();
-    auto supers = d_gbxs(ii).supersingbx(domainsupers);
+  /** Note(!): number of superdroplets in supers may change in call to run microphysics and, if so,
+   * then it is REQUIRED to sort allsupers outside this functor (i.e. after gbxs parallel loop)
+   * and then call set_refs for all gbxs. See sdm_microphysics(...) below. This can occur e.g.
+   * due to null superdroplet after collision coalescence of two xi=1 superdroplets.
+   *
+   * @return true if number of superdroplets changes, false otherwise
+   */
+  KOKKOS_INLINE_FUNCTION bool run_subtimestepping(const TeamMember& team_member, State& state,
+                                                  subviewd_supers supers) const {
+    const auto nsupers_before = static_cast<size_t>(supers.extent(0));
     for (unsigned int subt = t_sdm; subt < t_next; subt = microphys.next_step(subt)) {
-      supers = microphys.run_step(team_member, subt, supers, d_gbxs(ii).state, mo);
-      // TODO(CB): explicitly feed supers back into domainsupers after microphys.run_step(...)?
+      supers = microphys.run_step(team_member, subt, supers, state, mo);
     }
-
     mo.monitor_microphysics(team_member, supers);
+    const auto nsupers_after = static_cast<size_t>(supers.extent(0));
+
+    if (nsupers_before == nsupers_after) {
+      return false;
+    } else {
+      return true;  // number of superdroplets has changed
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION void operator()(const TeamMember& team_member,
+                                         bool& any_nsupers_change) const {
+    const auto ii = team_member.league_rank();
+    const auto nsupers_change =
+        run_subtimestepping(team_member, d_gbxs(ii).state, d_gbxs(ii).supersingbx(domainsupers));
+    any_nsupers_change = any_nsupers_change || nsupers_change;
   }
 };
 
@@ -150,28 +170,36 @@ class SDMMethods {
    * @brief run SDM microphysics for each gridbox (using sub-timestepping routine).
    *
    * This function runs SDM microphysics for each gridbox using a sub-timestepping routine.
-   * Kokkos::parallel_for is nested parallelism within parallelised loop over gridboxes,
-   * serial equivalent is simply: `for (size_t ii(0); ii < ngbxs; ++ii) { [...] }`
+   * Kokkos::parallel_reduce is nested parallelism within parallelised loop over gridboxes,
+   * serial equivalent is simply: `for (size_t ii(0); ii < ngbxs; ++ii) { [...] }` which then
+   * returns combined result of "logical or" operation over all gridboxes.
    *
    * @param t_sdm Current timestep for SDM.
    * @param t_next Next timestep for SDM.
    * @param d_gbxs View of gridboxes on device.
    * @param domainsupers View on device of all the superdroplets related to the gridboxes.
    * @param mo SDMMonitor to use.
+   * @return true if number of superdroplets in any gridbox has changed during microphysics
    */
   template <SDMMonitor SDMMo>
-  void sdm_microphysics(const unsigned int t_sdm, const unsigned int t_next, const viewd_gbx d_gbxs,
+  bool sdm_microphysics(const unsigned int t_sdm, const unsigned int t_next, const viewd_gbx d_gbxs,
                         const subviewd_supers domainsupers, const SDMMo mo) const {
     // TODO(ALL) use scratch space for parallel region(?)
     const size_t ngbxs(d_gbxs.extent(0));
     const auto functor = SDMMicrophysicsFunctor{microphys, t_sdm, t_next, d_gbxs, domainsupers, mo};
-    Kokkos::parallel_for("sdm_microphysics", TeamPolicy(ngbxs, KCS::team_size), functor);
+
+    auto any_nsupers_change = bool{false};
+    Kokkos::parallel_reduce("sdm_microphysics", TeamPolicy(ngbxs, KCS::team_size), functor,
+                            Kokkos::LOr<bool>(any_nsupers_change));
+    return any_nsupers_change;
   }
 
   /**
    * @brief run SDM microphysics for each gridbox (using sub-timestepping routine).
    *
-   * This operator is a wrapper around the function which runs SDM microphysics.
+   * This function is a wrapper around the function which runs SDM microphysics and then will
+   * sort all the superdroplets and set the refs of all the gridboxes if the change in number of
+   * superdroplets boolean returned from running microphysics is true
    *
    * Kokkos::Profiling are null pointers unless a Kokkos profiler library has been
    * exported to "KOKKOS_TOOLS_LIBS" prior to runtime so the lib gets dynamically loaded.
@@ -184,11 +212,21 @@ class SDMMethods {
    */
   template <SDMMonitor SDMMo>
   void sdm_microphysics(const unsigned int t_sdm, const unsigned int t_next, const viewd_gbx d_gbxs,
-                        const SupersInDomain& allsupers, const SDMMo mo) const {
+                        SupersInDomain& allsupers, const SDMMo mo) const {
     Kokkos::Profiling::ScopedRegion region("timestep_sdm_microphysics");
 
     const auto domainsupers = allsupers.domain_supers();
-    sdm_microphysics(t_sdm, t_next, d_gbxs, domainsupers, mo);
+    const auto any_nsupers_change = sdm_microphysics(t_sdm, t_next, d_gbxs, domainsupers, mo);
+
+    if (any_nsupers_change) {
+      allsupers.sort_totsupers(d_gbxs);
+      const size_t ngbxs(d_gbxs.extent(0));
+      Kokkos::parallel_for(
+          "microphysics_set_gridboxes_refs", Kokkos::RangePolicy<ExecSpace>(0, ngbxs),
+          KOKKOS_LAMBDA(const size_t ii) {
+            d_gbxs(ii).supersingbx.set_refs(allsupers.domain_supers());
+          });
+    }
   }
 
   /**

--- a/libs/superdrops/collisions/breakup.hpp
+++ b/libs/superdrops/collisions/breakup.hpp
@@ -72,19 +72,21 @@ struct DoBreakup {
    * @param prob Probability of collision.
    * @param phi_coll Random number in the range [0.0, 1.0] for collision.
    * @param phi_out Random number in the range [0.0, 1.0] for outcome of collision (not used).
-   * @return True if the resulting superdroplet is null, otherwise false.
+   * @return Resulting total number of null (xi=0) superdroplets from collision (i.e. 0, 1 or 2)
    */
   KOKKOS_FUNCTION
-  bool operator()(Superdrop& drop1, Superdrop& drop2, const double prob, const double phi_coll,
-                  const double phi_out) const;
+  size_t operator()(Superdrop& drop1, Superdrop& drop2, const double prob, const double phi_coll,
+                    const double phi_out) const;
 
   /**
    * enact collisional-breakup of droplets by changing multiplicity, radius and solute mass of each
    * superdroplet in a pair.
+   *
    * Note implicit assumption that gamma factor = 1.
-   * True if the resulting superdroplet is null, otherwise false.
+   *
+   * @return Resulting total number of null (xi=0) superdroplets from collision (i.e. 0, 1 or 2)
    */
-  KOKKOS_FUNCTION bool breakup_superdroplet_pair(Superdrop& drop1, Superdrop& drop2) const;
+  KOKKOS_FUNCTION size_t breakup_superdroplet_pair(Superdrop& drop1, Superdrop& drop2) const;
 };
 
 /*
@@ -133,12 +135,12 @@ inline MicrophysicalProcess auto CollBu(const unsigned int interval,
  * @param prob Probability of collision.
  * @param phi_coll Random number in the range [0.0, 1.0] for collision.
  * @param phi_out Random number in the range [0.0, 1.0] for outcome of collision (not used).
- * @return True if the resulting superdroplet is null, otherwise false.
+ * @return Resulting total number of null (xi=0) superdroplets from collision (i.e. 0, 1 or 2)
  */
 template <NFragments NFrags>
-KOKKOS_FUNCTION bool DoBreakup<NFrags>::operator()(Superdrop& drop1, Superdrop& drop2,
-                                                   const double prob, const double phi_coll,
-                                                   const double phi_out) const {
+KOKKOS_FUNCTION size_t DoBreakup<NFrags>::operator()(Superdrop& drop1, Superdrop& drop2,
+                                                     const double prob, const double phi_coll,
+                                                     const double phi_out) const {
   /* enact collision-breakup on pair of superdroplets if
   gamma factor for collision-breakup is not zero */
   if (breakup_gamma(prob, phi_coll) != 0) {
@@ -166,12 +168,14 @@ KOKKOS_FUNCTION unsigned int DoBreakup<NFrags>::breakup_gamma(const double prob,
 /**
  * enact collisional-breakup of droplets by changing multiplicity, radius and solute mass of each
  * superdroplet in a pair.
+ *
  * Note implicit assumption that gamma factor = 1.
- * True if the resulting superdroplet is null, otherwise false.
+ *
+ * @return Resulting total number of null (xi=0) superdroplets from collision (i.e. 0, 1 or 2)
  */
 template <NFragments NFrags>
-KOKKOS_FUNCTION bool DoBreakup<NFrags>::breakup_superdroplet_pair(Superdrop& drop1,
-                                                                  Superdrop& drop2) const {
+KOKKOS_FUNCTION size_t DoBreakup<NFrags>::breakup_superdroplet_pair(Superdrop& drop1,
+                                                                    Superdrop& drop2) const {
   if (drop1.get_xi() == drop2.get_xi()) {
     twin_superdroplet_breakup(drop1, drop2);
     return 0;

--- a/libs/superdrops/collisions/breakup.hpp
+++ b/libs/superdrops/collisions/breakup.hpp
@@ -78,12 +78,13 @@ struct DoBreakup {
   bool operator()(Superdrop& drop1, Superdrop& drop2, const double prob, const double phi_coll,
                   const double phi_out) const;
 
-  /* enact collisional-breakup of droplets by changing
-  multiplicity, radius and solute mass of each
-  superdroplet in a pair. Method created by Author
-  (no citation yet available). Note implicit assumption
-  that gamma factor = 1. */
-  KOKKOS_FUNCTION void breakup_superdroplet_pair(Superdrop& drop1, Superdrop& drop2) const;
+  /**
+   * enact collisional-breakup of droplets by changing multiplicity, radius and solute mass of each
+   * superdroplet in a pair.
+   * Note implicit assumption that gamma factor = 1.
+   * True if the resulting superdroplet is null, otherwise false.
+   */
+  KOKKOS_FUNCTION bool breakup_superdroplet_pair(Superdrop& drop1, Superdrop& drop2) const;
 };
 
 /*
@@ -141,7 +142,7 @@ KOKKOS_FUNCTION bool DoBreakup<NFrags>::operator()(Superdrop& drop1, Superdrop& 
   /* enact collision-breakup on pair of superdroplets if
   gamma factor for collision-breakup is not zero */
   if (breakup_gamma(prob, phi_coll) != 0) {
-    breakup_superdroplet_pair(drop1, drop2);
+    return breakup_superdroplet_pair(drop1, drop2);
   }
 
   return 0;
@@ -162,18 +163,21 @@ KOKKOS_FUNCTION unsigned int DoBreakup<NFrags>::breakup_gamma(const double prob,
   }
 }
 
-/* enact collisional-breakup of droplets by changing
-multiplicity, radius and solute mass of each
-superdroplet in a pair. Method created by Author
-(no citation yet available). Note implicit assumption
-that gamma factor = 1. */
+/**
+ * enact collisional-breakup of droplets by changing multiplicity, radius and solute mass of each
+ * superdroplet in a pair.
+ * Note implicit assumption that gamma factor = 1.
+ * True if the resulting superdroplet is null, otherwise false.
+ */
 template <NFragments NFrags>
-KOKKOS_FUNCTION void DoBreakup<NFrags>::breakup_superdroplet_pair(Superdrop& drop1,
+KOKKOS_FUNCTION bool DoBreakup<NFrags>::breakup_superdroplet_pair(Superdrop& drop1,
                                                                   Superdrop& drop2) const {
   if (drop1.get_xi() == drop2.get_xi()) {
     twin_superdroplet_breakup(drop1, drop2);
+    return 0;
   } else {
     different_superdroplet_breakup(drop1, drop2);
+    return 0;
   }
 }
 
@@ -188,7 +192,8 @@ KOKKOS_FUNCTION void DoBreakup<NFrags>::twin_superdroplet_breakup(Superdrop& dro
   const auto old_xi = drop2.get_xi();  // = drop1.xi
   const auto totnfrags = double{nfrags(drop1, drop2) * old_xi};
   if ((totnfrags / old_xi) <= 2.5) {
-    Kokkos::abort("nfrags must be > 2.5");
+    Kokkos::abort(
+        "nfrags must be > 2.5, breakup cannot create fewer droplets than originally present");
   }
 
   const auto new_xi1 = static_cast<uint64_t>(Kokkos::round(totnfrags / 2));
@@ -235,7 +240,8 @@ KOKKOS_FUNCTION void DoBreakup<NFrags>::different_superdroplet_breakup(Superdrop
   const auto totnfrags = double{nfrags(drop1, drop2) * old_xi2};
   const auto new_xi2 = static_cast<uint64_t>(Kokkos::round(totnfrags));
   if ((totnfrags / old_xi2) <= 2.5) {
-    Kokkos::abort("nfrags must be > 2.5");
+    Kokkos::abort(
+        "nfrags must be > 2.5, breakup cannot create fewer droplets than originally present");
   }
 
   if (new_xi2 <= old_xi2) {

--- a/libs/superdrops/collisions/coalbure.hpp
+++ b/libs/superdrops/collisions/coalbure.hpp
@@ -243,13 +243,13 @@ KOKKOS_FUNCTION bool DoCoalBuRe<NFrags, Flag>::coalesce_breakup_or_rebound(const
                                                                            Superdrop& drop2) const {
   const auto flag = coalbure_flag(phi, drop1, drop2);
 
-  bool is_null(0);
+  bool is_null = 0;
   switch (flag) {
     case 1:  // coalescence
       is_null = coal.coalesce_superdroplet_pair(gamma, drop1, drop2);
       break;
     case 2:  // breakup
-      bu.breakup_superdroplet_pair(drop1, drop2);
+      is_null = bu.breakup_superdroplet_pair(drop1, drop2);
       break;
   }
 

--- a/libs/superdrops/collisions/coalbure.hpp
+++ b/libs/superdrops/collisions/coalbure.hpp
@@ -95,11 +95,11 @@ struct DoCoalBuRe {
    * @param phi Phi value.
    * @param drop1 First superdroplet.
    * @param drop2 Second superdroplet.
-   * @return True if the resulting superdroplet is null, otherwise false.
+   * @return Resulting total number of null (xi=0) superdroplets from collision (i.e. 0, 1 or 2)
    */
   KOKKOS_FUNCTION
-  bool coalesce_breakup_or_rebound(const uint64_t gamma, const double phi, Superdrop& drop1,
-                                   Superdrop& drop2) const;
+  size_t coalesce_breakup_or_rebound(const uint64_t gamma, const double phi, Superdrop& drop1,
+                                     Superdrop& drop2) const;
 
  public:
   /**
@@ -128,11 +128,11 @@ struct DoCoalBuRe {
    * @param phi_coll Random number in the range [0.0, 1.0] for collision.
    * @param phi_out Random number in the range [0.0, 1.0] for outcome of collision as breakup,
    * rebound or coalescence.
-   * @return True if the resulting superdroplet is null, otherwise false.
+   * @return Resulting total number of null (xi=0) superdroplets from collision (i.e. 0, 1 or 2)
    */
   KOKKOS_INLINE_FUNCTION
-  bool operator()(Superdrop& drop1, Superdrop& drop2, const double prob, const double phi_coll,
-                  const double phi_out) const;
+  size_t operator()(Superdrop& drop1, Superdrop& drop2, const double prob, const double phi_coll,
+                    const double phi_out) const;
 };
 
 /**
@@ -202,12 +202,13 @@ inline MicrophysicalProcess auto CoalBuRe(const unsigned int interval,
  * @param phi_coll Random number in the range [0.0, 1.0] for collision.
  * @param phi_out Random number in the range [0.0, 1.0] for outcome of collision as breakup,
  * rebound or coalescence.
- * @return True if the resulting superdroplet is null, otherwise false.
+ * @return Resulting total number of null (xi=0) superdroplets from collision (i.e. 0, 1 or 2)
  */
 template <NFragments NFrags, CoalBuReFlag Flag>
-KOKKOS_FUNCTION bool DoCoalBuRe<NFrags, Flag>::operator()(Superdrop& drop1, Superdrop& drop2,
-                                                          const double prob, const double phi_coll,
-                                                          const double phi_out) const {
+KOKKOS_FUNCTION size_t DoCoalBuRe<NFrags, Flag>::operator()(Superdrop& drop1, Superdrop& drop2,
+                                                            const double prob,
+                                                            const double phi_coll,
+                                                            const double phi_out) const {
   /* 1. calculate gamma factor for collision  */
   const auto xi1 = drop1.get_xi();
   const auto xi2 = drop2.get_xi();
@@ -234,26 +235,24 @@ KOKKOS_FUNCTION bool DoCoalBuRe<NFrags, Flag>::operator()(Superdrop& drop1, Supe
  * @param phi Phi value.
  * @param drop1 First superdroplet.
  * @param drop2 Second superdroplet.
- * @return True if the resulting superdroplet is null, otherwise false.
+ * @return Resulting total number of null (xi=0) superdroplets from collision (i.e. 0, 1 or 2)
  */
 template <NFragments NFrags, CoalBuReFlag Flag>
-KOKKOS_FUNCTION bool DoCoalBuRe<NFrags, Flag>::coalesce_breakup_or_rebound(const uint64_t gamma,
-                                                                           const double phi,
-                                                                           Superdrop& drop1,
-                                                                           Superdrop& drop2) const {
+KOKKOS_FUNCTION size_t DoCoalBuRe<NFrags, Flag>::coalesce_breakup_or_rebound(
+    const uint64_t gamma, const double phi, Superdrop& drop1, Superdrop& drop2) const {
   const auto flag = coalbure_flag(phi, drop1, drop2);
 
-  bool is_null = 0;
+  size_t null_sds = 0;
   switch (flag) {
     case 1:  // coalescence
-      is_null = coal.coalesce_superdroplet_pair(gamma, drop1, drop2);
+      null_sds = coal.coalesce_superdroplet_pair(gamma, drop1, drop2);
       break;
     case 2:  // breakup
-      is_null = bu.breakup_superdroplet_pair(drop1, drop2);
+      null_sds = bu.breakup_superdroplet_pair(drop1, drop2);
       break;
   }
 
-  return is_null;
+  return null_sds;
 }
 
 #endif  // LIBS_SUPERDROPS_COLLISIONS_COALBURE_HPP_

--- a/libs/superdrops/collisions/coalescence.cpp
+++ b/libs/superdrops/collisions/coalescence.cpp
@@ -34,11 +34,11 @@
  * @param prob The probability of collision-coalescence.
  * @param phi_coll Random number in the range [0.0, 1.0] for collision.
  * @param phi_out Random number in the range [0.0, 1.0] for outcome of collision (not used).
- * @return boolean=true if collision-coalescence resulted in null superdrops.
+ * @return Resulting total number of null (xi=0) superdroplets from collision (i.e. 0, 1 or 2)
  */
-KOKKOS_FUNCTION bool DoCoalescence::operator()(Superdrop& drop1, Superdrop& drop2,
-                                               const double prob, const double phi_coll,
-                                               const double phi_out) const {
+KOKKOS_FUNCTION size_t DoCoalescence::operator()(Superdrop& drop1, Superdrop& drop2,
+                                                 const double prob, const double phi_coll,
+                                                 const double phi_out) const {
   /* 1. calculate gamma factor for collision-coalescence  */
   const auto xi1 = drop1.get_xi();
   const auto xi2 = drop2.get_xi();
@@ -87,11 +87,11 @@ KOKKOS_FUNCTION uint64_t DoCoalescence::coalescence_gamma(const uint64_t xi1, co
  * @param gamma The coalescence gamma factor.
  * @param drop1 The first superdroplet.
  * @param drop2 The second superdroplet.
- * @return True if coalescence results in a null superdroplet, false otherwise.
+ * @return Resulting total number of null (xi=0) superdroplets from collision (i.e. 0, 1 or 2)
  */
-KOKKOS_FUNCTION bool DoCoalescence::coalesce_superdroplet_pair(const uint64_t gamma,
-                                                               Superdrop& drop1,
-                                                               Superdrop& drop2) const {
+KOKKOS_FUNCTION size_t DoCoalescence::coalesce_superdroplet_pair(const uint64_t gamma,
+                                                                 Superdrop& drop1,
+                                                                 Superdrop& drop2) const {
   const auto xi1 = drop1.get_xi();
   const auto xi2 = drop2.get_xi();
 
@@ -102,8 +102,8 @@ KOKKOS_FUNCTION bool DoCoalescence::coalesce_superdroplet_pair(const uint64_t ga
     twin_superdroplet_coalescence(gamma, drop1, drop2);
 
     /* if xi1 = xi2 = 1 before coalesence, then xi1=0 now */
-    bool is_null = drop1.is_null();
-    return is_null;
+    const auto null_supers = static_cast<uint64_t>(drop1.is_null());
+    return null_supers;
   }
 
   if (xi1 < gamma * xi2) {

--- a/libs/superdrops/collisions/coalescence.cpp
+++ b/libs/superdrops/collisions/coalescence.cpp
@@ -147,7 +147,11 @@ KOKKOS_FUNCTION void DoCoalescence::twin_superdroplet_coalescence(const uint64_t
 
   const auto new_msol = double{drop2.get_msol() + gamma * drop1.get_msol()};
 
-  drop1.set_xi(new_xi);
+  if (new_xi == 0) {
+    drop1.set_null();
+  } else {
+    drop1.set_xi(new_xi);
+  }
   drop2.set_xi(old_xi - new_xi);
 
   drop1.set_radius(new_r);

--- a/libs/superdrops/collisions/coalescence.cpp
+++ b/libs/superdrops/collisions/coalescence.cpp
@@ -102,7 +102,8 @@ KOKKOS_FUNCTION bool DoCoalescence::coalesce_superdroplet_pair(const uint64_t ga
     twin_superdroplet_coalescence(gamma, drop1, drop2);
 
     /* if xi1 = xi2 = 1 before coalesence, then xi1=0 now */
-    return is_null_superdrop(drop1);
+    bool is_null = is_null_superdrop(drop1);
+    return is_null;
   }
 
   if (xi1 < gamma * xi2) {

--- a/libs/superdrops/collisions/coalescence.cpp
+++ b/libs/superdrops/collisions/coalescence.cpp
@@ -102,7 +102,7 @@ KOKKOS_FUNCTION bool DoCoalescence::coalesce_superdroplet_pair(const uint64_t ga
     twin_superdroplet_coalescence(gamma, drop1, drop2);
 
     /* if xi1 = xi2 = 1 before coalesence, then xi1=0 now */
-    bool is_null = is_null_superdrop(drop1);
+    bool is_null = drop1.is_null();
     return is_null;
   }
 

--- a/libs/superdrops/collisions/coalescence.hpp
+++ b/libs/superdrops/collisions/coalescence.hpp
@@ -29,18 +29,14 @@
 #include "./collisions.hpp"
 
 /**
- * @brief Raises an error if the multiplicity of the super-droplet is 0.
- *
- * This function checks if the given superdrop is null by verifying its multiplicity.
- * It ensures that the multiplicity (`xi`) of the superdrop is greater than 0.
- * If the multiplicity is 0, a runtime error is raised.
+ * @brief Returns True if the multiplicity of the super-droplet is 0.
  *
  * @param drop A reference to the `Superdrop` object to be checked.
- * @return Always returns 0 (=false).
+ * @return True if superdroplet xi=0, i.e. superdroplet is null, false otherwise.
  */
 KOKKOS_INLINE_FUNCTION bool is_null_superdrop(const Superdrop& drop) {
   if (drop.get_xi() <= 0) {
-    Kokkos::abort("superdrop xi < 1, null drop in coalescence");
+    return 1;
   }
   return 0;
 }

--- a/libs/superdrops/collisions/coalescence.hpp
+++ b/libs/superdrops/collisions/coalescence.hpp
@@ -29,22 +29,6 @@
 #include "../superdrop.hpp"
 #include "./collisions.hpp"
 
-/**
- * @brief Returns True if the multiplicity of the super-droplet is 0.
- *
- * Also sets superdroplet sdgbxindex to out of bounds value if xi=0
- *
- * @param drop A reference to the `Superdrop` object to be checked.
- * @return True if superdroplet xi=0, i.e. superdroplet is null, false otherwise.
- */
-KOKKOS_INLINE_FUNCTION bool is_null_superdrop(Superdrop& drop) {
-  if (drop.get_xi() <= 0) {
-    drop.set_sdgbxindex(LIMITVALUES::oob_gbxindex);
-    return 1;
-  }
-  return 0;
-}
-
 struct DoCoalescence {
  private:
   /**

--- a/libs/superdrops/collisions/coalescence.hpp
+++ b/libs/superdrops/collisions/coalescence.hpp
@@ -81,11 +81,11 @@ struct DoCoalescence {
    * @param prob The probability of collision-coalescence.
    * @param phi_coll Random number in the range [0.0, 1.0] for collision.
    * @param phi_out Random number in the range [0.0, 1.0] for outcome of collision (not used).
-   * @return boolean=true if collision-coalescence resulted in null superdrops.
+   * @return Resulting total number of null (xi=0) superdroplets from collision (i.e. 0, 1 or 2)
    */
   KOKKOS_FUNCTION
-  bool operator()(Superdrop& drop1, Superdrop& drop2, const double prob, const double phi_coll,
-                  const double phi_out) const;
+  size_t operator()(Superdrop& drop1, Superdrop& drop2, const double prob, const double phi_coll,
+                    const double phi_out) const;
 
   /**
    * @brief Calculates the value of the gamma factor in Monte Carlo collision-coalescence.
@@ -111,10 +111,10 @@ struct DoCoalescence {
    * @param gamma The coalescence gamma factor.
    * @param drop1 The first superdroplet.
    * @param drop2 The second superdroplet.
-   * @return True if coalescence results in a null superdroplet, false otherwise.
+   * @return Resulting total number of null (xi=0) superdroplets from collision (i.e. 0, 1 or 2)
    */
-  KOKKOS_FUNCTION bool coalesce_superdroplet_pair(const uint64_t gamma, Superdrop& drop1,
-                                                  Superdrop& drop2) const;
+  KOKKOS_FUNCTION size_t coalesce_superdroplet_pair(const uint64_t gamma, Superdrop& drop1,
+                                                    Superdrop& drop2) const;
 };
 
 /**

--- a/libs/superdrops/collisions/coalescence.hpp
+++ b/libs/superdrops/collisions/coalescence.hpp
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <functional>
 
+#include "../../cleoconstants.hpp"
 #include "../microphysicalprocess.hpp"
 #include "../superdrop.hpp"
 #include "./collisions.hpp"
@@ -31,11 +32,14 @@
 /**
  * @brief Returns True if the multiplicity of the super-droplet is 0.
  *
+ * Also sets superdroplet sdgbxindex to out of bounds value if xi=0
+ *
  * @param drop A reference to the `Superdrop` object to be checked.
  * @return True if superdroplet xi=0, i.e. superdroplet is null, false otherwise.
  */
-KOKKOS_INLINE_FUNCTION bool is_null_superdrop(const Superdrop& drop) {
+KOKKOS_INLINE_FUNCTION bool is_null_superdrop(Superdrop& drop) {
   if (drop.get_xi() <= 0) {
+    drop.set_sdgbxindex(LIMITVALUES::oob_gbxindex);
     return 1;
   }
   return 0;

--- a/libs/superdrops/collisions/collisions.hpp
+++ b/libs/superdrops/collisions/collisions.hpp
@@ -198,9 +198,9 @@ struct DoCollisions {
    * @param team_member The Kokkos team member.
    * @param supers The randomly shuffled view of super-droplets.
    * @param volume The volume in which to calculate the probability of collisions.
-   * @return The number of null (xi=0) superdrops.
+   * @return Boolean for if there are any null (xi=0) superdrops produced by collisions.
    */
-  KOKKOS_INLINE_FUNCTION void collide_supers(const TeamMember& team_member, subviewd_supers supers,
+  KOKKOS_INLINE_FUNCTION bool collide_supers(const TeamMember& team_member, subviewd_supers supers,
                                              const double volume) const {
     const auto nsupers = static_cast<size_t>(supers.extent(0));
     const auto npairs = size_t{nsupers / 2};  // no. pairs of superdrops (=floor() for nsupers > 0)
@@ -213,6 +213,8 @@ struct DoCollisions {
     Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team_member, npairs), functor,
                             Kokkos::LOr<bool>(is_any_null));
     team_member.team_barrier();  // synchronise threads
+
+    return is_any_null;
   }
 
   /**
@@ -235,7 +237,11 @@ struct DoCollisions {
     supers = shuffle_supers(team_member, supers, genpool);
 
     /* collide all randomly generated pairs of SDs */
-    collide_supers(team_member, supers, volume);
+    is_any_null = collide_supers(team_member, supers, volume);
+
+    if (is_any_null) {
+      Kokkos::abort("superdrop xi < 1, null drop occured in coalescence");
+    }
   }
 
  public:

--- a/libs/superdrops/collisions/collisions.hpp
+++ b/libs/superdrops/collisions/collisions.hpp
@@ -162,7 +162,7 @@ struct CollideSupersFunctor {
    */
   KOKKOS_INLINE_FUNCTION void operator()(const size_t jj, bool& is_any_null) const {
     const auto kk = size_t{jj * 2};
-    is_null = collide_superdroplet_pair(supers(kk), supers(kk + 1), scale_p, VOLUME);
+    const auto is_null = collide_superdroplet_pair(supers(kk), supers(kk + 1), scale_p, VOLUME);
     is_any_null = is_any_null || is_null;
   }
 };
@@ -237,7 +237,7 @@ struct DoCollisions {
     supers = shuffle_supers(team_member, supers, genpool);
 
     /* collide all randomly generated pairs of SDs */
-    is_any_null = collide_supers(team_member, supers, volume);
+    const auto is_any_null = collide_supers(team_member, supers, volume);
 
     if (is_any_null) {
       Kokkos::abort("superdrop xi < 1, null drop occured in coalescence");

--- a/libs/superdrops/collisions/collisions.hpp
+++ b/libs/superdrops/collisions/collisions.hpp
@@ -134,9 +134,9 @@ struct CollideSupersFunctor {
    * @param dropB The second superdroplet.
    * @param scale_p The probability scaling factor.
    * @param VOLUME The volume [m^-3].
-   * @return True if the collision event results in null superdrops with xi=0), otherwise false.
+   * @return True if the collision event results in null superdrops with xi=0, otherwise false.
    */
-  KOKKOS_INLINE_FUNCTION void collide_superdroplet_pair(Superdrop& dropA, Superdrop& dropB,
+  KOKKOS_INLINE_FUNCTION bool collide_superdroplet_pair(Superdrop& dropA, Superdrop& dropB,
                                                         const double scale_p,
                                                         const double VOLUME) const {
     /* 1. assign references to each superdrop in pair that will collide
@@ -153,16 +153,17 @@ struct CollideSupersFunctor {
     const auto phi_out = urbg.drand(0.0, 1.0);  // for outcome of collisions extended algorithm only
     genpool.free_state(urbg.gen);
 
-    enact_collision(drops.first, drops.second, prob, phi_coll, phi_out);
+    return enact_collision(drops.first, drops.second, prob, phi_coll, phi_out);
   }
 
   /*
    * operator for functor with parallel (TeamThreadRangePolicy) loop over superdroplet pairs
    * in supers view in order to call collide_superdroplet_pair
    */
-  KOKKOS_INLINE_FUNCTION void operator()(const size_t jj) const {
+  KOKKOS_INLINE_FUNCTION void operator()(const size_t jj, bool& is_any_null) const {
     const auto kk = size_t{jj * 2};
-    collide_superdroplet_pair(supers(kk), supers(kk + 1), scale_p, VOLUME);
+    is_null = collide_superdroplet_pair(supers(kk), supers(kk + 1), scale_p, VOLUME);
+    is_any_null = is_any_null || is_null;
   }
 };
 
@@ -206,9 +207,11 @@ struct DoCollisions {
     const auto scale_p = double{nsupers * (nsupers - 1.0) / (2.0 * npairs)};
     const auto VOLUME = double{volume * dlc::VOL0};  // volume in which collisions occur [m^3]
 
+    bool is_any_null = 0;
     const auto functor =
         CollideSupersFunctor{probability, enact_collision, genpool, supers, scale_p, DELT, VOLUME};
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team_member, npairs), functor);
+    Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team_member, npairs), functor,
+                            Kokkos::LOr<bool>(is_any_null));
     team_member.team_barrier();  // synchronise threads
   }
 

--- a/libs/superdrops/collisions/collisions.hpp
+++ b/libs/superdrops/collisions/collisions.hpp
@@ -20,6 +20,7 @@
 #define LIBS_SUPERDROPS_COLLISIONS_COLLISIONS_HPP_
 
 #include <Kokkos_Core.hpp>
+#include <Kokkos_NestedSort.hpp>
 #include <Kokkos_Random.hpp>
 #include <concepts>
 #include <random>
@@ -158,12 +159,14 @@ struct CollideSupersFunctor {
 
   /*
    * operator for functor with parallel (TeamThreadRangePolicy) loop over superdroplet pairs
-   * in supers view in order to call collide_superdroplet_pair
+   * in supers view in order to call collide_superdroplet_pair.
+   *
+   * Note: conversion of boolean from collide_superdroplet_pair to size_t in oob_nsupers
    */
-  KOKKOS_INLINE_FUNCTION void operator()(const size_t jj, bool& is_any_null) const {
+  KOKKOS_INLINE_FUNCTION void operator()(const size_t jj, size_t& oob_nsupers) const {
     const auto kk = size_t{jj * 2};
     const auto is_null = collide_superdroplet_pair(supers(kk), supers(kk + 1), scale_p, VOLUME);
-    is_any_null = is_any_null || is_null;
+    oob_nsupers += static_cast<size_t>(is_null);
   }
 };
 
@@ -180,6 +183,16 @@ struct DoCollisions {
   Probability probability; /**< Probability object for calculating collision probabilities. */
   EnactCollision enact_collision; /**< Enactment object for enacting collision events. */
   GenRandomPool genpool;          /**< Kokkos thread-safe random number generator pool.*/
+
+  /* helper structure in case of null superdroplets
+   * superdroplet a precedes b if its sdgbxindex is smaller
+   */
+  struct SortComparator {
+    KOKKOS_INLINE_FUNCTION
+    bool operator()(const Superdrop& a, const Superdrop& b) const {
+      return (a.get_sdgbxindex()) < (b.get_sdgbxindex());
+    }
+  };
 
   /**
    * @brief Performs collisions between super-droplets in supers view.
@@ -198,23 +211,40 @@ struct DoCollisions {
    * @param team_member The Kokkos team member.
    * @param supers The randomly shuffled view of super-droplets.
    * @param volume The volume in which to calculate the probability of collisions.
-   * @return Boolean for if there are any null (xi=0) superdrops produced by collisions.
+   * @return Total number of null (xi=0) superdrops produced by collisions.
    */
-  KOKKOS_INLINE_FUNCTION bool collide_supers(const TeamMember& team_member, subviewd_supers supers,
-                                             const double volume) const {
+  KOKKOS_INLINE_FUNCTION size_t collide_supers(const TeamMember& team_member,
+                                               subviewd_supers supers, const double volume) const {
     const auto nsupers = static_cast<size_t>(supers.extent(0));
     const auto npairs = size_t{nsupers / 2};  // no. pairs of superdrops (=floor() for nsupers > 0)
     const auto scale_p = double{nsupers * (nsupers - 1.0) / (2.0 * npairs)};
     const auto VOLUME = double{volume * dlc::VOL0};  // volume in which collisions occur [m^3]
 
-    bool is_any_null = 0;
+    const auto oob_nsupers = size_t{0};  // #WIP check this reduction works
     const auto functor =
         CollideSupersFunctor{probability, enact_collision, genpool, supers, scale_p, DELT, VOLUME};
-    Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team_member, npairs), functor,
-                            Kokkos::LOr<bool>(is_any_null));
+    Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team_member, npairs), functor, oob_nsupers);
     team_member.team_barrier();  // synchronise threads
 
-    return is_any_null;
+    return oob_nsupers;
+  }
+
+  /* sort subview from lowest to highest sdgbxindex (i.e. so that null superdroplets are
+   * at the right-hand side of subview and all valid superdroplets in the gridbox are at the
+   * left-hand side). Note sorting of superdrops with matching sdgbxindex can take any order
+   *
+   * @param team_member The Kokkos team member.
+   * @param supers The view of super-droplets.
+   * @param volume The volume in which to calculate the probability of collisions.
+   * @return The updated superdroplets.
+   */
+  KOKKOS_INLINE_FUNCTION subviewd_supers remove_null_supers(const TeamMember& team_member,
+                                                            const size_t oob_nsupers,
+                                                            subviewd_supers supers) const {
+    Kokkos::Experimental::sort_team(team_member, supers, SortComparator{});
+    const auto nsupers = static_cast<size_t>(supers.extent(0));
+    const kkpair_size_t new_refs({0, nsupers - oob_nsupers});  // #WIP: check this is correct bounds
+    return Kokkos::subview(supers, new_refs);
   }
 
   /**
@@ -230,17 +260,20 @@ struct DoCollisions {
    * @param volume The volume in which to calculate the probability of collisions.
    * @return The updated superdroplets.
    */
-  KOKKOS_INLINE_FUNCTION void do_collisions(const TeamMember& team_member, subviewd_supers supers,
-                                            const double volume) const {
+  KOKKOS_INLINE_FUNCTION subviewd_supers do_collisions(const TeamMember& team_member,
+                                                       subviewd_supers supers,
+                                                       const double volume) const {
     /* Randomly shuffle order of superdroplet objects
     in supers in order to generate random pairs */
     supers = shuffle_supers(team_member, supers, genpool);
 
     /* collide all randomly generated pairs of SDs */
-    const auto is_any_null = collide_supers(team_member, supers, volume);
+    const auto oob_nsupers = collide_supers(team_member, supers, volume);
 
-    if (is_any_null) {
-      Kokkos::abort("superdrop xi < 1, null drop occured in coalescence");
+    if (oob_nsupers == 0) {
+      return supers;
+    } else {
+      return remove_null_supers(team_member, supers);
     }
   }
 
@@ -289,8 +322,7 @@ struct DoCollisions {
                                                     const unsigned int subt, subviewd_supers supers,
                                                     const State& state,
                                                     const SDMMonitor auto mo) const {
-    do_collisions(team_member, supers, state.get_volume());
-    return supers;
+    return do_collisions(team_member, supers, state.get_volume());
   }
 };
 

--- a/libs/superdrops/collisions/collisions.hpp
+++ b/libs/superdrops/collisions/collisions.hpp
@@ -276,10 +276,12 @@ struct DoCollisions {
    * @param mo Monitor of SDM processes.
    * @return The updated superdroplets.
    */
-  KOKKOS_INLINE_FUNCTION void operator()(const TeamMember& team_member, const unsigned int subt,
-                                         subviewd_supers supers, const State& state,
-                                         const SDMMonitor auto mo) const {
+  KOKKOS_INLINE_FUNCTION subviewd_supers operator()(const TeamMember& team_member,
+                                                    const unsigned int subt, subviewd_supers supers,
+                                                    const State& state,
+                                                    const SDMMonitor auto mo) const {
     do_collisions(team_member, supers, state.get_volume());
+    return supers;
   }
 };
 

--- a/libs/superdrops/collisions/collisions.hpp
+++ b/libs/superdrops/collisions/collisions.hpp
@@ -238,9 +238,11 @@ struct DoCollisions {
    * @return The updated superdroplets.
    */
   KOKKOS_INLINE_FUNCTION subviewd_supers remove_null_supers(const TeamMember& team_member,
-                                                            const size_t oob_nsupers,
-                                                            subviewd_supers supers) const {
-    Kokkos::Experimental::sort_team(team_member, supers, SortComparator{});
+
+                                                            subviewd_supers supers,
+                                                            const size_t oob_nsupers) const {
+    Kokkos::Experimental::sort_team(team_member, supers,
+                                    SortComparator{});  // #WIP: check this sort works
     const auto nsupers = static_cast<size_t>(supers.extent(0));
     const kkpair_size_t new_refs({0, nsupers - oob_nsupers});  // #WIP: check this is correct bounds
     return Kokkos::subview(supers, new_refs);
@@ -272,7 +274,7 @@ struct DoCollisions {
     if (oob_nsupers == 0) {
       return supers;
     } else {
-      return remove_null_supers(team_member, supers);
+      return remove_null_supers(team_member, supers, oob_nsupers);
     }
   }
 

--- a/libs/superdrops/collisions/collisions.hpp
+++ b/libs/superdrops/collisions/collisions.hpp
@@ -63,7 +63,7 @@ concept PairProbability = requires(P p, Superdrop& drop, double d) {
  */
 template <typename X>
 concept PairEnactX = requires(X x, Superdrop& drop, double d) {
-  { x(drop, drop, d, d, d) } -> std::convertible_to<bool>;
+  { x(drop, drop, d, d, d) } -> std::convertible_to<size_t>;
 };
 
 /*
@@ -137,9 +137,9 @@ struct CollideSupersFunctor {
    * @param VOLUME The volume [m^-3].
    * @return True if the collision event results in null superdrops with xi=0, otherwise false.
    */
-  KOKKOS_INLINE_FUNCTION bool collide_superdroplet_pair(Superdrop& dropA, Superdrop& dropB,
-                                                        const double scale_p,
-                                                        const double VOLUME) const {
+  KOKKOS_INLINE_FUNCTION size_t collide_superdroplet_pair(Superdrop& dropA, Superdrop& dropB,
+                                                          const double scale_p,
+                                                          const double VOLUME) const {
     /* 1. assign references to each superdrop in pair that will collide
     such that (drop1.xi) >= (drop2.xi) */
     const auto drops = assign_drops(dropA, dropB);  // {drop1, drop2}
@@ -161,12 +161,11 @@ struct CollideSupersFunctor {
    * operator for functor with parallel (TeamThreadRangePolicy) loop over superdroplet pairs
    * in supers view in order to call collide_superdroplet_pair.
    *
-   * Note: conversion of boolean from collide_superdroplet_pair to size_t in oob_nsupers
    */
   KOKKOS_INLINE_FUNCTION void operator()(const size_t jj, size_t& oob_nsupers) const {
     const auto kk = size_t{jj * 2};
-    const auto is_null = collide_superdroplet_pair(supers(kk), supers(kk + 1), scale_p, VOLUME);
-    oob_nsupers += static_cast<size_t>(is_null);
+    const auto null_supers = collide_superdroplet_pair(supers(kk), supers(kk + 1), scale_p, VOLUME);
+    oob_nsupers += null_supers;
   }
 };
 

--- a/libs/superdrops/collisions/collisions.hpp
+++ b/libs/superdrops/collisions/collisions.hpp
@@ -219,7 +219,7 @@ struct DoCollisions {
     const auto scale_p = double{nsupers * (nsupers - 1.0) / (2.0 * npairs)};
     const auto VOLUME = double{volume * dlc::VOL0};  // volume in which collisions occur [m^3]
 
-    auto oob_nsupers = size_t{0};  // #WIP check this reduction works
+    auto oob_nsupers = size_t{0};
     const auto functor =
         CollideSupersFunctor{probability, enact_collision, genpool, supers, scale_p, DELT, VOLUME};
     Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team_member, npairs), functor, oob_nsupers);
@@ -241,10 +241,9 @@ struct DoCollisions {
 
                                                             subviewd_supers supers,
                                                             const size_t oob_nsupers) const {
-    Kokkos::Experimental::sort_team(team_member, supers,
-                                    SortComparator{});  // #WIP: check this sort works
+    Kokkos::Experimental::sort_team(team_member, supers, SortComparator{});
     const auto nsupers = static_cast<size_t>(supers.extent(0));
-    const kkpair_size_t new_refs({0, nsupers - oob_nsupers});  // #WIP: check this is correct bounds
+    const kkpair_size_t new_refs({0, nsupers - oob_nsupers});
     return Kokkos::subview(supers, new_refs);
   }
 

--- a/libs/superdrops/collisions/collisions.hpp
+++ b/libs/superdrops/collisions/collisions.hpp
@@ -219,7 +219,7 @@ struct DoCollisions {
     const auto scale_p = double{nsupers * (nsupers - 1.0) / (2.0 * npairs)};
     const auto VOLUME = double{volume * dlc::VOL0};  // volume in which collisions occur [m^3]
 
-    const auto oob_nsupers = size_t{0};  // #WIP check this reduction works
+    auto oob_nsupers = size_t{0};  // #WIP check this reduction works
     const auto functor =
         CollideSupersFunctor{probability, enact_collision, genpool, supers, scale_p, DELT, VOLUME};
     Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team_member, npairs), functor, oob_nsupers);

--- a/libs/superdrops/condensation.hpp
+++ b/libs/superdrops/condensation.hpp
@@ -217,10 +217,11 @@ struct DoCondensation {
    * @param mo Monitor of SDM processes.
    * @return The updated view super-droplets.
    */
-  KOKKOS_INLINE_FUNCTION void operator()(const TeamMember& team_member, const unsigned int subt,
-                                         subviewd_supers supers, State& state,
-                                         const SDMMonitor auto mo) const {
+  KOKKOS_INLINE_FUNCTION subviewd_supers operator()(const TeamMember& team_member,
+                                                    const unsigned int subt, subviewd_supers supers,
+                                                    State& state, const SDMMonitor auto mo) const {
     do_condensation(team_member, supers, state, mo);
+    return supers;
   }
 };
 

--- a/libs/superdrops/microphysicalprocess.hpp
+++ b/libs/superdrops/microphysicalprocess.hpp
@@ -48,7 +48,7 @@ concept MicrophysicalProcess =
              const NullSDMMonitor mo) {
       { p.next_step(t) } -> std::convertible_to<unsigned int>;
       { p.on_step(t) } -> std::same_as<bool>;
-      { p.run_step(tm, t, supers, state, mo) } -> std::same_as<void>;
+      { p.run_step(tm, t, supers, state, mo) } -> std::same_as<subviewd_supers>;
     };
 
 /**
@@ -110,11 +110,12 @@ struct CombinedMicrophysicalProcess {
    * @param mo Monitor of SDM processes.
    * @return The updated view of super-droplets after the process.
    */
-  KOKKOS_INLINE_FUNCTION void run_step(const TeamMember& team_member, const unsigned int subt,
-                                       subviewd_supers supers, State& state,
-                                       const SDMMonitor auto mo) const {
-    a.run_step(team_member, subt, supers, state, mo);
-    b.run_step(team_member, subt, supers, state, mo);
+  KOKKOS_INLINE_FUNCTION subviewd_supers run_step(const TeamMember& team_member,
+                                                  const unsigned int subt, subviewd_supers supers,
+                                                  State& state, const SDMMonitor auto mo) const {
+    supers = a.run_step(team_member, subt, supers, state, mo);
+    supers = b.run_step(team_member, subt, supers, state, mo);
+    return supers;
   }
 };
 
@@ -170,9 +171,11 @@ struct NullMicrophysicalProcess {
    * @param mo Monitor of SDM processes.
    * @return The unchanged view of super-droplets.
    */
-  KOKKOS_INLINE_FUNCTION void run_step(const TeamMember& team_member, const unsigned int subt,
-                                       subviewd_supers supers, State& state,
-                                       const SDMMonitor auto mo) const {}
+  KOKKOS_INLINE_FUNCTION subviewd_supers run_step(const TeamMember& team_member,
+                                                  const unsigned int subt, subviewd_supers supers,
+                                                  State& state, const SDMMonitor auto mo) const {
+    return supers;
+  }
 };
 
 /**
@@ -189,7 +192,7 @@ struct NullMicrophysicalProcess {
 template <typename F>
 concept MicrophysicsFunc = requires(F f, const TeamMember& tm, const unsigned int subt,
                                     subviewd_supers supers, State& state, const NullSDMMonitor mo) {
-  { f(tm, subt, supers, state, mo) } -> std::same_as<void>;
+  { f(tm, subt, supers, state, mo) } -> std::same_as<subviewd_supers>;
 };
 
 /**
@@ -254,12 +257,13 @@ struct ConstTstepMicrophysics {
    * @param mo Monitor of SDM processes.
    * @return The updated view of super-droplets after the process.
    */
-  KOKKOS_INLINE_FUNCTION void run_step(const TeamMember& team_member, const unsigned int subt,
-                                       subviewd_supers supers, State& state,
-                                       const SDMMonitor auto mo) const {
+  KOKKOS_INLINE_FUNCTION subviewd_supers run_step(const TeamMember& team_member,
+                                                  const unsigned int subt, subviewd_supers supers,
+                                                  State& state, const SDMMonitor auto mo) const {
     if (on_step(subt)) {
-      do_microphysics(team_member, subt, supers, state, mo);
+      supers = do_microphysics(team_member, subt, supers, state, mo);
     }
+    return supers;
   }
 };
 

--- a/libs/superdrops/superdrop.hpp
+++ b/libs/superdrops/superdrop.hpp
@@ -79,6 +79,21 @@ class Superdrop {
         sdId(i_sdId) {}
 
   /**
+   * @brief Returns True if the multiplicity of the super-droplet is 0.
+   *
+   * Also sets superdroplet sdgbxindex to out of bounds value if xi=0
+   *
+   * @return True if superdroplet xi=0, i.e. superdroplet is null, false otherwise.
+   */
+  KOKKOS_INLINE_FUNCTION bool is_null() {
+    if (attrs.xi <= 0) {
+      sdgbxindex = LIMITVALUES::oob_gbxindex;
+      return 1;
+    }
+    return 0;
+  }
+
+  /**
    * @brief Get the index of the Gridbox the superdrop currently occupies.
    *
    * @return Gridbox Index.

--- a/libs/superdrops/superdrop.hpp
+++ b/libs/superdrops/superdrop.hpp
@@ -79,21 +79,6 @@ class Superdrop {
         sdId(i_sdId) {}
 
   /**
-   * @brief Returns True if the multiplicity of the super-droplet is 0.
-   *
-   * Also sets superdroplet sdgbxindex to out of bounds value if xi=0
-   *
-   * @return True if superdroplet xi=0, i.e. superdroplet is null, false otherwise.
-   */
-  KOKKOS_INLINE_FUNCTION bool is_null() {
-    if (attrs.xi <= 0) {
-      sdgbxindex = LIMITVALUES::oob_gbxindex;
-      return true;
-    }
-    return false;
-  }
-
-  /**
    * @brief Get the index of the Gridbox the superdrop currently occupies.
    *
    * @return Gridbox Index.
@@ -206,6 +191,19 @@ class Superdrop {
    * @return radius of the super-droplet cubed.
    */
   KOKKOS_INLINE_FUNCTION double rcubed() const { return attrs.rcubed(); }
+
+  /**
+   * @brief returns true if attributes are null
+   */
+  KOKKOS_INLINE_FUNCTION bool is_null() { return attrs.is_null(); }
+
+  /**
+   * @brief sets sdgbxindex to out of bounds index and attributes to null
+   */
+  KOKKOS_INLINE_FUNCTION void set_null() {
+    attrs.set_null();
+    sdgbxindex = LIMITVALUES::oob_gbxindex;
+  }
 
   /**
    * @brief Set the multiplicity 'xi' of the super-droplet.

--- a/libs/superdrops/superdrop.hpp
+++ b/libs/superdrops/superdrop.hpp
@@ -88,9 +88,9 @@ class Superdrop {
   KOKKOS_INLINE_FUNCTION bool is_null() {
     if (attrs.xi <= 0) {
       sdgbxindex = LIMITVALUES::oob_gbxindex;
-      return 1;
+      return true;
     }
-    return 0;
+    return false;
   }
 
   /**

--- a/libs/superdrops/superdrop_attrs.hpp
+++ b/libs/superdrops/superdrop_attrs.hpp
@@ -132,6 +132,21 @@ struct SuperdropAttrs {
   KOKKOS_FUNCTION auto get_ionic() const { return solute.ionic(); }
 
   /**
+   * @brief returns true if attributes are null
+   *
+   * i.e. if multiplicity == 0
+   */
+  KOKKOS_INLINE_FUNCTION bool is_null() { return xi == 0; }
+
+  /**
+   * @brief sets attributes to null values
+   *
+   * i.e. sets multiplicity = 0
+   *
+   */
+  KOKKOS_INLINE_FUNCTION void set_null() { xi = 0; }
+
+  /**
    * @brief Set the multiplicity of superdroplet.
    *
    * Set the multiplicity 'xi' of the superdroplet with assurance that new xi >= 1.


### PR DESCRIPTION
- parallel loop over pairs of collisions now a reducer loop which returns number of superdroplets with xi=0 occurs during collisions.

- parallel loop over gridboxes in microphysics now a reducer loop which returns true boolean if number of superdroplets in any gridbox has changed after microphysics ( e.g. decreased due to any superdroplets with xi=0)

- *NOTE*:  by this PR non-existent superdroplets are allowed exist in the superdroplets array during the microphysics time-loop (not seen in supers for each gridbox) , which are not sorted away (except if sorting occurs in superdroplet movement) until outside of gbxs loop in microphysics. Non-existent superdroplets may be created in time-loop e.g. from collision-coalescence of two xi=1 superdroplets
